### PR TITLE
Removed openssl dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.8"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sha2 = "0.9"
-shiplift = "0.7"
+shiplift = { version = "0.7", default-features = false, features = [ "chrono", "unix-socket" ] }
 tokio = { version = "1", features = [ "macros" ] }
 
 [dev-dependencies]


### PR DESCRIPTION
Looks like a dependency on openssl creeped in with the addition of shiplift. This assumed #105 still holds and that openssl is not required. It still built without the feature enabled.