### PR TITLE
cargo: Upgrade reqwest 0.9 -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ rusoto_credential = "0.44"
 rusoto_dynamodb = "0.44"
 rusoto_sqs = "0.44"
 spectral = "0.6"
-reqwest = "0.9"
+reqwest = { version = "0.10", features = ["blocking"] }
 json = "0.12"
 tokio = { version = "0.2", features = ["macros"] }

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -42,7 +42,7 @@ fn parity_parity_net_version() {
     let node = docker.run(images::parity_parity::ParityEthereum::default());
     let host_port = node.get_host_port(8545).unwrap();
 
-    let mut response = reqwest::Client::new()
+    let response = reqwest::blocking::Client::new()
         .post(&format!("http://localhost:{}", host_port))
         .body(
             json::object! {
@@ -70,7 +70,7 @@ fn trufflesuite_ganachecli_listaccounts() {
     let node = docker.run(images::trufflesuite_ganachecli::GanacheCli::default());
     let host_port = node.get_host_port(8545).unwrap();
 
-    let mut response = reqwest::Client::new()
+    let response = reqwest::blocking::Client::new()
         .post(&format!("http://localhost:{}", host_port))
         .body(
             json::object! {


### PR DESCRIPTION
We used the blocking API so no async conversion is required for this.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>