### PR TITLE
Add documentation for most public items

### DIFF
--- a/cli_client/Cargo.toml
+++ b/cli_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_cli_client"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",
@@ -14,7 +14,7 @@ keywords = ["docker", "testcontainers"]
 description = "An implementation of the testcontainers `Docker` trait that uses the Docker CLI to issue the necessary commands to the docker daemon."
 
 [dependencies]
-tc_core = { path = "../core", version = "0.1" }
+tc_core = { path = "../core", version = "0.2" }
 serde = "1"
 serde_json = "1"
 serde_derive = "1"

--- a/cli_client/src/cli.rs
+++ b/cli_client/src/cli.rs
@@ -8,6 +8,9 @@ use std::{
 };
 use tc_core::{self, Container, Docker, Image, Logs};
 
+/// Implementation of the Docker client API using the docker cli.
+///
+/// This (fairly naive) implementation of the Docker client API simply creates `Command`s to the `docker` CLI. It thereby assumes that the `docker` CLI is installed and that it is in the PATH of the current execution environment.
 #[derive(Debug, Default)]
 pub struct Cli;
 
@@ -32,11 +35,7 @@ impl Docker for Cli {
 
         let container_id = reader.lines().next().unwrap().unwrap();
 
-        let container = Container::new(container_id, self, image);
-
-        container.block_until_ready();
-
-        container
+        Container::new(container_id, self, image)
     }
 
     fn logs(&self, id: &str) -> Logs {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_core"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",

--- a/core/src/container.rs
+++ b/core/src/container.rs
@@ -1,7 +1,27 @@
-use std::{collections::HashMap, env::var, io::Read};
+use std::env::var;
 use Docker;
 use Image;
+use Logs;
 
+/// Represents a running docker container.
+///
+/// Containers have a [`custom destructor`][drop_impl] that removes them as soon as they go out of scope:
+///
+/// ```rust
+/// #[test]
+/// fn a_test() {
+///     let docker = Cli::default();
+///
+///     {
+///         let container = docker.run(MyImage::default());
+///
+///         // Docker container is stopped/removed at the end of this scope.
+///     }
+/// }
+///
+/// ```
+///
+/// [drop_impl]: struct.Container.html#impl-Drop
 #[derive(Debug)]
 pub struct Container<'d, D, I>
 where
@@ -19,27 +39,43 @@ where
     D: Docker,
     I: Image,
 {
+    /// Constructs a new container given an id, a docker client and the image.
+    ///
+    /// This function will block the current thread (if [`wait_until_ready`] is implemented correctly) until the container is actually ready to be used.
+    ///
+    /// [`wait_until_ready`]: trait.Image.html#tymethod.wait_until_ready
     pub fn new(id: String, docker_client: &'d D, image: I) -> Self {
-        Container {
+        let container = Container {
             id,
             docker_client,
             image,
-        }
+        };
+
+        container.block_until_ready();
+
+        container
     }
 
+    /// Returns the id of this container.
     pub fn id(&self) -> &str {
         &self.id
     }
 
+    /// Gives access to the log streams of this container.
     pub fn logs(&self) -> Logs {
         self.docker_client.logs(&self.id)
     }
 
+    /// Returns the mapped host port for an internal port of this docker container.
+    ///
+    /// This method does **not** magically expose the given port, it simply performs a mapping on
+    /// the already exposed ports. If a docker image does not expose a port, this method will not
+    /// be able to resolve it.
     pub fn get_host_port(&self, internal_port: u32) -> Option<u32> {
         let resolved_port = self
             .docker_client
             .ports(&self.id)
-            .map_to_external_port(internal_port);
+            .map_to_host_port(internal_port);
 
         match resolved_port {
             Some(port) => {
@@ -59,7 +95,18 @@ where
         resolved_port
     }
 
-    pub fn block_until_ready(&self) {
+    /// Returns a reference to the [`Image`] of this container.
+    ///
+    /// Access to this is useful if the [`arguments`] of the [`Image`] change how to connect to the
+    /// container (for example, because of authentication information).
+    ///
+    /// [`Image`]: trait.Image.html
+    /// [`arguments`]: trait.Image.html#associatedtype.Args
+    pub fn image(&self) -> &I {
+        &self.image
+    }
+
+    fn block_until_ready(&self) {
         debug!("Waiting for container {} to be ready", self.id);
 
         self.image.wait_until_ready(self);
@@ -67,23 +114,23 @@ where
         debug!("Container {} is now ready!", self.id);
     }
 
-    pub fn image(&self) -> &I {
-        &self.image
-    }
-
-    pub fn stop(&self) {
+    fn stop(&self) {
         debug!("Stopping docker container {}", self.id);
 
         self.docker_client.stop(&self.id)
     }
 
-    pub fn rm(&self) {
+    fn rm(&self) {
         debug!("Deleting docker container {}", self.id);
 
         self.docker_client.rm(&self.id)
     }
 }
 
+/// The destructor implementation for a Container.
+///
+/// As soon as the container goes out of scope, the destructor will either only stop or completely the docker container.
+/// This behaviour can be controlled through the `KEEP_CONTAINERS` environment variable. Setting it to `true` will only stop containers instead of removing them. Any other or no value will remove the container.
 impl<'d, D, I> Drop for Container<'d, D, I>
 where
     D: Docker,
@@ -100,31 +147,4 @@ where
             false => self.rm(),
         }
     }
-}
-
-#[derive(Debug, PartialEq, Default)]
-pub struct Ports {
-    mapping: HashMap<u32, u32>,
-}
-
-impl Ports {
-    pub fn add_mapping(&mut self, internal: u32, external: u32) -> &mut Self {
-        debug!("Registering port mapping: {} -> {}", internal, external);
-
-        self.mapping.insert(internal, external);
-
-        self
-    }
-
-    pub fn map_to_external_port(&self, port: u32) -> Option<u32> {
-        self.mapping.get(&port).map(|p| p.clone())
-    }
-}
-
-#[derive(DebugStub)]
-pub struct Logs {
-    #[debug_stub = "stream"]
-    pub stdout: Box<Read>,
-    #[debug_stub = "stream"]
-    pub stderr: Box<Read>,
 }

--- a/core/src/container.rs
+++ b/core/src/container.rs
@@ -98,7 +98,7 @@ where
     /// Returns a reference to the [`Image`] of this container.
     ///
     /// Access to this is useful if the [`arguments`] of the [`Image`] change how to connect to the
-    /// container (for example, because of authentication information).
+    /// Access to this is useful to retrieve [`Image`] specific information such as authentication details or other relevant information which have been passed as [`arguments`]
     ///
     /// [`Image`]: trait.Image.html
     /// [`arguments`]: trait.Image.html#associatedtype.Args

--- a/core/src/container.rs
+++ b/core/src/container.rs
@@ -129,7 +129,7 @@ where
 
 /// The destructor implementation for a Container.
 ///
-/// As soon as the container goes out of scope, the destructor will either only stop or completely the docker container.
+/// As soon as the container goes out of scope, the destructor will either only stop or delete the docker container.
 /// This behaviour can be controlled through the `KEEP_CONTAINERS` environment variable. Setting it to `true` will only stop containers instead of removing them. Any other or no value will remove the container.
 impl<'d, D, I> Drop for Container<'d, D, I>
 where

--- a/core/src/docker.rs
+++ b/core/src/docker.rs
@@ -1,8 +1,8 @@
+use std::{collections::HashMap, io::Read};
 use Container;
 use Image;
-use Logs;
-use Ports;
 
+/// Defines the minimum API required for interacting with the Docker daemon.
 pub trait Docker
 where
     Self: Sized,
@@ -12,4 +12,35 @@ where
     fn ports(&self, id: &str) -> Ports;
     fn rm(&self, id: &str);
     fn stop(&self, id: &str);
+}
+
+/// The exposed ports of a running container.
+#[derive(Debug, PartialEq, Default)]
+pub struct Ports {
+    mapping: HashMap<u32, u32>,
+}
+
+impl Ports {
+    /// Registers the mapping of an exposed port.
+    pub fn add_mapping(&mut self, internal: u32, host: u32) -> &mut Self {
+        debug!("Registering port mapping: {} -> {}", internal, host);
+
+        self.mapping.insert(internal, host);
+
+        self
+    }
+
+    /// Returns the host port for the given internal port.
+    pub fn map_to_host_port(&self, internal_port: u32) -> Option<u32> {
+        self.mapping.get(&internal_port).map(|p| p.clone())
+    }
+}
+
+/// Log streams of running container (stdout & stderr).
+#[derive(DebugStub)]
+pub struct Logs {
+    #[debug_stub = "stream"]
+    pub stdout: Box<Read>,
+    #[debug_stub = "stream"]
+    pub stderr: Box<Read>,
 }

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -1,16 +1,55 @@
 use Container;
 use Docker;
 
+/// Represents a docker image.
+///
+/// Implementations are required to implement Default. The default instance of an [`Image`]
+/// should have a meaningful configuration! It should be possible to [`run`][docker_run] the default
+/// instance of an Image and get back a working container!
+///
+/// [`Image`]: trait.Image.html
+/// [docker_run]: trait.Docker.html#tymethod.run
 pub trait Image
 where
     Self: Sized + Default,
-    Self::Args: IntoIterator<Item = String>,
+    Self::Args: Default + IntoIterator<Item = String>,
 {
+    /// A type representing the arguments for an Image.
+    ///
+    /// There are a couple of things regarding the arguments of images:
+    ///
+    /// 1. Similar to the Default implementation of an Image, the Default instance
+    /// of its arguments should be meaningful!
+    /// 2. Implementations should be conservative about which arguments they expose. Many times,
+    /// users will either go with the default arguments or just override one or two. When defining
+    /// the arguments of your image, consider that the whole purpose is to facilitate integration
+    /// testing. Only expose those that actually make sense for this case.
     type Args;
 
+    /// The descriptor of the docker image.
+    ///
+    /// This should return a full-qualified descriptor.
+    /// Implementations are encouraged to include a tag that will not change (i.e. NOT latest)
+    /// in order to prevent test code from randomly breaking because the underlying docker
+    /// suddenly changed.
     fn descriptor(&self) -> String;
+
+    /// Blocks the current thread until the started container is ready.
+    ///
+    /// This method is the **bread and butter** of the whole testcontainers library. Containers are
+    /// rarely instantly available as soon as they are started. Most of them take some time to boot
+    /// up.
+    ///
+    /// Implementations MUST block the current thread until the passed-in container is ready to be
+    /// interacted with. The container instance provides access to logs of the container.
+    ///
+    /// Most implementations will very likely want to make use of this to wait for a particular
+    /// message to be emitted.
     fn wait_until_ready<D: Docker>(&self, container: &Container<D, Self>);
+
+    /// Returns the arguments this instance was created with.
     fn args(&self) -> Self::Args;
 
+    /// Re-configures the current instance of this image with the given arguments.
     fn with_args(self, arguments: Self::Args) -> Self;
 }

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -36,7 +36,7 @@ where
 
     /// Blocks the current thread until the started container is ready.
     ///
-    /// This method is the **bread and butter** of the whole testcontainers library. Containers are
+    /// This method is the **🍞 and butter** of the whole testcontainers library. Containers are
     /// rarely instantly available as soon as they are started. Most of them take some time to boot
     /// up.
     ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ mod docker;
 mod image;
 mod wait_for_message;
 
-pub use self::container::{Container, Logs, Ports};
-pub use self::docker::Docker;
+pub use self::container::Container;
+pub use self::docker::{Docker, Logs, Ports};
 pub use self::image::Image;
 pub use self::wait_for_message::{WaitError, WaitForMessage};

--- a/core/src/wait_for_message.rs
+++ b/core/src/wait_for_message.rs
@@ -1,5 +1,6 @@
 use std::io::{self, BufRead, BufReader, Read};
 
+/// Defines error cases when waiting for a message in a stream.
 #[derive(Debug)]
 pub enum WaitError {
     EndOfStream,
@@ -12,6 +13,7 @@ impl From<io::Error> for WaitError {
     }
 }
 
+/// Extension trait for io::Read to wait for a message to appear in the given stream.
 pub trait WaitForMessage {
     fn wait_for_message(self, message: &str) -> Result<(), WaitError>;
 }

--- a/images/coblox_bitcoincore/Cargo.toml
+++ b/images/coblox_bitcoincore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_coblox_bitcoincore"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",
@@ -14,7 +14,7 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "bitcoin"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.1" }
+tc_core = { path = "../../core", version = "0.2" }
 log = "0.4"
 hmac = "0.6"
 sha2 = "0.7"

--- a/images/coblox_bitcoincore/src/lib.rs
+++ b/images/coblox_bitcoincore/src/lib.rs
@@ -10,4 +10,4 @@ extern crate sha2;
 
 mod image;
 
-pub use image::BitcoinCore;
+pub use image::{BitcoinCore, BitcoinCoreImageArgs, Network, RpcAuth};

--- a/images/parity_parity/Cargo.toml
+++ b/images/parity_parity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_parity_parity"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",
@@ -14,7 +14,7 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "parity", "ethereum"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.1" }
+tc_core = { path = "../../core", version = "0.2" }
 log = "0.4"
 
 [dev-dependencies]

--- a/images/parity_parity/src/image.rs
+++ b/images/parity_parity/src/image.rs
@@ -5,7 +5,7 @@ pub struct ParityEthereum {
     arguments: ParityEthereumArgs,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct ParityEthereumArgs {}
 
 impl IntoIterator for ParityEthereumArgs {

--- a/images/trufflesuite_ganachecli/Cargo.toml
+++ b/images/trufflesuite_ganachecli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_trufflesuite_ganachecli"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",
@@ -14,7 +14,7 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "ethereum"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.1" }
+tc_core = { path = "../../core", version = "0.2" }
 
 [dev-dependencies]
 web3 = "0.4"

--- a/testcontainers/.gitignore
+++ b/testcontainers/.gitignore
@@ -1,5 +1,0 @@
-/target
-**/*.rs.bk
-Cargo.lock
-
-/.idea

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testcontainers"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",
@@ -14,7 +14,7 @@ keywords = ["docker", "testcontainers"]
 description = "Meta crate for testcontainers, a library for integration-testing against docker containers from within Rust."
 
 [dependencies]
-tc_core = { path = "../core", version = "0.1" }
+tc_core = { path = "../core", version = "0.2" }
 
 # Clients
 tc_cli_client = { path = "../cli_client", version = "0.1" }

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -1,5 +1,40 @@
 #![deny(missing_debug_implementations)]
 
+//! A library for integration testing against docker containers from within Rust.
+//!
+//! This crate is the official Rust language fork of [`Testcontainers`][tc_website].
+//!
+//! Tests should be self-contained and isolated. While this is usually easy for unit-tests, integration-tests typically require a more complex environment.
+//! The testcontainers ecosystem facilitates self-contained and isolated integration tests. It allows to easily spin up Docker containers from within in your tests and removes them afterwards.
+//!
+//! A very typical usecase for testcontainers are integration-tests of persistence layers. These require an actual database to be present. Using testcontainers, your tests can spin up database containers themselves, without the need for any other setup.
+//!
+//! # Main benefits
+//!
+//! - Run integration tests in parallel (because each test sets up its own environment)
+//! - Run integration tests the same way you run unit tests (`cargo test` and you are fine)
+//!
+//! # Usage
+//!
+//! Unsurprisingly, working with testcontainers is very similar to working with Docker itself.
+//!
+//! First you choose a [`Client`]. Given a client instance, you can [`run`][docker_run] [`Images`]. This gives you back a [`Container`]. Containers implement [`Drop`]. As soon as they go out of scope, the underlying docker container is removed.
+//!
+//! # Usage in production code
+//!
+//! Although nothing inherently prevents testcontainers from being used in production code, the library itself was not designed with that in mind. For example, many methods will panic if something goes wrong but because the usage is intended to be within tests, this is deemed acceptable.
+//!
+//! # Ecosystem
+//!
+//! The testcontainers ecosystem is split into multiple crates, however, the `testcontainers` crate itself is a meta-crate, re-exporting the others. Usually, depending on `testcontainers` should be sufficient for most users needs.
+//!
+//! [tc_website]: https://testcontainers.org
+//! [`Docker`]: https://docker.com
+//! [docker_run]: trait.Docker.html#tymethod.run
+//! [`Client`]: trait.Docker.html#implementors
+//! [`Images`]: trait.Image.html#implementors
+//! [`Container`]: struct.Container.html
+
 extern crate tc_cli_client;
 extern crate tc_core;
 
@@ -7,13 +42,15 @@ extern crate tc_coblox_bitcoincore;
 extern crate tc_parity_parity;
 extern crate tc_trufflesuite_ganachecli;
 
+/// All available Docker clients.
 pub mod clients {
     pub use tc_cli_client::Cli;
 }
 
+/// All available Docker images.
 pub mod images {
     pub mod coblox_bitcoincore {
-        pub use tc_coblox_bitcoincore::BitcoinCore;
+        pub use tc_coblox_bitcoincore::{BitcoinCore, BitcoinCoreImageArgs, Network, RpcAuth};
     }
 
     pub mod parity_parity {

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate is the official Rust language fork of [`Testcontainers`][tc_website].
 //!
 //! Tests should be self-contained and isolated. While this is usually easy for unit-tests, integration-tests typically require a more complex environment.
-//! The testcontainers ecosystem facilitates self-contained and isolated integration tests. It allows to easily spin up Docker containers from within in your tests and removes them afterwards.
+//! The testcontainers ecosystem facilitates self-contained and isolated integration tests. It allows to easily spin up Docker containers from within your tests and removes them afterwards.
 //!
 //! A very typical usecase for testcontainers are integration-tests of persistence layers. These require an actual database to be present. Using testcontainers, your tests can spin up database containers themselves, without the need for any other setup.
 //!
@@ -18,7 +18,7 @@
 //!
 //! Unsurprisingly, working with testcontainers is very similar to working with Docker itself.
 //!
-//! First you choose a [`Client`]. Given a client instance, you can [`run`][docker_run] [`Images`]. This gives you back a [`Container`]. Containers implement [`Drop`]. As soon as they go out of scope, the underlying docker container is removed.
+//! First you choose a [`Client`]. Given a client instance, you can [`run`][docker_run] [`Images`]. This gives you back a [`Container`]. Containers implement `Drop`. As soon as they go out of scope, the underlying docker container is removed.
 //!
 //! # Usage in production code
 //!


### PR DESCRIPTION
This commit also directly increments all the necessary versions for
the next release.

As I was writing the documentation for the main traits + structs, I
realized that they actually expose more things publicly than needed.

Therefore, this commit also includes a breaking change for the tc_core
crate because some of the public methods are removed. For users of the
testcontainers crate, this shouldn't be noticeable though since from the
PoV of testcontainers, it is a non-breaking change and thus a
patch-release.

Fixes #6.