### PR TITLE
Fix mongodb test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1", features = [ "macros" ] }
 [dev-dependencies]
 bitcoincore-rpc = "0.13"
 json = "0.12"
-mongodb = "2.0.0-alpha"
+mongodb = "2.0.0-beta"
 orientdb-client = "0.5"
 postgres = "0.19"
 pretty_env_logger = "0.4"

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -162,7 +162,7 @@ async fn mongo_fetch_document() {
     let host_port = node.get_host_port(27017);
     let url = format!("mongodb://localhost:{}/", host_port);
 
-    let client: Client = Client::with_uri_str(url.as_ref()).await.unwrap();
+    let client: Client = Client::with_uri_str(&url).await.unwrap();
     let db = client.database("some_db");
     let coll = db.collection("some-coll");
 


### PR DESCRIPTION
fix "cannot infer type" error of mongodb test

update mongodb version. Somehow, CI is actually testing with
mongodb@2.0.0-beta instead of specified 2.0.0-alpha