### PR TITLE
enable gh actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 20
   rebase-strategy: disabled
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 3
   rebase-strategy: disabled
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
- Keep Github actions up-to-date via dependabot
- Allow more PRs to be opened
