### PR TITLE
Misc improvements to postgres image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   MSRV bumped to 1.36 from 1.32.
+-   Change postgres image authentication POSTGRES_HOST_AUTH_METHOD rather than username and password
 
 ## [0.9.1] - 2020-03-24
 

--- a/src/images/postgres.rs
+++ b/src/images/postgres.rs
@@ -7,6 +7,7 @@ pub struct Postgres {
     arguments: PostgresArgs,
     env_vars: HashMap<String, String>,
     ports: Option<Vec<Port>>,
+    version: u8,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -25,13 +26,13 @@ impl Default for Postgres {
     fn default() -> Self {
         let mut env_vars = HashMap::new();
         env_vars.insert("POSTGRES_DB".to_owned(), "postgres".to_owned());
-        env_vars.insert("POSTGRES_USER".to_owned(), "postgres".to_owned());
-        env_vars.insert("POSTGRES_PASSWORD".to_owned(), "postgres".to_owned());
+        env_vars.insert("POSTGRES_HOST_AUTH_METHOD".into(), "trust".into());
 
         Self {
             arguments: PostgresArgs::default(),
             env_vars,
             ports: None,
+            version: 11,
         }
     }
 }
@@ -54,7 +55,7 @@ impl Image for Postgres {
     type Volumes = HashMap<String, String>;
 
     fn descriptor(&self) -> String {
-        "postgres:11-alpine".to_string()
+        format!("postgres:{}-alpine", self.version)
     }
 
     fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {


### PR DESCRIPTION
- Allow passing in version (note 12 is the stable verison now but kept it at 11 for backwards compat).
- Remove password in favour of just trusting any connection
- Remove strange empty struct so you can actually pass in arguments