### PR TITLE
Add Kafka image confluentinc/cp-kafka

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ mongodb = "2.0.0-alpha"
 orientdb-client = "0.5"
 postgres = "0.19"
 pretty_env_logger = "0.4"
+rdkafka = "0.26"
 redis = "0.20"
 reqwest = { version = "0.11", features = [ "blocking" ] }
 rusoto_core = "0.46"

--- a/src/images.rs
+++ b/src/images.rs
@@ -3,6 +3,7 @@ pub mod dynamodb_local;
 pub mod elasticmq;
 pub mod generic;
 pub mod hello_world;
+pub mod kafka;
 pub mod mongo;
 pub mod orientdb;
 pub mod parity_parity;

--- a/src/images/kafka.rs
+++ b/src/images/kafka.rs
@@ -1,0 +1,123 @@
+use crate::{core::WaitFor, Image};
+use std::collections::HashMap;
+
+const CONTAINER_IDENTIFIER: &str = "confluentinc/cp-kafka";
+const DEFAULT_TAG: &str = "6.1.1";
+
+pub const KAFKA_PORT: u16 = 9093;
+const ZOOKEEPER_PORT: u16 = 2181;
+
+#[derive(Clone, Debug, Default)]
+pub struct KafkaArgs;
+
+impl IntoIterator for KafkaArgs {
+    type Item = String;
+    type IntoIter = ::std::vec::IntoIter<String>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        vec![
+            "/bin/bash".to_owned(),
+            "-c".to_owned(),
+            format!(
+                r#"
+echo 'clientPort={}' > zookeeper.properties;
+echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties;
+echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties;
+zookeeper-server-start zookeeper.properties &
+. /etc/confluent/docker/bash-config &&
+/etc/confluent/docker/configure &&
+/etc/confluent/docker/launch"#,
+                ZOOKEEPER_PORT
+            ),
+        ]
+        .into_iter()
+    }
+}
+
+#[derive(Debug)]
+pub struct Kafka {
+    arguments: KafkaArgs,
+    env_vars: HashMap<String, String>,
+    tag: String,
+}
+
+impl Kafka {
+    pub fn with_tag<T: Into<String>>(self, tag: T) -> Self {
+        Self {
+            tag: tag.into(),
+            ..self
+        }
+    }
+}
+
+impl Default for Kafka {
+    fn default() -> Self {
+        let mut env_vars = HashMap::new();
+
+        env_vars.insert(
+            "KAFKA_ZOOKEEPER_CONNECT".to_owned(),
+            format!("localhost:{}", ZOOKEEPER_PORT),
+        );
+        env_vars.insert(
+            "KAFKA_LISTENERS".to_owned(),
+            format!("PLAINTEXT://0.0.0.0:{},BROKER://0.0.0.0:9092", KAFKA_PORT),
+        );
+        env_vars.insert(
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP".to_owned(),
+            "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT".to_owned(),
+        );
+        env_vars.insert(
+            "KAFKA_INTER_BROKER_LISTENER_NAME".to_owned(),
+            "BROKER".to_owned(),
+        );
+        env_vars.insert(
+            "KAFKA_ADVERTISED_LISTENERS".to_owned(),
+            format!(
+                "PLAINTEXT://localhost:{},BROKER://localhost:9092",
+                KAFKA_PORT
+            ),
+        );
+        env_vars.insert("KAFKA_BROKER_ID".to_owned(), "1".to_owned());
+        env_vars.insert(
+            "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR".to_owned(),
+            "1".to_owned(),
+        );
+
+        Self {
+            arguments: KafkaArgs::default(),
+            env_vars,
+            tag: DEFAULT_TAG.to_owned(),
+        }
+    }
+}
+
+impl Image for Kafka {
+    type Args = KafkaArgs;
+    type EnvVars = HashMap<String, String>;
+    type Volumes = HashMap<String, String>;
+    type EntryPoint = std::convert::Infallible;
+
+    fn descriptor(&self) -> String {
+        format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("Creating new log file")]
+    }
+
+    fn args(&self) -> <Self as Image>::Args {
+        self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        self.env_vars.clone()
+    }
+
+    fn volumes(&self) -> Self::Volumes {
+        HashMap::new()
+    }
+
+    fn with_args(self, arguments: <Self as Image>::Args) -> Self {
+        Self { arguments, ..self }
+    }
+}

--- a/tests/kafka.rs
+++ b/tests/kafka.rs
@@ -1,0 +1,75 @@
+use futures::StreamExt;
+use rdkafka::{
+    config::ClientConfig,
+    consumer::{stream_consumer::StreamConsumer, Consumer},
+    producer::{FutureProducer, FutureRecord},
+    Message,
+};
+use std::time::Duration;
+
+use testcontainers::{clients, core::RunArgs, images::kafka};
+
+#[tokio::test]
+async fn test_produce_and_consume_messages() {
+    let docker = clients::Cli::default();
+    let kafka_node = docker.run_with_args(
+        kafka::Kafka::default(),
+        RunArgs::default().with_mapped_port((kafka::KAFKA_PORT, kafka::KAFKA_PORT)),
+    );
+
+    let bootstrap_servers = format!("localhost:{}", kafka_node.get_host_port(kafka::KAFKA_PORT));
+
+    let producer = ClientConfig::new()
+        .set("bootstrap.servers", &bootstrap_servers)
+        .set("message.timeout.ms", "5000")
+        .create::<FutureProducer>()
+        .expect("Failed to create Kafka FutureProducer");
+
+    let consumer = ClientConfig::new()
+        .set("group.id", "testcontainer-rs")
+        .set("bootstrap.servers", &bootstrap_servers)
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .create::<StreamConsumer>()
+        .expect("Failed to create Kafka StreamConsumer");
+
+    let topic = "test-topic";
+    consumer
+        .subscribe(&[&topic])
+        .expect("Failed to subscribe to a topic");
+
+    let number_of_messages_to_produce = 5_usize;
+    let expected: Vec<String> = (0..number_of_messages_to_produce)
+        .map(|i| format!("Message {}", i))
+        .collect();
+
+    for (i, message) in expected.iter().enumerate() {
+        producer
+            .send(
+                FutureRecord::to(&topic)
+                    .payload(message)
+                    .key(&format!("Key {}", i)),
+                Duration::from_secs(0),
+            )
+            .await
+            .unwrap();
+    }
+
+    let mut message_stream = consumer.stream();
+    for produced in expected {
+        let borrowed_message = tokio::time::timeout(Duration::from_secs(10), message_stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            produced,
+            borrowed_message
+                .unwrap()
+                .payload_view::<str>()
+                .unwrap()
+                .unwrap()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a Kafka image [confluentinc/cp-kafka](https://hub.docker.com/r/confluentinc/cp-kafka/) to the crate. I was aware that there was an existing #229 and wanted to help cross the finish line, but decided to start from scratch for the following reasons:
- Other client libraries for `testcontainers`, e.g. Java, Python, and NodeJS, use `confluentinc/cp-kafka` whereas #229 uses `bitnami/kafka`. For consistency with other client libraries, this PR has chosen `confluentinc/cp-kafka`.
- #229 shells out to bash execute `kafka-console-consumer` and `kafka-console-consumer` during testing. The test in this PR uses the `rdkafka` crate to interact with a Kafka broker, illustrating how that can be done without bash.
- #229 has been inactive for the last couple of months and I needed the Kafka image urgently.

That said, I have no intention of devaluing or competing with #229, so please feel free to take whichever PR that makes sense to the crate.

Finally, for adding tests, I have noticed that `tests/images.rs` is gradually becoming a monolith of tests for various images. Maybe that's actually intended, but I had hard time figuring out where to place a test for the Kafka image. Furthermore, the test for the Kafka image is longer and I did not feel comfortable squeezing it in `tests/images.rs`. I thought it may be easier for someone looking for tests as a form of documentation to locate them if tests are organized by images. To this end, I have created a separate test file `tests/images/kafka.rs` just to contain the test for the Kafka image and `tests/tests.rs` to tell Cargo where to find the test. If this is not something the crate wants in the long term, I'm happy to move the test for the Kafka image to `tests/images.rs` and remove `tests/images/kafka.rs` and `tests/tests.rs`.