### PR TITLE
Allow tests to be run inside a docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       cache: cargo
       services:
         - docker
+      before_install:
+        - docker build -t cargo-dockercli tests
       addons:
         apt:
           packages:
@@ -19,6 +21,7 @@ matrix:
         - cargo fmt -- --check
         - cargo build --all-targets
         - cargo test
+        - docker run -it -w /src/ -v $PWD:/src/ -v /var/run/docker.sock:/var/run/docker.sock cargo-dockercli:latest cargo test
 branches:
   only:
     - staging # This is where pull requests from "bors r+" are built.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: rust
 matrix:
   include:
-    - rust: 1.32.0 # test for the MSRV when included as a library
+    - rust: 1.36.0 # test for the MSRV when included as a library
       cache: cargo
       script: cargo build
-    - rust: 1.36.0 # our tests need this to compile certain dependencies
+    - rust: 1.39.0 # our tests need this to compile certain dependencies
       sudo: required
       cache: cargo
       services:

--- a/src/core/docker.rs
+++ b/src/core/docker.rs
@@ -11,6 +11,7 @@ where
     fn ports(&self, id: &str) -> Ports;
     fn rm(&self, id: &str);
     fn stop(&self, id: &str);
+    fn ip_address(&self, id: &str) -> String;
 }
 
 /// The exposed ports of a running container.

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.39.0
+
+RUN apt-get update && \
+    apt-get install \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      gnupg2 \
+      software-properties-common -y && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add  && \
+    add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/debian \
+      $(lsb_release -cs) \
+      stable" && \
+    apt-get update && \
+    apt-get install docker-ce-cli -y && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This adds the `ip_address` method to `Docker` trait in order to to query the ip address of the spawned container. This is derived from a `docker inspect` call.

This also introduces a new usage pattern when used from the host system: 
Rather than relying on a port mapping to the host, the presumably known target port can be directly queried by using the ip address of the container in the internal docker network.
Let me know whether this actually breaks any workflows I didn't think of.
Note: This relies on the fact, that the default docker bridge network is configured for all involved containers.

I looked into shiplift to create a new `Client` impl, but refrained from doing so, as the current API is completely sync, and it felt rather heavy pulling in shiplift w/ a runtime. However, I'm very much interested in a follow-up discussion, where this crate could offer an additional async API, or a way forward with the sync API.
Futhermore, with the approach presented in this PR, the orchestrating container needs to have the `docker` cli available. When adding more and more features, it might make sense eventually to use shiplift to interface with the docker daemon, and by this also get rid of this requirement..


Closes https://github.com/testcontainers/testcontainers-rs/pull/129
Related https://github.com/testcontainers/testcontainers-rs/pull/139

I also bumped the version in `.travis.yml` #140.