### PR TITLE
Add environment variables

### DIFF
--- a/cli_client/tests/waits_before_fetching_logs.rs
+++ b/cli_client/tests/waits_before_fetching_logs.rs
@@ -4,6 +4,7 @@ extern crate tc_cli_client;
 extern crate tc_core;
 
 use spectral::prelude::*;
+use std::collections::HashMap;
 use std::time::Duration;
 use std::time::Instant;
 use tc_cli_client::Cli;
@@ -17,6 +18,7 @@ struct HelloWorld;
 
 impl Image for HelloWorld {
     type Args = Vec<String>;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         String::from("hello-world")
@@ -32,6 +34,10 @@ impl Image for HelloWorld {
 
     fn args(&self) -> <Self as Image>::Args {
         vec![]
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, _arguments: <Self as Image>::Args) -> Self {

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -13,6 +13,7 @@ pub trait Image
 where
     Self: Sized + Default,
     Self::Args: Default + IntoIterator<Item = String>,
+    Self::EnvVars: Default + IntoIterator<Item = (String, String)>,
 {
     /// A type representing the arguments for an Image.
     ///
@@ -25,6 +26,18 @@ where
     /// the arguments of your image, consider that the whole purpose is to facilitate integration
     /// testing. Only expose those that actually make sense for this case.
     type Args;
+
+    /// A type representing the environment variables for an Image.
+    ///
+    /// There are a couple of things regarding the arguments of images:
+    ///
+    /// 1. Similar to the Default implementation of an Image, the Default instance
+    /// of its environment variables should be meaningful!
+    /// 2. Implementations should be conservative about which environment variables they expose. Many times,
+    /// users will either go with the default ones or just override one or two. When defining
+    /// the environment variables of your image, consider that the whole purpose is to facilitate integration
+    /// testing. Only expose those that actually make sense for this case.
+    type EnvVars;
 
     /// The descriptor of the docker image.
     ///
@@ -49,6 +62,9 @@ where
 
     /// Returns the arguments this instance was created with.
     fn args(&self) -> Self::Args;
+
+    /// Returns the environment variables this instance was created with.
+    fn env_vars(&self) -> Self::EnvVars;
 
     /// Re-configures the current instance of this image with the given arguments.
     fn with_args(self, arguments: Self::Args) -> Self;

--- a/images/coblox_bitcoincore/src/image.rs
+++ b/images/coblox_bitcoincore/src/image.rs
@@ -2,6 +2,7 @@ use hex::encode;
 use hmac::{Hmac, Mac};
 use rand::{thread_rng, Rng};
 use sha2::Sha256;
+use std::collections::HashMap;
 use std::{env::var, thread::sleep, time::Duration};
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
@@ -147,6 +148,7 @@ impl IntoIterator for BitcoinCoreImageArgs {
 
 impl Image for BitcoinCore {
     type Args = BitcoinCoreImageArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         format!("coblox/bitcoin-core:{}", self.tag)
@@ -177,6 +179,10 @@ impl Image for BitcoinCore {
 
     fn args(&self) -> <Self as Image>::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {

--- a/images/dynamodb_local/src/image.rs
+++ b/images/dynamodb_local/src/image.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::{env::var, thread::sleep, time::Duration};
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
@@ -35,6 +36,7 @@ impl Default for DynamoDb {
 
 impl Image for DynamoDb {
     type Args = DynamoDbArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
@@ -64,6 +66,10 @@ impl Image for DynamoDb {
 
     fn args(&self) -> <Self as Image>::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {

--- a/images/elasticmq/src/image.rs
+++ b/images/elasticmq/src/image.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
 const CONTAINER_IDENTIFIER: &'static str = "softwaremill/elasticmq";
@@ -32,6 +33,7 @@ impl Default for ElasticMQ {
 
 impl Image for ElasticMQ {
     type Args = ElasticMQArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
@@ -47,6 +49,10 @@ impl Image for ElasticMQ {
 
     fn args(&self) -> <Self as Image>::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {

--- a/images/parity_parity/src/image.rs
+++ b/images/parity_parity/src/image.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
 const CONTAINER_IDENTIFIER: &'static str = "parity/parity";
@@ -38,6 +39,7 @@ impl Default for ParityEthereum {
 
 impl Image for ParityEthereum {
     type Args = ParityEthereumArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
@@ -53,6 +55,10 @@ impl Image for ParityEthereum {
 
     fn args(&self) -> Self::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: Self::Args) -> Self {

--- a/images/postgres/src/image.rs
+++ b/images/postgres/src/image.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
 #[derive(Debug)]
@@ -27,6 +28,7 @@ impl Default for Postgres {
 
 impl Image for Postgres {
     type Args = PostgresArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         "postgres:11-alpine".to_string()
@@ -42,6 +44,10 @@ impl Image for Postgres {
 
     fn args(&self) -> Self::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: Self::Args) -> Self {

--- a/images/redis/src/image.rs
+++ b/images/redis/src/image.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
 const CONTAINER_IDENTIFIER: &'static str = "redis";
@@ -32,6 +33,7 @@ impl Default for Redis {
 
 impl Image for Redis {
     type Args = RedisArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
@@ -47,6 +49,10 @@ impl Image for Redis {
 
     fn args(&self) -> <Self as Image>::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {

--- a/images/trufflesuite_ganachecli/src/image.rs
+++ b/images/trufflesuite_ganachecli/src/image.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tc_core::{Container, Docker, Image, WaitForMessage};
 
 #[derive(Debug)]
@@ -55,6 +56,7 @@ impl IntoIterator for GanacheCliArgs {
 
 impl Image for GanacheCli {
     type Args = GanacheCliArgs;
+    type EnvVars = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
         format!("trufflesuite/ganache-cli:{}", self.tag)
@@ -70,6 +72,10 @@ impl Image for GanacheCli {
 
     fn args(&self) -> <Self as Image>::Args {
         self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
     }
 
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {


### PR DESCRIPTION
Attempt to fix #57

This PR introduces:
- a new method to return env vars added to the Image trait
- environment variables handling added in the Cli
- a new method to declare custom env vars added to the GenericImage

It does not provide any solution for the non-generic images; a per-image specific solution is outside the scope of this PR. 