### PR TITLE
Fix `Cli::rm` not blocking until rm is successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 matrix:
   include:
-    - rust: 1.36.0 # test for the MSRV when included as a library
+    - rust: 1.41.0 # test for the MSRV when included as a library
       cache: cargo
       script: cargo build
     - rust: 1.43.0 # our tests need this to compile certain dependencies

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -162,14 +162,15 @@ impl Docker for Cli {
     }
 
     fn rm(&self, id: &str) {
-        Command::new("docker")
+        let output = Command::new("docker")
             .arg("rm")
             .arg("-f")
             .arg("-v") // Also remove volumes
             .arg(id)
             .stdout(Stdio::piped())
-            .spawn()
+            .output()
             .expect("Failed to execute docker command");
+        assert!(output.status.success(), "Failed to remove docker container");
     }
 
     fn stop(&self, id: &str) {

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -167,10 +167,8 @@ impl Docker for Cli {
             .arg("-f")
             .arg("-v") // Also remove volumes
             .arg(id)
-            .stdout(Stdio::piped())
             .output()
             .expect("Failed to execute docker command");
-        log::error!("{:?}", output);
         assert!(output.status.success(), "Failed to remove docker container");
     }
 

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -170,6 +170,7 @@ impl Docker for Cli {
             .stdout(Stdio::piped())
             .output()
             .expect("Failed to execute docker command");
+        log::error!("{:?}", output);
         assert!(output.status.success(), "Failed to remove docker container");
     }
 
@@ -403,5 +404,13 @@ mod tests {
         assert!(!format!("{:?}", command).contains(r#"-P"#));
         assert!(format!("{:?}", command).contains(r#""-p" "123:456""#));
         assert!(format!("{:?}", command).contains(r#""-p" "555:888""#));
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to remove docker container")]
+    fn cli_rm_command_should_panic_on_invalid_container() {
+        let docker = Cli::default();
+        docker.rm("!INVALID_NAME_DUE_TO_SYMBOLS!");
+        unreachable!()
     }
 }


### PR DESCRIPTION
Fixes #199

Potentially fixes - #193, #106

Changed:
- `Cli::rm()` method now blocks until command finishes executing.

Added:
- Test case to ensure that `Cli::rm()` command actually fails instead of silently succeeding. 