### PR TITLE
Bump tc_core version to 0.3.0, testcontainers to 0.5.1

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -8,7 +8,12 @@
     3. `testcontainers` meta crate goes last
 4. Do `git diff <CRATE>-<VERSION>` for the latest released version, f.e. `git diff testcontainers-0.5.0`
 5. Determine the degree of changes with respect to the [release guide](./RELEASING.md)
-6. Bump the version accordingly and make a commit
-7. Create a new tag based on your new version: `git tag <CRATE>-<NEW_VERSION>`, f.e. `git tag testcontainers-0.5.1`
-8. Make sure `cargo test` and `cargo package` pass
-9. Do `cargo release`
+6. Bump the version accordingly
+7. Do step 3. through all crates that need bumping
+8. Make one commit
+9. Make sure `cargo test` and `cargo package` pass
+10. Create PR, merge in master
+11. Checkout latest master
+12. Create a new tag based on your new version: `git tag <CRATE>-<NEW_VERSION>`, f.e. `git tag testcontainers-0.5.1`
+13. Make sure `cargo test` and `cargo package` pass
+14  . Do `cargo release`

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -16,4 +16,4 @@
 11. Checkout latest master
 12. Create a new tag based on your new version: `git tag <CRATE>-<NEW_VERSION>`, f.e. `git tag testcontainers-0.5.1`
 13. Make sure `cargo test` and `cargo package` pass
-14  . Do `cargo release`
+14. Do `cargo release`

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -10,8 +10,8 @@
 5. Determine the degree of changes with respect to the [release guide](./RELEASING.md)
 6. Bump the version accordingly
 7. Do step 3. through all crates that need bumping
-8. Make one commit
-9. Make sure `cargo test` and `cargo package` pass
+8. Make sure `cargo test` pass
+9. Make one commit
 10. Create PR, merge in master
 11. Checkout latest master
 12. Create a new tag based on your new version: `git tag <CRATE>-<NEW_VERSION>`, f.e. `git tag testcontainers-0.5.1`

--- a/cli_client/Cargo.toml
+++ b/cli_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_cli_client"
-version = "0.1.1"
+version = "0.2.0"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"
@@ -9,7 +9,7 @@ keywords = ["docker", "testcontainers"]
 description = "An implementation of the testcontainers `Docker` trait that uses the Docker CLI to issue the necessary commands to the docker daemon."
 
 [dependencies]
-tc_core = { path = "../core", version = "0.2" }
+tc_core = { path = "../core", version = "0.3" }
 serde = "1"
 serde_json = "1"
 serde_derive = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_core"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"

--- a/images/coblox_bitcoincore/Cargo.toml
+++ b/images/coblox_bitcoincore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_coblox_bitcoincore"
-version = "0.4.0"
+version = "0.5.0"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the coblox/bitcoin-core docker image."
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "bitcoin"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }
 log = "0.4"
 hmac = "0.7"
 sha2 = "0.8"

--- a/images/dynamodb_local/Cargo.toml
+++ b/images/dynamodb_local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_dynamodb_local"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Jack Wright <ayax79@gmail.com>" ]
 description = "Testcontainers image for local dynamodb"
 license = "MIT OR Apache-2.0"
@@ -9,5 +9,5 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "dynamodb"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }
 log = "0.4"

--- a/images/elasticmq/Cargo.toml
+++ b/images/elasticmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_elasticmq"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Jack Wright <ayax79@gmail.com>" ]
 description = "Testcontainers image for ElasticMQ"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "elasticmq", "sqs"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }

--- a/images/generic/Cargo.toml
+++ b/images/generic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_generic"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Francesco Cina <ufoscout@gmail.com>" ]
 description = "Testcontainers generic image"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }

--- a/images/parity_parity/Cargo.toml
+++ b/images/parity_parity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_parity_parity"
-version = "0.3.0"
+version = "0.4.0"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the parity/parity docker image."
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "parity", "ethereum"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }
 log = "0.4"
 
 [dev-dependencies]

--- a/images/postgres/Cargo.toml
+++ b/images/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_postgres"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Thomas Eizinger <thomas@eizinger.io>" ]
 description = "Testcontainers image for the postgres docker image."
 license = "MIT OR Apache-2.0"
@@ -9,5 +9,5 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "database", "postgres"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }
 log = "0.4"

--- a/images/redis/Cargo.toml
+++ b/images/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_redis"
-version = "0.1.0"
+version = "0.2.0"
 authors = [ "Jack Wright <ayax79@gmail.com>" ]
 description = "Testcontainers image for Redis"
 license = "MIT OR Apache-2.0"
@@ -9,4 +9,4 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "redis"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }

--- a/images/trufflesuite_ganachecli/Cargo.toml
+++ b/images/trufflesuite_ganachecli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_trufflesuite_ganachecli"
-version = "0.3.1"
+version = "0.4.0"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the trufflesuite/ganache-cli docker image."
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ categories = ["development-tools::testing"]
 keywords = ["docker", "testcontainers", "ethereum"]
 
 [dependencies]
-tc_core = { path = "../../core", version = "0.2" }
+tc_core = { path = "../../core", version = "0.3" }
 
 [dev-dependencies]
 web3 = "0.5"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testcontainers"
-version = "0.5.0"
+version = "0.5.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"
@@ -9,20 +9,20 @@ keywords = ["docker", "testcontainers"]
 description = "Meta crate for testcontainers, a library for integration-testing against docker containers from within Rust."
 
 [dependencies]
-tc_core = { path = "../core", version = "0.2" }
+tc_core = { path = "../core", version = "0.3" }
 
 # Clients
-tc_cli_client = { path = "../cli_client", version = "0.1" }
+tc_cli_client = { path = "../cli_client", version = "0.2" }
 
 # Images
-tc_coblox_bitcoincore = { path = "../images/coblox_bitcoincore", version = "0.4" }
-tc_trufflesuite_ganachecli = { path = "../images/trufflesuite_ganachecli", version = "0.3" }
-tc_parity_parity = { path = "../images/parity_parity", version = "0.3" }
-tc_dynamodb_local = { path = "../images/dynamodb_local", version = "0.1" }
-tc_redis = { path = "../images/redis", version = "0.1" }
-tc_elasticmq = { path = "../images/elasticmq", version = "0.1" }
-tc_generic = { path = "../images/generic", version = "0.1" }
-tc_postgres = { path = "../images/postgres", version = "0.1" }
+tc_coblox_bitcoincore = { path = "../images/coblox_bitcoincore", version = "0.5" }
+tc_trufflesuite_ganachecli = { path = "../images/trufflesuite_ganachecli", version = "0.4" }
+tc_parity_parity = { path = "../images/parity_parity", version = "0.4" }
+tc_dynamodb_local = { path = "../images/dynamodb_local", version = "0.2" }
+tc_redis = { path = "../images/redis", version = "0.2" }
+tc_elasticmq = { path = "../images/elasticmq", version = "0.2" }
+tc_generic = { path = "../images/generic", version = "0.2" }
+tc_postgres = { path = "../images/postgres", version = "0.2" }
 
 [dev-dependencies]
 bitcoin_rpc_client = "0.5"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testcontainers"
-version = "0.5.1"
+version = "0.6.0"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"


### PR DESCRIPTION
Because of tc_core bump, all crates must be upgraded.
This version contains other functional changes for most images crates.

Related to comit-network/comit-rs#762