### PR TITLE
Support expose ports and add Google Cloud SDK image

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -160,7 +160,10 @@ impl Client {
                     .arg(format!("{}:{}", port.local, port.internal));
             }
         } else {
-            command.arg("-P"); // expose all ports
+            for port in image.expose_ports() {
+                command.arg(format!("--expose={}", port));
+            }
+            command.arg("-P"); // publish all exposed ports
         }
 
         command

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -96,6 +96,14 @@ where
     fn entrypoint(&self) -> Option<String> {
         None
     }
+
+    /// Returns the ports that needs to be exposed when a container is created.
+    ///
+    /// This method is useful when there is a need to expose some ports, but there is
+    /// no EXPOSE instruction in the Dockerfile of an image.
+    fn expose_ports(&self) -> Vec<u16> {
+        Default::default()
+    }
 }
 
 /// Represents a port mapping between a local port and the internal port of a container.

--- a/src/images.rs
+++ b/src/images.rs
@@ -2,6 +2,7 @@ pub mod coblox_bitcoincore;
 pub mod dynamodb_local;
 pub mod elasticmq;
 pub mod generic;
+pub mod google_cloud_sdk;
 pub mod hello_world;
 pub mod kafka;
 pub mod mongo;

--- a/src/images/google_cloud_sdk.rs
+++ b/src/images/google_cloud_sdk.rs
@@ -1,0 +1,182 @@
+use crate::{core::WaitFor, Image};
+use std::collections::HashMap;
+
+const CONTAINER_IDENTIFIER: &str = "google/cloud-sdk";
+const DEFAULT_TAG: &str = "353.0.0";
+
+const HOST: &str = "0.0.0.0";
+const DEFAULT_PORT: u16 = 80;
+pub const BIGTABLE_PORT: u16 = 8086;
+pub const DATASTORE_PORT: u16 = 8081;
+pub const FIRESTORE_PORT: u16 = 8080;
+pub const PUBSUB_PORT: u16 = 8085;
+
+const DEFAULT_DATASTORE_PROJECT: &str = "test";
+
+#[derive(Debug, Clone, Default)]
+pub struct CloudSdkArgs {
+    pub host: String,
+    pub port: u16,
+    pub project: String,
+    pub emulator: Emulator,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Emulator {
+    Bigtable,
+    Datastore,
+    Firestore,
+    PubSub,
+    Help,
+}
+
+impl Default for Emulator {
+    fn default() -> Self {
+        Emulator::Help
+    }
+}
+
+impl IntoIterator for CloudSdkArgs {
+    type Item = String;
+    type IntoIter = ::std::vec::IntoIter<String>;
+
+    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
+        let mut args: Vec<String> = ["gcloud", "beta", "emulators"]
+            .iter()
+            .map(|&s| s.to_owned())
+            .collect();
+        args.push(
+            match self.emulator {
+                Emulator::Bigtable => "bigtable",
+                Emulator::Datastore => "datastore",
+                Emulator::Firestore => "firestore",
+                Emulator::PubSub => "pubsub",
+                Emulator::Help => "--help",
+            }
+            .to_owned(),
+        );
+        args.push("start".to_owned());
+        if self.emulator != Emulator::Help {
+            if self.emulator == Emulator::Datastore {
+                args.push("--project".to_owned());
+                args.push(self.project);
+            }
+            args.push("--host-port".to_owned());
+            args.push(format!("{}:{}", self.host, self.port));
+        }
+        args.into_iter()
+    }
+}
+
+#[derive(Debug)]
+pub struct CloudSdk {
+    tag: String,
+    arguments: CloudSdkArgs,
+    exposed_port: u16,
+    ready_condition: WaitFor,
+}
+
+impl Default for CloudSdk {
+    fn default() -> Self {
+        CloudSdk {
+            tag: DEFAULT_TAG.to_owned(),
+            arguments: CloudSdkArgs::default(),
+            exposed_port: DEFAULT_PORT,
+            ready_condition: WaitFor::Nothing,
+        }
+    }
+}
+
+impl Image for CloudSdk {
+    type Args = CloudSdkArgs;
+    type EnvVars = HashMap<String, String>;
+    type Volumes = HashMap<String, String>;
+    type EntryPoint = std::convert::Infallible;
+
+    fn descriptor(&self) -> String {
+        format!("{}:{}", CONTAINER_IDENTIFIER, &self.tag)
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![self.ready_condition.clone()]
+    }
+
+    fn args(&self) -> <Self as Image>::Args {
+        self.arguments.clone()
+    }
+
+    fn env_vars(&self) -> Self::EnvVars {
+        HashMap::new()
+    }
+
+    fn volumes(&self) -> Self::Volumes {
+        HashMap::new()
+    }
+
+    fn with_args(self, arguments: <Self as Image>::Args) -> Self {
+        CloudSdk { arguments, ..self }
+    }
+
+    fn expose_ports(&self) -> Vec<u16> {
+        vec![self.exposed_port]
+    }
+}
+
+impl CloudSdk {
+    pub fn new(emulator: Emulator) -> Self {
+        let tag = DEFAULT_TAG.to_owned();
+        let (exposed_port, ready_condition) = match &emulator {
+            Emulator::Bigtable => (
+                BIGTABLE_PORT,
+                WaitFor::message_on_stderr("[bigtable] Cloud Bigtable emulator running on"),
+            ),
+            Emulator::Datastore => (
+                DATASTORE_PORT,
+                WaitFor::message_on_stderr("[datastore] Dev App Server is now running"),
+            ),
+            Emulator::Firestore => (
+                FIRESTORE_PORT,
+                WaitFor::message_on_stderr("[firestore] Dev App Server is now running"),
+            ),
+            Emulator::PubSub => (
+                PUBSUB_PORT,
+                WaitFor::message_on_stderr("[pubsub] INFO: Server started, listening on"),
+            ),
+            _ => (DEFAULT_PORT, WaitFor::Nothing),
+        };
+        let arguments = CloudSdkArgs {
+            host: HOST.to_owned(),
+            port: exposed_port,
+            project: if emulator == Emulator::Datastore {
+                DEFAULT_DATASTORE_PROJECT.to_owned()
+            } else {
+                String::default()
+            },
+            emulator,
+        };
+        Self {
+            tag,
+            arguments,
+            exposed_port,
+            ready_condition,
+        }
+    }
+
+    pub fn with_exposed_port(self, port: u16) -> Self {
+        Self {
+            exposed_port: port,
+            arguments: CloudSdkArgs {
+                port,
+                ..self.arguments
+            },
+            ..self
+        }
+    }
+
+    pub fn with_tag(self, tag_str: &str) -> Self {
+        CloudSdk {
+            tag: tag_str.to_string(),
+            ..self
+        }
+    }
+}

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -9,10 +9,12 @@ use rusoto_dynamodb::{
 };
 use rusoto_sqs::{ListQueuesRequest, Sqs, SqsClient};
 use spectral::prelude::*;
-use std::time::Duration;
+use std::{ops::Range, time::Duration};
 use zookeeper::{Acl, CreateMode, ZooKeeper};
 
 use testcontainers::{core::WaitFor, *};
+
+const RANDOM_PORTS: Range<u16> = 32768..61000;
 
 #[test]
 fn coblox_bitcoincore_getnewaddress() {
@@ -37,6 +39,46 @@ fn coblox_bitcoincore_getnewaddress() {
     assert_that(&client.create_wallet("miner", None, None, None, None)).is_ok();
 
     assert_that(&client.get_new_address(None, None)).is_ok();
+}
+
+#[test]
+fn bigtable_emulator_expose_port() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::google_cloud_sdk::CloudSdk::new(
+        images::google_cloud_sdk::Emulator::Bigtable,
+    ));
+    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::BIGTABLE_PORT)));
+}
+
+#[test]
+fn datastore_emulator_expose_port() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::google_cloud_sdk::CloudSdk::new(
+        images::google_cloud_sdk::Emulator::Datastore,
+    ));
+    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::DATASTORE_PORT)));
+}
+
+#[test]
+fn firestore_emulator_expose_port() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::google_cloud_sdk::CloudSdk::new(
+        images::google_cloud_sdk::Emulator::Firestore,
+    ));
+    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::FIRESTORE_PORT)));
+}
+
+#[test]
+fn pubsub_emulator_expose_port() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::google_cloud_sdk::CloudSdk::new(
+        images::google_cloud_sdk::Emulator::PubSub,
+    ));
+    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::PUBSUB_PORT)));
 }
 
 #[test]


### PR DESCRIPTION
Hey @thomaseizinger 

Certain images (eg. [google/cloud-sdk](https://hub.docker.com/layers/google/cloud-sdk/353.0.0/images/sha256-fe242b7bb1334f7ce5fa56872347dd9819f3717040e65dec9478a566b2033f0e?context=explore)) don't have an `EXPOSE` layer. I think we can make use of `--expose` option in `docker run` command for those cases. I have added a method `expose_port` in `Image` trait. It has a default implementation. So, we can implement it only for the images where it is really required. 

At the moment, I only need bigtable emulator for my usecase. But when I looked at `testcontainers-java`, I thought I can add the rest too.

What do you think of this approach? 

I only focussed on `Docker` and `Cli`. Based on our discussion, I will iterate (`expose_port` to `expose_ports`, tests, changes in other files, etc.) this PR.  