### PR TITLE
Deprecate all microcrates

### DIFF
--- a/cli_client/Cargo.toml
+++ b/cli_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_cli_client"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"

--- a/cli_client/src/lib.rs
+++ b/cli_client/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.2.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate serde;
 extern crate serde_json;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_core"
-version = "0.3.0"
+version = "0.3.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.3.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 #[macro_use]
 extern crate log;

--- a/images/coblox_bitcoincore/Cargo.toml
+++ b/images/coblox_bitcoincore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_coblox_bitcoincore"
-version = "0.5.0"
+version = "0.5.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the coblox/bitcoin-core docker image."
 license = "MIT OR Apache-2.0"

--- a/images/coblox_bitcoincore/src/lib.rs
+++ b/images/coblox_bitcoincore/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.5.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 #[macro_use]

--- a/images/dynamodb_local/Cargo.toml
+++ b/images/dynamodb_local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_dynamodb_local"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Jack Wright <ayax79@gmail.com>" ]
 description = "Testcontainers image for local dynamodb"
 license = "MIT OR Apache-2.0"

--- a/images/dynamodb_local/src/lib.rs
+++ b/images/dynamodb_local/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.2.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 #[macro_use]
 extern crate log;

--- a/images/elasticmq/Cargo.toml
+++ b/images/elasticmq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_elasticmq"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Jack Wright <ayax79@gmail.com>" ]
 description = "Testcontainers image for ElasticMQ"
 license = "MIT OR Apache-2.0"

--- a/images/elasticmq/src/lib.rs
+++ b/images/elasticmq/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.2.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 

--- a/images/generic/Cargo.toml
+++ b/images/generic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_generic"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Francesco Cina <ufoscout@gmail.com>" ]
 description = "Testcontainers generic image"
 license = "MIT OR Apache-2.0"

--- a/images/generic/src/lib.rs
+++ b/images/generic/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.2.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 

--- a/images/parity_parity/Cargo.toml
+++ b/images/parity_parity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_parity_parity"
-version = "0.5.0"
+version = "0.5.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the parity/parity docker image."
 license = "MIT OR Apache-2.0"

--- a/images/parity_parity/src/lib.rs
+++ b/images/parity_parity/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.5.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 

--- a/images/postgres/Cargo.toml
+++ b/images/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_postgres"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Thomas Eizinger <thomas@eizinger.io>" ]
 description = "Testcontainers image for the postgres docker image."
 license = "MIT OR Apache-2.0"

--- a/images/postgres/src/lib.rs
+++ b/images/postgres/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.2.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 

--- a/images/redis/Cargo.toml
+++ b/images/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_redis"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "Jack Wright <ayax79@gmail.com>" ]
 description = "Testcontainers image for Redis"
 license = "MIT OR Apache-2.0"

--- a/images/redis/src/lib.rs
+++ b/images/redis/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.2.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 

--- a/images/trufflesuite_ganachecli/Cargo.toml
+++ b/images/trufflesuite_ganachecli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_trufflesuite_ganachecli"
-version = "0.4.0"
+version = "0.4.1"
 authors = [ "CoBloX developers <team@coblox.tech>" ]
 description = "Testcontainers image for the trufflesuite/ganache-cli docker image."
 license = "MIT OR Apache-2.0"

--- a/images/trufflesuite_ganachecli/src/lib.rs
+++ b/images/trufflesuite_ganachecli/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(missing_debug_implementations)]
+#![deprecated(
+    since = "0.4.1",
+    note = "Testcontainers is no longer using microcrates, please upgrade to testcontainers version 0.8"
+)]
 
 extern crate tc_core;
 


### PR DESCRIPTION
After this is merged, we will need to release all those crates for the deprecation to take effect.

Part of #103.