### PR TITLE
Upgrade default bitcoin image version to 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The default value is `remove` which deletes all containers and networks that were used in the test.
   By setting the value to `keep`, containers and networks will not be deleted but kept **running**.
   You will have to **stop** and **delete** those yourself eventually.
+- Upgrade default bitcoin-core image version to 0.21.0. This allows us to remove `-debug` for bitcoind and replace it with
+  `-startupnotify=echo ...`. More details on bitcoind 0.21.0 can be found [here](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.21.0.md).
+  Note: This release also removed the default wallet.
 
 ### Changed
 

--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -5,6 +5,8 @@ use rand::{thread_rng, Rng};
 use sha2::Sha256;
 use std::{collections::HashMap, fmt};
 
+const BITCOIND_STARTUP_MESSAGE: &str = "bitcoind startup sequence completed.";
+
 #[derive(Debug)]
 pub struct BitcoinCore {
     tag: String,
@@ -135,7 +137,8 @@ impl IntoIterator for BitcoinCoreImageArgs {
     fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
         let mut args = vec![
             format!("-rpcauth={}", self.rpc_auth.encode()),
-            "-debug".into(), // Needed for message "Flushed wallet.dat"
+            // Will print a message when bitcoind is fully started
+            format!("-startupnotify='echo \'{}\''", BITCOIND_STARTUP_MESSAGE),
             format!("-addresstype={}", self.address_type),
         ];
 
@@ -197,7 +200,7 @@ impl Image for BitcoinCore {
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
         vec![
-            WaitFor::message_on_stdout("Flushed wallet.dat"),
+            WaitFor::message_on_stdout(BITCOIND_STARTUP_MESSAGE),
             WaitFor::millis_in_env_var("BITCOIND_ADDITIONAL_SLEEP_PERIOD"),
         ]
     }
@@ -222,7 +225,7 @@ impl Image for BitcoinCore {
 impl Default for BitcoinCore {
     fn default() -> Self {
         BitcoinCore {
-            tag: "0.20.0".into(),
+            tag: "0.21.0".into(),
             arguments: BitcoinCoreImageArgs::default(),
         }
     }

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -34,6 +34,8 @@ fn coblox_bitcoincore_getnewaddress() {
         .unwrap()
     };
 
+    assert_that(&client.create_wallet("miner", None, None, None, None)).is_ok();
+
     assert_that(&client.get_new_address(None, None)).is_ok();
 }
 


### PR DESCRIPTION
With the upgrade to 0.21.0 a new startup command was introduced which allows us to execute a script when the startup sequence was completed. We simply echo `bitcoind startup sequence completed.`.
This allows us to remove `-debug` which keeps the bitcoind log _clean_.
Note: this release also removed the default wallet.
