### PR TITLE
Allow containers to be named and assigned to a network on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   `Docker#run_with_args` method. This allows naming a container and assigning it to a specific docker network. The docker
+-   `Docker::run_with_args` method. This allows naming a container and assigning it to a specific docker network. The docker
 network will be created if it doesn't exist yet. Once the client is dropped, the network will be removed again if it
 has previously been created. A network that already existed will not be removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   `Docker#run_with_args` method. This allows naming a container and assigning it to a specific docker network. The docker
+network will be created if it doesn't exist yet. Once the client is dropped, the network will be removed again if it
+has previously been created. A network that already existed will not be removed.
+
 ## [0.10.0] - 2020-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ has previously been created. A network that already existed will not be removed.
 ### Added
 
 -   Mongo image.
--   `run_with_options` method that allows running a docker container with custom options instead of the currently
-    hardcoded ones.
 -   Support for the `fallbackfee` argument for the `bitcoin-core` image.
 -   Ability to customize the `entrypoint` used by the image.
 -   Ability to start a container once stopped. 

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
 pub use self::container::Container;
-pub use self::docker::{Docker, Logs, Ports};
+pub use self::docker::{Docker, Logs, Ports, RunArgs};
 pub use self::image::{Image, Port};
 pub use self::wait_for_message::{WaitError, WaitForMessage};
 

--- a/src/core/docker.rs
+++ b/src/core/docker.rs
@@ -7,11 +7,45 @@ where
     Self: Sized,
 {
     fn run<I: Image>(&self, image: I) -> Container<'_, Self, I>;
+    fn run_with_args<I: Image>(&self, image: I, run_args: RunArgs) -> Container<'_, Self, I>;
     fn logs(&self, id: &str) -> Logs;
     fn ports(&self, id: &str) -> Ports;
     fn rm(&self, id: &str);
     fn stop(&self, id: &str);
     fn start(&self, id: &str);
+}
+
+/// Container run command arguments.
+/// `name` - run image instance with the given name (should be explicitly set to be seen by other containers created in the same docker network).
+/// `network` - run image instance on the given network.
+#[derive(Debug, Clone, Default)]
+pub struct RunArgs {
+    name: Option<String>,
+    network: Option<String>,
+}
+
+impl RunArgs {
+    pub fn with_name<T: ToString>(self, name: T) -> Self {
+        RunArgs {
+            name: Some(name.to_string()),
+            ..self
+        }
+    }
+
+    pub fn with_network<T: ToString>(self, network: T) -> Self {
+        RunArgs {
+            network: Some(network.to_string()),
+            ..self
+        }
+    }
+
+    pub(crate) fn network(&self) -> Option<String> {
+        self.network.clone()
+    }
+
+    pub(crate) fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
 }
 
 /// The exposed ports of a running container.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 pub use crate::core::Container;
 pub use crate::core::Docker;
 pub use crate::core::Image;
+pub use crate::core::RunArgs;
 pub use crate::core::WaitError;
 pub use crate::core::WaitForMessage;
 


### PR DESCRIPTION
Docker::run_args allows users to specify a docker network and a name
for the container. The network will be created on-demand and clean-up
in the end when the client is dropped.

Co-authored-by: Aleksandrov Vladimir <invis87@gmail.com>