### PR TITLE
Allow custom options on docker run

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -82,9 +82,18 @@ impl Cli {
             command.arg("-v").arg(format!("{}:{}", orig, dest));
         }
 
+        if let Some(ports) = image.ports() {
+            for port in &ports {
+                command
+                    .arg("-p")
+                    .arg(format!("{}:{}", port.local, port.internal));
+            }
+        } else {
+            command.arg("-P"); // expose all ports
+        }
+
         command
             .arg("-d") // Always run detached
-            .arg("-P") // Always expose all ports
             .arg(image.descriptor())
             .args(image.args())
             .stdout(Stdio::piped())
@@ -226,6 +235,8 @@ impl Ports {
 
 #[cfg(test)]
 mod tests {
+    use crate::core::Port;
+    use crate::images::generic::GenericImage;
     use crate::{Container, Docker, Image};
 
     use super::*;
@@ -310,6 +321,10 @@ mod tests {
             self.env_vars.clone()
         }
 
+        fn ports(&self) -> Option<Vec<Port>> {
+            None
+        }
+
         fn with_args(self, _arguments: <Self as Image>::Args) -> Self {
             self
         }
@@ -332,9 +347,42 @@ mod tests {
 
         println!("Executing command: {:?}", command);
 
+        assert!(format!("{:?}", command).contains(r#"-d"#));
+        assert!(format!("{:?}", command).contains(r#"-P"#));
         assert!(format!("{:?}", command).contains(r#""-v" "one-from:one-dest"#));
         assert!(format!("{:?}", command).contains(r#""-v" "two-from:two-dest"#));
         assert!(format!("{:?}", command).contains(r#""-e" "one-key=one-value""#));
         assert!(format!("{:?}", command).contains(r#""-e" "two-key=two-value""#));
+    }
+
+    #[test]
+    fn cli_run_command_should_expose_all_ports_if_no_explicit_mapping_requested() {
+        let image = GenericImage::new("hello");
+
+        let mut docker = Command::new("docker");
+        let command = Cli::build_run_command(&image, &mut docker);
+
+        println!("Executing command: {:?}", command);
+
+        assert!(format!("{:?}", command).contains(r#"-d"#));
+        assert!(format!("{:?}", command).contains(r#"-P"#));
+        assert!(!format!("{:?}", command).contains(r#"-p"#));
+    }
+
+    #[test]
+    fn cli_run_command_should_expose_only_requested_ports() {
+        let image = GenericImage::new("hello")
+            .with_mapped_port((123, 456))
+            .with_mapped_port((555, 888));
+
+        let mut docker = Command::new("docker");
+        let command = Cli::build_run_command(&image, &mut docker);
+
+        println!("Executing command: {:?}", command);
+
+        assert!(format!("{:?}", command).contains(r#"-d"#));
+        assert!(!format!("{:?}", command).contains(r#"-P"#));
+        assert!(format!("{:?}", command).contains(r#""-p" "123:456""#));
+        assert!(format!("{:?}", command).contains(r#""-p" "555:888""#));
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,6 @@
 pub use self::container::Container;
 pub use self::docker::{Docker, Logs, Ports};
-pub use self::image::Image;
+pub use self::image::{Image, Port};
 pub use self::wait_for_message::{WaitError, WaitForMessage};
 
 mod container;

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -81,6 +81,27 @@ where
     /// Returns the volumes this instance was created with.
     fn volumes(&self) -> Self::Volumes;
 
+    /// Returs the ports mapping requested for the image.
+    /// If not explicit port mappings is defined, all image ports will be automatically
+    /// exposed and mapped on randon host ports.
+    fn ports(&self) -> Option<Vec<Port>>;
+
     /// Re-configures the current instance of this image with the given arguments.
     fn with_args(self, arguments: Self::Args) -> Self;
+}
+
+/// Represents a port mapping between a local port and the internal port of a container.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Port {
+    pub local: u16,
+    pub internal: u16,
+}
+
+impl Into<Port> for (u16, u16) {
+    fn into(self) -> Port {
+        Port {
+            local: self.0,
+            internal: self.1,
+        }
+    }
 }

--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::core::{Container, Docker, Image, WaitForMessage};
 use hex::encode;
 use hmac::{Hmac, Mac};
@@ -9,6 +10,7 @@ use std::{collections::HashMap, env::var, thread::sleep, time::Duration};
 pub struct BitcoinCore {
     tag: String,
     arguments: BitcoinCoreImageArgs,
+    ports: Option<Vec<Port>>,
 }
 
 impl BitcoinCore {
@@ -205,6 +207,10 @@ impl Image for BitcoinCore {
         HashMap::new()
     }
 
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
+    }
+
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {
         BitcoinCore { arguments, ..self }
     }
@@ -215,6 +221,7 @@ impl Default for BitcoinCore {
         BitcoinCore {
             tag: "0.17.0".into(),
             arguments: BitcoinCoreImageArgs::default(),
+            ports: None,
         }
     }
 }
@@ -225,6 +232,13 @@ impl BitcoinCore {
             tag: tag_str.to_string(),
             ..self
         }
+    }
+
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }
 

--- a/src/images/dynamodb_local.rs
+++ b/src/images/dynamodb_local.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::{Container, Docker, Image, WaitForMessage};
 use std::{collections::HashMap, env::var, thread::sleep, time::Duration};
 
@@ -22,6 +23,7 @@ impl IntoIterator for DynamoDbArgs {
 pub struct DynamoDb {
     tag: String,
     arguments: DynamoDbArgs,
+    ports: Option<Vec<Port>>,
 }
 
 impl Default for DynamoDb {
@@ -29,6 +31,7 @@ impl Default for DynamoDb {
         DynamoDb {
             tag: DEFAULT_TAG.to_string(),
             arguments: DynamoDbArgs {},
+            ports: None,
         }
     }
 }
@@ -76,6 +79,10 @@ impl Image for DynamoDb {
         HashMap::new()
     }
 
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
+    }
+
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {
         DynamoDb { arguments, ..self }
     }
@@ -87,5 +94,12 @@ impl DynamoDb {
             tag: tag_str.to_string(),
             ..self
         }
+    }
+
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }

--- a/src/images/elasticmq.rs
+++ b/src/images/elasticmq.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::{Container, Docker, Image, WaitForMessage};
 use std::collections::HashMap;
 
@@ -20,6 +21,7 @@ impl IntoIterator for ElasticMQArgs {
 pub struct ElasticMQ {
     tag: String,
     arguments: ElasticMQArgs,
+    ports: Option<Vec<Port>>,
 }
 
 impl Default for ElasticMQ {
@@ -27,6 +29,7 @@ impl Default for ElasticMQ {
         ElasticMQ {
             tag: DEFAULT_TAG.to_string(),
             arguments: ElasticMQArgs {},
+            ports: None,
         }
     }
 }
@@ -60,6 +63,10 @@ impl Image for ElasticMQ {
         HashMap::new()
     }
 
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
+    }
+
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {
         ElasticMQ { arguments, ..self }
     }
@@ -71,5 +78,12 @@ impl ElasticMQ {
             tag: tag_str.to_string(),
             ..self
         }
+    }
+
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }

--- a/src/images/parity_parity.rs
+++ b/src/images/parity_parity.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::{Container, Docker, Image, WaitForMessage};
 use std::collections::HashMap;
 
@@ -8,6 +9,7 @@ const DEFAULT_TAG: &'static str = "v2.5.0";
 pub struct ParityEthereum {
     arguments: ParityEthereumArgs,
     tag: String,
+    ports: Option<Vec<Port>>,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -33,6 +35,7 @@ impl Default for ParityEthereum {
         ParityEthereum {
             arguments: ParityEthereumArgs {},
             tag: DEFAULT_TAG.to_string(),
+            ports: None,
         }
     }
 }
@@ -66,6 +69,10 @@ impl Image for ParityEthereum {
         HashMap::new()
     }
 
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
+    }
+
     fn with_args(self, arguments: Self::Args) -> Self {
         Self { arguments, ..self }
     }
@@ -77,5 +84,12 @@ impl ParityEthereum {
             tag: tag_str.to_string(),
             ..self
         }
+    }
+
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }

--- a/src/images/postgres.rs
+++ b/src/images/postgres.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::{Container, Docker, Image, WaitForMessage};
 use std::collections::HashMap;
 
@@ -5,6 +6,7 @@ use std::collections::HashMap;
 pub struct Postgres {
     arguments: PostgresArgs,
     env_vars: HashMap<String, String>,
+    ports: Option<Vec<Port>>,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -29,12 +31,20 @@ impl Default for Postgres {
         Self {
             arguments: PostgresArgs::default(),
             env_vars,
+            ports: None,
         }
     }
 }
 impl Postgres {
     pub fn with_env_vars(self, env_vars: HashMap<String, String>) -> Self {
         Self { env_vars, ..self }
+    }
+
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }
 
@@ -65,6 +75,10 @@ impl Image for Postgres {
 
     fn env_vars(&self) -> Self::EnvVars {
         self.env_vars.clone()
+    }
+
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
     }
 
     fn with_args(self, arguments: Self::Args) -> Self {

--- a/src/images/redis.rs
+++ b/src/images/redis.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::{Container, Docker, Image, WaitForMessage};
 use std::collections::HashMap;
 
@@ -20,6 +21,7 @@ impl IntoIterator for RedisArgs {
 pub struct Redis {
     tag: String,
     arguments: RedisArgs,
+    ports: Option<Vec<Port>>,
 }
 
 impl Default for Redis {
@@ -27,6 +29,7 @@ impl Default for Redis {
         Redis {
             tag: DEFAULT_TAG.to_string(),
             arguments: RedisArgs {},
+            ports: None,
         }
     }
 }
@@ -60,6 +63,10 @@ impl Image for Redis {
         HashMap::new()
     }
 
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
+    }
+
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {
         Redis { arguments, ..self }
     }
@@ -71,5 +78,12 @@ impl Redis {
             tag: tag_str.to_string(),
             ..self
         }
+    }
+
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }

--- a/src/images/trufflesuite_ganachecli.rs
+++ b/src/images/trufflesuite_ganachecli.rs
@@ -1,3 +1,4 @@
+use crate::core::Port;
 use crate::{Container, Docker, Image, WaitForMessage};
 use std::collections::HashMap;
 
@@ -5,6 +6,7 @@ use std::collections::HashMap;
 pub struct GanacheCli {
     tag: String,
     arguments: GanacheCliArgs,
+    ports: Option<Vec<Port>>,
 }
 
 #[derive(Debug, Clone)]
@@ -19,6 +21,7 @@ impl Default for GanacheCli {
         GanacheCli {
             tag: "v6.1.3".into(),
             arguments: GanacheCliArgs::default(),
+            ports: None,
         }
     }
 }
@@ -83,7 +86,20 @@ impl Image for GanacheCli {
         HashMap::new()
     }
 
+    fn ports(&self) -> Option<Vec<Port>> {
+        self.ports.clone()
+    }
+
     fn with_args(self, arguments: <Self as Image>::Args) -> Self {
         GanacheCli { arguments, ..self }
+    }
+}
+
+impl GanacheCli {
+    pub fn with_mapped_port<P: Into<Port>>(mut self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+        self.ports = Some(ports);
+        self
     }
 }

--- a/tests/cli_client.rs
+++ b/tests/cli_client.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use spectral::prelude::*;
 
+use testcontainers::core::Port;
 use testcontainers::*;
 
 #[derive(Default)]
@@ -36,6 +37,10 @@ impl Image for HelloWorld {
 
     fn env_vars(&self) -> Self::EnvVars {
         HashMap::new()
+    }
+
+    fn ports(&self) -> Option<Vec<Port>> {
+        None
     }
 
     fn with_args(self, _arguments: <Self as Image>::Args) -> Self {

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -228,3 +228,35 @@ fn postgres_one_plus_one() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows.get(0).get::<_, i32>("result"), 2);
 }
+
+#[test]
+fn postgres_one_plus_one_with_custom_mapped_port() {
+    let _ = pretty_env_logger::try_init();
+    let free_local_port = free_local_port().unwrap();
+
+    let docker = clients::Cli::default();
+    let _node =
+        docker.run(images::postgres::Postgres::default().with_mapped_port((free_local_port, 5432)));
+
+    let conn = Connection::connect(
+        format!(
+            "postgres://postgres:postgres@localhost:{}/postgres",
+            free_local_port
+        ),
+        TlsMode::None,
+    )
+    .unwrap();
+    let rows = conn.query("SELECT 1+1 AS result;", &[]).unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows.get(0).get::<_, i32>("result"), 2);
+}
+
+/// Returns an available localhost port
+pub fn free_local_port() -> Option<u16> {
+    let socket = std::net::SocketAddrV4::new(std::net::Ipv4Addr::LOCALHOST, 0);
+    std::net::TcpListener::bind(socket)
+        .and_then(|listener| listener.local_addr())
+        .and_then(|addr| Ok(addr.port()))
+        .ok()
+}


### PR DESCRIPTION
This PR adds a `run_with_options` method that allows running a docker container with custom options instead of the currently hardcoded ones (i.e. "-d" "-P").
This permits, for example, to start a container on a predetermined port.

E.g.:
```rust
    let fixed_port = get_the_port_from_somewhere();

    let docker = clients::Cli::default();
    let _node = docker.run_with_options(
        vec!["-d", "-p", &format!("{}:5432", fixed_port)],
        images::postgres::Postgres::default(),
    );
```

