### PR TITLE
Refactoring in preparation for integration of other Docker clients

### DIFF
--- a/images/coblox_bitcoincore/examples/get_new_address.rs
+++ b/images/coblox_bitcoincore/examples/get_new_address.rs
@@ -5,11 +5,10 @@ extern crate testcontainers;
 use bitcoin_rpc_client::BitcoinCoreClient;
 use bitcoin_rpc_client::BitcoinRpcApi;
 use tc_coblox_bitcoincore::BitcoinCore;
-use testcontainers::clients::DockerCli;
-use testcontainers::Docker;
+use testcontainers::prelude::*;
 
 fn main() {
-    let docker = DockerCli::new();
+    let docker = clients::Cli::new();
     let node = docker.run(BitcoinCore::default());
 
     let client = {

--- a/images/parity_parity/examples/list_accounts.rs
+++ b/images/parity_parity/examples/list_accounts.rs
@@ -4,8 +4,7 @@ extern crate web3;
 
 use std::ops::Deref;
 use tc_parity_parity::*;
-use testcontainers::Container;
-use testcontainers::{clients::DockerCli, Docker};
+use testcontainers::prelude::*;
 use web3::futures::Future;
 use web3::{
     transports::{EventLoopHandle, Http},
@@ -13,7 +12,7 @@ use web3::{
 };
 
 fn main() {
-    let docker = DockerCli::new();
+    let docker = clients::Cli::new();
 
     // This blocks until the container is ready to accept requests
     let node = docker.run(ParityEthereum::default());

--- a/images/trufflesuite_ganachecli/examples/list_accounts.rs
+++ b/images/trufflesuite_ganachecli/examples/list_accounts.rs
@@ -4,8 +4,7 @@ extern crate web3;
 
 use std::ops::Deref;
 use tc_trufflesuite_ganachecli::*;
-use testcontainers::Container;
-use testcontainers::{clients::DockerCli, Docker};
+use testcontainers::prelude::*;
 use web3::futures::Future;
 use web3::{
     transports::{EventLoopHandle, Http},
@@ -13,7 +12,7 @@ use web3::{
 };
 
 fn main() {
-    let docker = DockerCli::new();
+    let docker = clients::Cli::new();
 
     // This blocks until the container is ready to accept requests
     let node = docker.run(GanacheCli::default());

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -18,3 +18,6 @@ serde = "1.0.66"
 serde_json = "1.0.22"
 serde_derive = "1.0.66"
 log = "0.4.3"
+
+[dev-dependencies]
+maplit = "1"

--- a/testcontainers/examples/usage.rs
+++ b/testcontainers/examples/usage.rs
@@ -1,6 +1,6 @@
 extern crate testcontainers;
 
-use testcontainers::{clients::DockerCli, *};
+use testcontainers::prelude::*;
 
 struct FakeImage {
     authentication_token: String,
@@ -39,8 +39,9 @@ struct FakeClient {}
 
 fn main() {
     let image = FakeImage::default();
+    let cli = clients::Cli::new();
 
-    let container = DockerCli::new().run(image);
+    let container = cli.run(image);
 
     let _client = {
         // Query all the necessary information from our container so that you can connect to

--- a/testcontainers/src/api.rs
+++ b/testcontainers/src/api.rs
@@ -27,26 +27,43 @@ where
     fn with_args(self, arguments: Self::Args) -> Self;
 }
 
-pub struct Container<D: Docker, I: Image> {
+pub struct Container<'d, D, I>
+where
+    D: 'd,
+    D: Docker,
+    I: Image,
+{
     id: String,
-    docker_client: D,
+    docker_client: &'d D,
     image: I,
 }
 
-impl<D: Docker, I: Image> fmt::Debug for Container<D, I> {
+impl<'d, D, I> fmt::Debug for Container<'d, D, I>
+where
+    D: Docker,
+    I: Image,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "Container ({})", self.id)
     }
 }
 
-impl<D: Docker, I: Image> fmt::Display for Container<D, I> {
+impl<'d, D, I> fmt::Display for Container<'d, D, I>
+where
+    D: Docker,
+    I: Image,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "Container ({})", self.id)
     }
 }
 
-impl<D: Docker, I: Image> Container<D, I> {
-    pub fn new(id: String, docker_client: D, image: I) -> Self {
+impl<'d, D, I> Container<'d, D, I>
+where
+    D: Docker,
+    I: Image,
+{
+    pub fn new(id: String, docker_client: &'d D, image: I) -> Self {
         Container {
             id,
             docker_client,
@@ -105,7 +122,11 @@ impl<D: Docker, I: Image> Container<D, I> {
     }
 }
 
-impl<D: Docker, I: Image> Drop for Container<D, I> {
+impl<'d, D, I> Drop for Container<'d, D, I>
+where
+    D: Docker,
+    I: Image,
+{
     fn drop(&mut self) {
         let keep_container = var("KEEP_CONTAINERS")
             .ok()

--- a/testcontainers/src/api.rs
+++ b/testcontainers/src/api.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, env::var, fmt, io::Read, str::FromStr};
 
 pub trait Docker
 where
-    Self: Sized + Copy,
+    Self: Sized,
 {
     fn new() -> Self;
     fn run<I: Image>(&self, image: I) -> Container<Self, I>;

--- a/testcontainers/src/clients/docker_inspect_response.json
+++ b/testcontainers/src/clients/docker_inspect_response.json
@@ -1,0 +1,34 @@
+{
+  "Id": "fd2e896b883052dae31202b065a06dc5374a214ae348b7a8f8da3734f690d010",
+  "NetworkSettings": {
+    "Ports": {
+      "18332/tcp": [
+        {
+          "HostIp": "0.0.0.0",
+          "HostPort": "33076"
+        }
+      ],
+      "18333/tcp": [
+        {
+          "HostIp": "0.0.0.0",
+          "HostPort": "33075"
+        }
+      ],
+      "18443/tcp": null,
+      "18444/tcp": null,
+      "8332/tcp": [
+        {
+          "HostIp": "0.0.0.0",
+          "HostPort": "33078"
+        }
+      ],
+      "8333/tcp": [
+        {
+          "HostIp": "0.0.0.0",
+          "HostPort": "33077"
+        }
+      ]
+    }
+  }
+}
+

--- a/testcontainers/src/clients/mod.rs
+++ b/testcontainers/src/clients/mod.rs
@@ -1,0 +1,1 @@
+pub mod cli;

--- a/testcontainers/src/clients/mod.rs
+++ b/testcontainers/src/clients/mod.rs
@@ -1,1 +1,3 @@
-pub mod cli;
+mod cli;
+
+pub use self::cli::Cli;

--- a/testcontainers/src/docker_cli.rs
+++ b/testcontainers/src/docker_cli.rs
@@ -36,7 +36,7 @@ impl Docker for DockerCli {
         let container_id = reader.lines().next().unwrap().unwrap();
 
         // TODO maybe move log statements to container
-        let container = Container::new(container_id, DockerCli {}, image);
+        let container = Container::new(container_id, self, image);
 
         debug!("Waiting for {} to be ready.", container);
 

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -16,3 +16,18 @@ pub mod clients;
 
 pub use api::*;
 pub use wait_for_message::{WaitError, WaitForMessage};
+
+pub mod prelude {
+
+    pub use Docker;
+    pub use Image;
+
+    pub use Container;
+    pub use Logs;
+    pub use Ports;
+
+    pub use WaitError;
+    pub use WaitForMessage;
+
+    pub use clients;
+}

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -6,12 +6,9 @@ extern crate serde_derive;
 extern crate log;
 
 mod api;
-mod docker_cli;
 mod wait_for_message;
+
+pub mod clients;
 
 pub use api::*;
 pub use wait_for_message::{WaitError, WaitForMessage};
-
-pub mod clients {
-    pub use docker_cli::DockerCli;
-}

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -5,6 +5,10 @@ extern crate serde_derive;
 #[macro_use]
 extern crate log;
 
+#[cfg(test)]
+#[macro_use]
+extern crate maplit;
+
 mod api;
 mod wait_for_message;
 


### PR DESCRIPTION
I tried to integrate a 2nd docker client next to the `Cli` and identified some necessary refactorings.

In short:

- Store only a reference to the Docker client inside a Container
- Only expose a `ports()` getter from the Docker API

Please see the commit messages for more detail.