### PR TITLE
Added address_type default to bech 32 to bitcoincore

### DIFF
--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -56,7 +56,6 @@ impl RpcAuth {
     fn generate_salt() -> String {
         let mut buffer = [0u8; 16];
         thread_rng().fill(&mut buffer[..]);
-
         encode(buffer)
     }
 
@@ -93,6 +92,7 @@ pub struct BitcoinCoreImageArgs {
     pub accept_non_std_txn: Option<bool>,
     pub rest: bool,
     pub fallback_fee: Option<f64>,
+    pub address_type: String,
 }
 
 impl Default for BitcoinCoreImageArgs {
@@ -108,6 +108,7 @@ impl Default for BitcoinCoreImageArgs {
             accept_non_std_txn: Some(false),
             rest: true,
             fallback_fee: Some(0.0002),
+            address_type: "bech32".to_string(),
         }
     }
 }
@@ -164,6 +165,10 @@ impl IntoIterator for BitcoinCoreImageArgs {
         }
 
         args.push("-debug".into()); // Needed for message "Flushed wallet.dat"
+
+        if !self.address_type.is_empty() {
+            args.push(format!("-addresstype={}", self.address_type))
+        }
 
         args.into_iter()
     }

--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -4,6 +4,7 @@ use hex::encode;
 use hmac::{Hmac, Mac, NewMac};
 use rand::{thread_rng, Rng};
 use sha2::Sha256;
+use std::fmt;
 use std::{collections::HashMap, env::var, thread::sleep, time::Duration};
 
 #[derive(Debug)]
@@ -24,6 +25,23 @@ pub enum Network {
     Mainnet,
     Testnet,
     Regtest,
+}
+
+#[derive(Debug, Clone)]
+pub enum AddressType {
+    Legacy,
+    P2shSegwit,
+    Bech32,
+}
+
+impl fmt::Display for AddressType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            AddressType::Legacy => "legacy",
+            AddressType::P2shSegwit => "p2sh-segwit",
+            AddressType::Bech32 => "bech32",
+        })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -92,7 +110,7 @@ pub struct BitcoinCoreImageArgs {
     pub accept_non_std_txn: Option<bool>,
     pub rest: bool,
     pub fallback_fee: Option<f64>,
-    pub address_type: String,
+    pub address_type: AddressType,
 }
 
 impl Default for BitcoinCoreImageArgs {
@@ -108,7 +126,7 @@ impl Default for BitcoinCoreImageArgs {
             accept_non_std_txn: Some(false),
             rest: true,
             fallback_fee: Some(0.0002),
-            address_type: "bech32".to_string(),
+            address_type: AddressType::Bech32,
         }
     }
 }
@@ -166,9 +184,7 @@ impl IntoIterator for BitcoinCoreImageArgs {
 
         args.push("-debug".into()); // Needed for message "Flushed wallet.dat"
 
-        if !self.address_type.is_empty() {
-            args.push(format!("-addresstype={}", self.address_type))
-        }
+        args.push(format!("-addresstype={}", self.address_type));
 
         args.into_iter()
     }


### PR DESCRIPTION
This is to address issue: https://github.com/testcontainers/testcontainers-rs/issues/161

Passed all existing test including coblox_bitcoincore_getnewaddress which caught my typo in types. Let me know if I need to add a test for difference address type.

Fixes #161.