### PR TITLE
Allow using podman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow using `podman` CLI in addition to `docker`
+
 ### Changed
 
 - How images express when a container is ready: Instead of implementing `wait_until_ready`, images now need to implement `ready_conditions` which returns a list of `WaitFor` instances.

--- a/src/images.rs
+++ b/src/images.rs
@@ -2,6 +2,7 @@ pub mod coblox_bitcoincore;
 pub mod dynamodb_local;
 pub mod elasticmq;
 pub mod generic;
+pub mod hello_world;
 pub mod mongo;
 pub mod orientdb;
 pub mod parity_parity;

--- a/src/images/hello_world.rs
+++ b/src/images/hello_world.rs
@@ -1,0 +1,36 @@
+use crate::{core::WaitFor, Image};
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub struct HelloWorld;
+
+impl Image for HelloWorld {
+    type Args = Vec<String>;
+    type EnvVars = HashMap<String, String>;
+    type Volumes = HashMap<String, String>;
+    type EntryPoint = std::convert::Infallible;
+
+    fn descriptor(&self) -> String {
+        String::from("hello-world")
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Hello from Docker!")]
+    }
+
+    fn args(&self) -> <Self as Image>::Args {
+        vec![]
+    }
+
+    fn volumes(&self) -> Self::Volumes {
+        HashMap::new()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
+    }
+
+    fn with_args(self, _: <Self as Image>::Args) -> Self {
+        self
+    }
+}

--- a/tests/cli_client.rs
+++ b/tests/cli_client.rs
@@ -1,45 +1,6 @@
-use std::{
-    collections::HashMap,
-    time::{Duration, Instant},
-};
-
 use spectral::prelude::*;
-
-use testcontainers::{core::WaitFor, *};
-
-#[derive(Default)]
-struct HelloWorld;
-
-impl Image for HelloWorld {
-    type Args = Vec<String>;
-    type EnvVars = HashMap<String, String>;
-    type Volumes = HashMap<String, String>;
-    type EntryPoint = std::convert::Infallible;
-
-    fn descriptor(&self) -> String {
-        String::from("hello-world")
-    }
-
-    fn ready_conditions(&self) -> Vec<WaitFor> {
-        vec![WaitFor::message_on_stdout("Hello from Docker!")]
-    }
-
-    fn args(&self) -> <Self as Image>::Args {
-        vec![]
-    }
-
-    fn volumes(&self) -> Self::Volumes {
-        HashMap::new()
-    }
-
-    fn env_vars(&self) -> Self::EnvVars {
-        HashMap::new()
-    }
-
-    fn with_args(self, _arguments: <Self as Image>::Args) -> Self {
-        self
-    }
-}
+use std::time::{Duration, Instant};
+use testcontainers::{images::hello_world::HelloWorld, *};
 
 #[test]
 fn should_wait_for_at_least_one_second_before_fetching_logs() {

--- a/tests/podman.rs
+++ b/tests/podman.rs
@@ -1,0 +1,8 @@
+use testcontainers::{images::hello_world::HelloWorld, *};
+
+#[test]
+fn podman_can_run_hello_world() {
+    let podman = clients::Cli::podman();
+
+    let _container = podman.run(HelloWorld);
+}


### PR DESCRIPTION
This change allows using podman: https://podman.io/

`podman` is a drop in CLI replacement for `docker`, so the change should be minimal.

My main usecase for this is that `docker` fails to run Postgres images in GitHub actions. When the container starts, it shuts down the database and then execs into the main database process. This gets stuck when run in Docker, probably because GitHub actions already runs inside Docker.

Switching to podman, which is available by default on Ubuntu 20.04, and also available by default on GitHub actions workers, fixes the problem.