### PR TITLE
Conditionally wait longer before fetching logs

### DIFF
--- a/cli_client/Cargo.toml
+++ b/cli_client/Cargo.toml
@@ -19,3 +19,7 @@ serde = "1"
 serde_json = "1"
 serde_derive = "1"
 log = "0.4"
+
+[dev-dependencies]
+spectral = "0.6"
+pretty_env_logger = "0.2"

--- a/cli_client/src/cli.rs
+++ b/cli_client/src/cli.rs
@@ -1,5 +1,7 @@
 use serde_json;
 use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::Instant;
 use std::{
     io::{BufRead, BufReader},
     process::{Command, Stdio},
@@ -8,11 +10,68 @@ use std::{
 };
 use tc_core::{self, Container, Docker, Image, Logs};
 
+const ONE_SECOND: Duration = Duration::from_secs(1);
+const ZERO: Duration = Duration::from_secs(0);
+
 /// Implementation of the Docker client API using the docker cli.
 ///
 /// This (fairly naive) implementation of the Docker client API simply creates `Command`s to the `docker` CLI. It thereby assumes that the `docker` CLI is installed and that it is in the PATH of the current execution environment.
 #[derive(Debug, Default)]
-pub struct Cli;
+pub struct Cli {
+    /// The docker CLI has an issue that if you request logs for a container
+    /// too quickly after it was started up, the resulting stream will never
+    /// emit any data, even if the container is already emitting logs.
+    ///
+    /// We keep track of when we started a container in order to make sure
+    /// that we wait at least one second after that. Subsequent invocations
+    /// directly fetch the logs of a container.
+    container_startup_timestamps: RwLock<HashMap<String, Instant>>,
+}
+
+impl Cli {
+    fn register_container_started(&self, id: String) {
+        let mut lock_guard = match self.container_startup_timestamps.write() {
+            Ok(lock_guard) => lock_guard,
+
+            // We only need the mutex to not require a &mut self in this function.
+            // Data cannot be in-consistent even if a thread panics while holding the lock
+            Err(e) => e.into_inner(),
+        };
+        let start_timestamp = Instant::now();
+
+        trace!(
+            "Registring starting of container {} at {:?}",
+            id,
+            start_timestamp
+        );
+
+        lock_guard.insert(id, start_timestamp);
+    }
+
+    fn time_since_container_was_started(&self, id: &str) -> Option<Duration> {
+        let lock_guard = match self.container_startup_timestamps.read() {
+            Ok(lock_guard) => lock_guard,
+
+            // We only need the mutex to not require a &mut self in this function.
+            // Data cannot be in-consistent even if a thread panics while holding the lock
+            Err(e) => e.into_inner(),
+        };
+
+        let result = lock_guard.get(id).map(|i| Instant::now() - *i);
+
+        trace!("Time since container {} was started: {:?}", id, result);
+
+        result
+    }
+
+    fn wait_at_least_one_second_after_container_was_started(&self, id: &str) {
+        if let Some(duration) = self.time_since_container_was_started(id) {
+            if duration < ONE_SECOND {
+                sleep(ONE_SECOND.checked_sub(duration).unwrap_or_else(|| ZERO))
+            }
+        }
+    }
+}
 
 impl Docker for Cli {
     fn run<I: Image>(&self, image: I) -> Container<Cli, I> {
@@ -35,13 +94,13 @@ impl Docker for Cli {
 
         let container_id = reader.lines().next().unwrap().unwrap();
 
+        self.register_container_started(container_id.clone());
+
         Container::new(container_id, self, image)
     }
 
     fn logs(&self, id: &str) -> Logs {
-        // Hack to fix unstable CI builds. Sometimes the logs are not immediately available after starting the container.
-        // Let's sleep for a little bit of time to let the container start up before we actually process the logs.
-        sleep(Duration::from_millis(100));
+        self.wait_at_least_one_second_after_container_was_started(id);
 
         let child = Command::new("docker")
             .arg("logs")

--- a/cli_client/src/cli.rs
+++ b/cli_client/src/cli.rs
@@ -40,7 +40,7 @@ impl Cli {
         let start_timestamp = Instant::now();
 
         trace!(
-            "Registring starting of container {} at {:?}",
+            "Registering starting of container {} at {:?}",
             id,
             start_timestamp
         );

--- a/cli_client/tests/waits_before_fetching_logs.rs
+++ b/cli_client/tests/waits_before_fetching_logs.rs
@@ -1,0 +1,62 @@
+extern crate pretty_env_logger;
+extern crate spectral;
+extern crate tc_cli_client;
+extern crate tc_core;
+
+use spectral::prelude::*;
+use std::time::Duration;
+use std::time::Instant;
+use tc_cli_client::Cli;
+use tc_core::Container;
+use tc_core::Docker;
+use tc_core::Image;
+use tc_core::WaitForMessage;
+
+#[derive(Default)]
+struct HelloWorld;
+
+impl Image for HelloWorld {
+    type Args = Vec<String>;
+
+    fn descriptor(&self) -> String {
+        String::from("hello-world")
+    }
+
+    fn wait_until_ready<D: Docker>(&self, container: &Container<D, Self>) {
+        container
+            .logs()
+            .stdout
+            .wait_for_message("Hello from Docker!")
+            .unwrap();
+    }
+
+    fn args(&self) -> <Self as Image>::Args {
+        vec![]
+    }
+
+    fn with_args(self, _arguments: <Self as Image>::Args) -> Self {
+        self
+    }
+}
+
+#[test]
+fn should_wait_for_at_least_one_second_before_fetching_logs() {
+    let _ = pretty_env_logger::try_init();
+
+    let docker = Cli::default();
+
+    let before_run = Instant::now();
+
+    let container = docker.run(HelloWorld);
+
+    let after_run = Instant::now();
+
+    let before_logs = Instant::now();
+
+    docker.logs(container.id());
+
+    let after_logs = Instant::now();
+
+    assert_that(&(after_run - before_run)).is_greater_than(Duration::from_secs(1));
+    assert_that(&(after_logs - before_logs)).is_less_than(Duration::from_secs(1));
+}


### PR DESCRIPTION
We wait for at least one second before fetching the logs from a
container in order to avoid the problem of not seeing logs when we try
to get them immediately after starting the container.

Fixex #17.