### PR TITLE
Make `get_host_port` return a u16

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -214,9 +214,9 @@ impl Ports {
         ports
     }
 
-    fn parse_port(port: &str) -> u32 {
+    fn parse_port(port: &str) -> u16 {
         port.parse()
-            .unwrap_or_else(|e| panic!("Failed to parse {} as u32 because {}", port, e))
+            .unwrap_or_else(|e| panic!("Failed to parse {} as u16 because {}", port, e))
     }
 }
 

--- a/src/core/container.rs
+++ b/src/core/container.rs
@@ -69,7 +69,7 @@ where
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker image does not expose a port, this method will not
     /// be able to resolve it.
-    pub fn get_host_port(&self, internal_port: u32) -> Option<u32> {
+    pub fn get_host_port(&self, internal_port: u16) -> Option<u16> {
         let resolved_port = self
             .docker_client
             .ports(&self.id)

--- a/src/core/docker.rs
+++ b/src/core/docker.rs
@@ -16,12 +16,12 @@ where
 /// The exposed ports of a running container.
 #[derive(Debug, PartialEq, Default)]
 pub struct Ports {
-    mapping: HashMap<u32, u32>,
+    mapping: HashMap<u16, u16>,
 }
 
 impl Ports {
     /// Registers the mapping of an exposed port.
-    pub fn add_mapping(&mut self, internal: u32, host: u32) -> &mut Self {
+    pub fn add_mapping(&mut self, internal: u16, host: u16) -> &mut Self {
         log::debug!("Registering port mapping: {} -> {}", internal, host);
 
         self.mapping.insert(internal, host);
@@ -30,8 +30,8 @@ impl Ports {
     }
 
     /// Returns the host port for the given internal port.
-    pub fn map_to_host_port(&self, internal_port: u32) -> Option<u32> {
-        self.mapping.get(&internal_port).map(|p| p.clone())
+    pub fn map_to_host_port(&self, internal_port: u16) -> Option<u16> {
+        self.mapping.get(&internal_port).cloned()
     }
 }
 

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -112,7 +112,7 @@ fn dynamodb_local_create_table() {
     assert_that(&result).is_ok();
 }
 
-fn build_dynamodb_client(host_port: u32) -> DynamoDbClient {
+fn build_dynamodb_client(host_port: u16) -> DynamoDbClient {
     let credentials_provider =
         StaticProvider::new("fakeKey".to_string(), "fakeSecret".to_string(), None, None);
 
@@ -190,7 +190,7 @@ fn generic_image() {
     assert_eq!(rows.get(0).get::<_, i32>("result"), 2);
 }
 
-fn build_sqs_client(host_port: u32) -> SqsClient {
+fn build_sqs_client(host_port: u16) -> SqsClient {
     let dispatcher = HttpClient::new().expect("could not create http client");
     let credentials_provider =
         StaticProvider::new("fakeKey".to_string(), "fakeSecret".to_string(), None, None);


### PR DESCRIPTION
All possible ports fit within the u16 range, no need for u32.

Fixes #118.