### PR TITLE
Remove `derivative` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/testcontainers/testcontainers-rs"
 version = "0.11.0"
 
 [dependencies]
-derivative = "2"
 hex = "0.4"
 hmac = "0.9"
 log = "0.4"

--- a/src/core/docker.rs
+++ b/src/core/docker.rs
@@ -1,5 +1,5 @@
 use crate::{Container, Image};
-use std::{collections::HashMap, io::Read};
+use std::{collections::HashMap, fmt, io::Read};
 
 /// Defines the minimum API required for interacting with the Docker daemon.
 pub trait Docker
@@ -71,11 +71,13 @@ impl Ports {
 }
 
 /// Log streams of running container (stdout & stderr).
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct Logs {
-    #[derivative(Debug = "ignore")]
     pub stdout: Box<dyn Read>,
-    #[derivative(Debug = "ignore")]
     pub stderr: Box<dyn Read>,
+}
+
+impl fmt::Debug for Logs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Logs").finish()
+    }
 }


### PR DESCRIPTION
The functionality can easily be replicated without adding this dependency.

Fixes #231.