### PR TITLE
Replace `wait_until_ready` with declarative `ready_conditions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- How images express when a container is ready: Instead of implementing `wait_until_ready`, images now need to implement `ready_conditions` which returns a list of `WaitFor` instances.
+
+### Removed
+
+- `DYNAMODB_ADDITIONAL_SLEEP_PERIOD` variable from `dynamodb_local` image.
+  Previously, we had a fallback of 2 seconds if this variable was not defined.
+  We now wait for 2 seconds unconditionally after the specified message has been found.
+
 ## [0.12.0] - 2021-01-27
 
 ### Added

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -326,7 +326,7 @@ impl Ports {
 
 #[cfg(test)]
 mod tests {
-    use crate::{images::generic::GenericImage, Container, Docker, Image};
+    use crate::{core::WaitFor, images::generic::GenericImage, Docker, Image};
 
     use super::*;
 
@@ -397,7 +397,9 @@ mod tests {
             String::from("hello-world")
         }
 
-        fn wait_until_ready<D: Docker>(&self, _container: &Container<'_, D, Self>) {}
+        fn ready_conditions(&self) -> Vec<WaitFor> {
+            vec![]
+        }
 
         fn args(&self) -> <Self as Image>::Args {
             vec![]

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,7 @@
 pub use self::{
     container::Container,
     docker::{Docker, Logs, Ports, RunArgs},
-    image::{Image, Port},
+    image::{Image, Port, WaitFor},
     wait_for_message::{WaitError, WaitForMessage},
 };
 

--- a/src/images/elasticmq.rs
+++ b/src/images/elasticmq.rs
@@ -1,4 +1,4 @@
-use crate::{Container, Docker, Image, WaitForMessage};
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const CONTAINER_IDENTIFIER: &str = "softwaremill/elasticmq";
@@ -41,12 +41,8 @@ impl Image for ElasticMQ {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stdout
-            .wait_for_message("Started SQS rest server")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Started SQS rest server")]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/src/images/mongo.rs
+++ b/src/images/mongo.rs
@@ -1,6 +1,5 @@
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
-
-use crate::{Container, Docker, Image, WaitForMessage};
 
 const CONTAINER_IDENTIFIER: &str = "mongo";
 const DEFAULT_TAG: &str = "4.0.17";
@@ -42,12 +41,10 @@ impl Image for Mongo {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stdout
-            .wait_for_message("waiting for connections on port")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout(
+            "waiting for connections on port",
+        )]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/src/images/orientdb.rs
+++ b/src/images/orientdb.rs
@@ -1,6 +1,5 @@
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
-
-use crate::{Container, Docker, Image, WaitForMessage};
 
 const CONTAINER_IDENTIFIER: &str = "orientdb";
 const DEFAULT_TAG: &str = "3.1.3";
@@ -47,12 +46,8 @@ impl Image for OrientDB {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stderr
-            .wait_for_message("OrientDB Studio available at")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr("OrientDB Studio available at")]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/src/images/parity_parity.rs
+++ b/src/images/parity_parity.rs
@@ -1,4 +1,4 @@
-use crate::{Container, Docker, Image, WaitForMessage};
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const CONTAINER_IDENTIFIER: &str = "parity/parity";
@@ -47,12 +47,8 @@ impl Image for ParityEthereum {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stderr
-            .wait_for_message("Public node URL:")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr("Public node URL:")]
     }
 
     fn args(&self) -> Self::Args {

--- a/src/images/postgres.rs
+++ b/src/images/postgres.rs
@@ -1,4 +1,4 @@
-use crate::{Container, Docker, Image, WaitForMessage};
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -53,12 +53,10 @@ impl Image for Postgres {
         format!("postgres:{}-alpine", self.version)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stderr
-            .wait_for_message("database system is ready to accept connections")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        )]
     }
 
     fn args(&self) -> Self::Args {

--- a/src/images/redis.rs
+++ b/src/images/redis.rs
@@ -1,4 +1,4 @@
-use crate::{Container, Docker, Image, WaitForMessage};
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const CONTAINER_IDENTIFIER: &str = "redis";
@@ -41,12 +41,8 @@ impl Image for Redis {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stdout
-            .wait_for_message("Ready to accept connections")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Ready to accept connections")]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/src/images/trufflesuite_ganachecli.rs
+++ b/src/images/trufflesuite_ganachecli.rs
@@ -1,4 +1,4 @@
-use crate::{Container, Docker, Image, WaitForMessage};
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -64,12 +64,8 @@ impl Image for GanacheCli {
         format!("trufflesuite/ganache-cli:{}", self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stdout
-            .wait_for_message("Listening on localhost:")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Listening on localhost:")]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/src/images/zookeeper.rs
+++ b/src/images/zookeeper.rs
@@ -1,4 +1,4 @@
-use crate::{Container, Docker, Image, WaitForMessage};
+use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const CONTAINER_IDENTIFIER: &str = "zookeeper";
@@ -38,12 +38,8 @@ impl Image for Zookeeper {
         format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<'_, D, Self>) {
-        container
-            .logs()
-            .stdout
-            .wait_for_message("Started AdminServer")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Started AdminServer")]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/tests/cli_client.rs
+++ b/tests/cli_client.rs
@@ -5,7 +5,7 @@ use std::{
 
 use spectral::prelude::*;
 
-use testcontainers::*;
+use testcontainers::{core::WaitFor, *};
 
 #[derive(Default)]
 struct HelloWorld;
@@ -20,12 +20,8 @@ impl Image for HelloWorld {
         String::from("hello-world")
     }
 
-    fn wait_until_ready<D: Docker>(&self, container: &Container<D, Self>) {
-        container
-            .logs()
-            .stdout
-            .wait_for_message("Hello from Docker!")
-            .unwrap();
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Hello from Docker!")]
     }
 
     fn args(&self) -> <Self as Image>::Args {

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -12,7 +12,7 @@ use spectral::prelude::*;
 use std::time::Duration;
 use zookeeper::{Acl, CreateMode, ZooKeeper};
 
-use testcontainers::*;
+use testcontainers::{core::WaitFor, *};
 
 #[test]
 fn coblox_bitcoincore_getnewaddress() {
@@ -202,7 +202,7 @@ fn generic_image() {
     let password = "postgres-password-test";
 
     let generic_postgres = images::generic::GenericImage::new("postgres:9.6-alpine")
-        .with_wait_for(images::generic::WaitFor::message_on_stderr(
+        .with_wait_for(WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))
         .with_env_var("POSTGRES_DB", db)
@@ -231,7 +231,7 @@ fn generic_image() {
 #[test]
 fn generic_image_with_custom_entrypoint() {
     let docker = clients::Cli::default();
-    let msg = images::generic::WaitFor::message_on_stdout("server is ready");
+    let msg = WaitFor::message_on_stdout("server is ready");
 
     let generic = images::generic::GenericImage::new("tumdum/simple_web_server:latest")
         .with_wait_for(msg.clone());


### PR DESCRIPTION
Making this feature declarative has several advantages:

- It reduces the amount of code one needs to write for a new image.
- It avoids the need for an `ImageAsync` trait once we introduce that,
see discussions in #216 for details. cc @ywalterh
- It allows for a re-usable abstraction of waiting for a specific
amount of time, which fixes #39.