### PR TITLE
Upgrade default parity image tag

### DIFF
--- a/images/parity_parity/Cargo.toml
+++ b/images/parity_parity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_parity_parity"
-version = "0.2.1"
+version = "0.3.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the parity/parity docker image."
 license = "MIT OR Apache-2.0"

--- a/images/parity_parity/src/image.rs
+++ b/images/parity_parity/src/image.rs
@@ -1,8 +1,12 @@
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
+const CONTAINER_IDENTIFIER: &'static str = "parity/parity";
+const DEFAULT_TAG: &'static str = "v2.1.3";
+
 #[derive(Debug)]
 pub struct ParityEthereum {
     arguments: ParityEthereumArgs,
+    tag: String,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -27,6 +31,7 @@ impl Default for ParityEthereum {
     fn default() -> Self {
         ParityEthereum {
             arguments: ParityEthereumArgs {},
+            tag: DEFAULT_TAG.to_string(),
         }
     }
 }
@@ -35,7 +40,7 @@ impl Image for ParityEthereum {
     type Args = ParityEthereumArgs;
 
     fn descriptor(&self) -> String {
-        "parity/parity:v1.11.11".to_string()
+        format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
     fn wait_until_ready<D: Docker>(&self, container: &Container<D, Self>) {
@@ -51,6 +56,15 @@ impl Image for ParityEthereum {
     }
 
     fn with_args(self, arguments: Self::Args) -> Self {
-        Self { arguments }
+        Self { arguments, ..self }
+    }
+}
+
+impl ParityEthereum {
+    pub fn with_tag(self, tag_str: &str) -> Self {
+        ParityEthereum {
+            tag: tag_str.to_string(),
+            ..self
+        }
     }
 }

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -17,7 +17,7 @@ tc_cli_client = { path = "../cli_client", version = "0.1" }
 # Images
 tc_coblox_bitcoincore = { path = "../images/coblox_bitcoincore", version = "0.3" }
 tc_trufflesuite_ganachecli = { path = "../images/trufflesuite_ganachecli", version = "0.3" }
-tc_parity_parity = { path = "../images/parity_parity", version = "0.2" }
+tc_parity_parity = { path = "../images/parity_parity", version = "0.3" }
 tc_dynamodb_local = { path = "../images/dynamodb_local", version = "0.1" }
 tc_redis = { path = "../images/redis", version = "0.1" }
 tc_elasticmq = { path = "../images/elasticmq", version = "0.1" }


### PR DESCRIPTION
Allows tag to be passed when using the parity image and default to latest parity v2.1.3.

Resolves #46. 