### PR TITLE
Allow containers to be started once stopped

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -169,12 +169,25 @@ impl Docker for Cli {
     }
 
     fn stop(&self, id: &str) {
-        Command::new("docker")
+        let _ = Command::new("docker")
             .arg("stop")
             .arg(id)
             .stdout(Stdio::piped())
             .spawn()
-            .expect("Failed to execute docker command");
+            .expect("Failed to execute docker command")
+            .wait()
+            .expect("Failed to stop docker container");
+    }
+
+    fn start(&self, id: &str) {
+        Command::new("docker")
+            .arg("start")
+            .arg(id)
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Failed to execute docker command")
+            .wait()
+            .expect("Failed to start docker container");
     }
 }
 

--- a/src/core/container.rs
+++ b/src/core/container.rs
@@ -115,13 +115,17 @@ where
         log::debug!("Container {} is now ready!", self.id);
     }
 
-    fn stop(&self) {
+    pub fn stop(&self) {
         log::debug!("Stopping docker container {}", self.id);
 
         self.docker_client.stop(&self.id)
     }
 
-    fn rm(&self) {
+    pub fn start(&self) {
+        self.docker_client.start(&self.id);
+    }
+
+    pub fn rm(&self) {
         log::debug!("Deleting docker container {}", self.id);
 
         self.docker_client.rm(&self.id)

--- a/src/core/docker.rs
+++ b/src/core/docker.rs
@@ -11,6 +11,7 @@ where
     fn ports(&self, id: &str) -> Ports;
     fn rm(&self, id: &str);
     fn stop(&self, id: &str);
+    fn start(&self, id: &str);
 }
 
 /// The exposed ports of a running container.


### PR DESCRIPTION
To be able to test connection dropping. Also wait for commands to stop.

Resolves #164.