### PR TITLE
Fix clippy warnings and simplify structs in images

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{env, env::GetEnvValue, logs::LogStream, ports::Ports, Docker},
-    Container, Image, RunnableImage,
+    Container, Image, ImageArgs, RunnableImage,
 };
 use shiplift::rep::ContainerDetails;
 use std::{
@@ -162,7 +162,7 @@ impl Client {
         command
             .arg("-d") // Always run detached
             .arg(image.descriptor())
-            .args(image.args().clone().into_iter())
+            .args(image.args().clone().into_iterator())
             .stdout(Stdio::piped());
 
         command
@@ -393,7 +393,7 @@ mod tests {
     }
 
     impl Image for HelloWorld {
-        type Args = Vec<String>;
+        type Args = ();
 
         fn name(&self) -> String {
             "hello-world".to_owned()

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,7 +4,7 @@ pub(crate) use container_async::DockerAsync;
 
 pub use self::{
     container::Container,
-    image::{Image, Port, RunnableImage, WaitFor},
+    image::{Image, ImageArgs, Port, RunnableImage, WaitFor},
 };
 
 #[cfg(feature = "experimental")]

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeMap, env::var, fmt::Debug, time::Duration};
 pub trait Image
 where
     Self: Sized,
-    Self::Args: IntoIterator<Item = String> + Clone + Debug,
+    Self::Args: ImageArgs + Clone + Debug,
 {
     /// A type representing the arguments for an Image.
     ///
@@ -80,6 +80,16 @@ where
     /// no EXPOSE instruction in the Dockerfile of an image.
     fn expose_ports(&self) -> Vec<u16> {
         Default::default()
+    }
+}
+
+pub trait ImageArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>>;
+}
+
+impl ImageArgs for () {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(vec![].into_iter())
     }
 }
 

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -169,16 +169,14 @@ impl<I: Image> RunnableImage<I> {
         }
     }
 
-    pub fn with_env_var(self, env_var: (impl Into<String>, impl Into<String>)) -> Self {
+    pub fn with_env_var(self, (key, value): (impl Into<String>, impl Into<String>)) -> Self {
         let mut env_vars = self.env_vars;
-        let (key, value) = env_var;
         env_vars.insert(key.into(), value.into());
         Self { env_vars, ..self }
     }
 
-    pub fn with_volume(self, volume: (impl Into<String>, impl Into<String>)) -> Self {
+    pub fn with_volume(self, (orig, dest): (impl Into<String>, impl Into<String>)) -> Self {
         let mut volumes = self.volumes;
-        let (orig, dest) = volume;
         volumes.insert(orig.into(), dest.into());
         Self { volumes, ..self }
     }

--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -11,7 +11,6 @@ const BITCOIND_STARTUP_MESSAGE: &str = "bitcoind startup sequence completed.";
 #[derive(Debug)]
 pub struct BitcoinCore {
     tag: String,
-    arguments: BitcoinCoreImageArgs,
 }
 
 #[derive(Debug, Clone)]
@@ -206,7 +205,6 @@ impl Default for BitcoinCore {
     fn default() -> Self {
         BitcoinCore {
             tag: "0.21.0".into(),
-            arguments: BitcoinCoreImageArgs::default(),
         }
     }
 }

--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -1,4 +1,4 @@
-use crate::{core::WaitFor, Image};
+use crate::{core::WaitFor, Image, ImageArgs};
 use hex::encode;
 use hmac::{Hmac, Mac, NewMac};
 use rand::{thread_rng, Rng};
@@ -123,11 +123,8 @@ impl Default for BitcoinCoreImageArgs {
     }
 }
 
-impl IntoIterator for BitcoinCoreImageArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
+impl ImageArgs for BitcoinCoreImageArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
         let mut args = vec![
             format!("-rpcauth={}", self.rpc_auth.encode()),
             // Will print a message when bitcoind is fully started
@@ -177,7 +174,7 @@ impl IntoIterator for BitcoinCoreImageArgs {
             args.push(format!("-fallbackfee={}", fallback_fee));
         }
 
-        args.into_iter()
+        Box::new(args.into_iter())
     }
 }
 

--- a/src/images/coblox_bitcoincore.rs
+++ b/src/images/coblox_bitcoincore.rs
@@ -6,12 +6,11 @@ use sha2::Sha256;
 use std::fmt;
 
 const NAME: &str = "coblox/bitcoin-core";
+const TAG: &str = "0.21.0";
 const BITCOIND_STARTUP_MESSAGE: &str = "bitcoind startup sequence completed.";
 
-#[derive(Debug)]
-pub struct BitcoinCore {
-    tag: String,
-}
+#[derive(Debug, Default)]
+pub struct BitcoinCore;
 
 #[derive(Debug, Clone)]
 pub enum Network {
@@ -190,7 +189,7 @@ impl Image for BitcoinCore {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
@@ -198,14 +197,6 @@ impl Image for BitcoinCore {
             WaitFor::message_on_stdout(BITCOIND_STARTUP_MESSAGE),
             WaitFor::millis_in_env_var("BITCOIND_ADDITIONAL_SLEEP_PERIOD"),
         ]
-    }
-}
-
-impl Default for BitcoinCore {
-    fn default() -> Self {
-        BitcoinCore {
-            tag: "0.21.0".into(),
-        }
     }
 }
 

--- a/src/images/dynamodb_local.rs
+++ b/src/images/dynamodb_local.rs
@@ -4,23 +4,11 @@ const NAME: &str = "amazon/dynamodb-local";
 const TAG: &str = "latest";
 const DEFAULT_WAIT: u64 = 2000;
 
-#[derive(Debug, Default, Clone)]
-pub struct DynamoDbArgs;
-
-impl IntoIterator for DynamoDbArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 #[derive(Default, Debug)]
 pub struct DynamoDb;
 
 impl Image for DynamoDb {
-    type Args = DynamoDbArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/images/dynamodb_local.rs
+++ b/src/images/dynamodb_local.rs
@@ -1,8 +1,8 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "amazon/dynamodb-local";
+const TAG: &str = "latest";
 const DEFAULT_WAIT: u64 = 2000;
-const DEFAULT_TAG: &str = "latest";
 
 #[derive(Debug, Default, Clone)]
 pub struct DynamoDbArgs;
@@ -16,18 +16,8 @@ impl IntoIterator for DynamoDbArgs {
     }
 }
 
-#[derive(Debug)]
-pub struct DynamoDb {
-    tag: String,
-}
-
-impl Default for DynamoDb {
-    fn default() -> Self {
-        DynamoDb {
-            tag: DEFAULT_TAG.to_string(),
-        }
-    }
-}
+#[derive(Default, Debug)]
+pub struct DynamoDb;
 
 impl Image for DynamoDb {
     type Args = DynamoDbArgs;
@@ -37,7 +27,7 @@ impl Image for DynamoDb {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/dynamodb_local.rs
+++ b/src/images/dynamodb_local.rs
@@ -19,14 +19,12 @@ impl IntoIterator for DynamoDbArgs {
 #[derive(Debug)]
 pub struct DynamoDb {
     tag: String,
-    arguments: DynamoDbArgs,
 }
 
 impl Default for DynamoDb {
     fn default() -> Self {
         DynamoDb {
             tag: DEFAULT_TAG.to_string(),
-            arguments: DynamoDbArgs {},
         }
     }
 }

--- a/src/images/elasticmq.rs
+++ b/src/images/elasticmq.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "softwaremill/elasticmq";
-const DEFAULT_TAG: &str = "0.14.6";
+const TAG: &str = "0.14.6";
 
 #[derive(Debug, Default, Clone)]
 pub struct ElasticMqArgs;
@@ -15,18 +15,8 @@ impl IntoIterator for ElasticMqArgs {
     }
 }
 
-#[derive(Debug)]
-pub struct ElasticMq {
-    tag: String,
-}
-
-impl Default for ElasticMq {
-    fn default() -> Self {
-        ElasticMq {
-            tag: DEFAULT_TAG.to_string(),
-        }
-    }
-}
+#[derive(Debug, Default)]
+pub struct ElasticMq;
 
 impl Image for ElasticMq {
     type Args = ElasticMqArgs;
@@ -36,7 +26,7 @@ impl Image for ElasticMq {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/elasticmq.rs
+++ b/src/images/elasticmq.rs
@@ -18,14 +18,12 @@ impl IntoIterator for ElasticMqArgs {
 #[derive(Debug)]
 pub struct ElasticMq {
     tag: String,
-    arguments: ElasticMqArgs,
 }
 
 impl Default for ElasticMq {
     fn default() -> Self {
         ElasticMq {
             tag: DEFAULT_TAG.to_string(),
-            arguments: ElasticMqArgs {},
         }
     }
 }

--- a/src/images/elasticmq.rs
+++ b/src/images/elasticmq.rs
@@ -3,23 +3,11 @@ use crate::{core::WaitFor, Image};
 const NAME: &str = "softwaremill/elasticmq";
 const TAG: &str = "0.14.6";
 
-#[derive(Debug, Default, Clone)]
-pub struct ElasticMqArgs;
-
-impl IntoIterator for ElasticMqArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct ElasticMq;
 
 impl Image for ElasticMq {
-    type Args = ElasticMqArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/images/generic.rs
+++ b/src/images/generic.rs
@@ -5,7 +5,6 @@ use std::collections::BTreeMap;
 pub struct GenericImage {
     name: String,
     tag: String,
-    arguments: Vec<String>,
     volumes: BTreeMap<String, String>,
     env_vars: BTreeMap<String, String>,
     wait_for: Vec<WaitFor>,
@@ -17,7 +16,6 @@ impl Default for GenericImage {
         Self {
             name: "".to_owned(),
             tag: "".to_owned(),
-            arguments: vec![],
             volumes: BTreeMap::new(),
             env_vars: BTreeMap::new(),
             wait_for: Vec::new(),

--- a/src/images/generic.rs
+++ b/src/images/generic.rs
@@ -1,5 +1,11 @@
-use crate::{core::WaitFor, Image};
+use crate::{core::WaitFor, Image, ImageArgs};
 use std::collections::BTreeMap;
+
+impl ImageArgs for Vec<String> {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(self.into_iter())
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct GenericImage {

--- a/src/images/google_cloud_sdk.rs
+++ b/src/images/google_cloud_sdk.rs
@@ -1,4 +1,4 @@
-use crate::{core::WaitFor, Image};
+use crate::{core::WaitFor, Image, ImageArgs};
 
 const NAME: &str = "google/cloud-sdk";
 const TAG: &str = "353.0.0";
@@ -24,11 +24,8 @@ pub enum Emulator {
     PubSub,
 }
 
-impl IntoIterator for CloudSdkArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
+impl ImageArgs for CloudSdkArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
         let (emulator, project) = match &self.emulator {
             Emulator::Bigtable => ("bigtable", None),
             Emulator::Datastore { project } => ("datastore", Some(project)),
@@ -49,7 +46,7 @@ impl IntoIterator for CloudSdkArgs {
         args.push("--host-port".to_owned());
         args.push(format!("{}:{}", self.host, self.port));
 
-        args.into_iter()
+        Box::new(args.into_iter())
     }
 }
 

--- a/src/images/google_cloud_sdk.rs
+++ b/src/images/google_cloud_sdk.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "google/cloud-sdk";
-const DEFAULT_TAG: &str = "353.0.0";
+const TAG: &str = "353.0.0";
 
 const HOST: &str = "0.0.0.0";
 pub const BIGTABLE_PORT: u16 = 8086;
@@ -55,7 +55,6 @@ impl IntoIterator for CloudSdkArgs {
 
 #[derive(Debug)]
 pub struct CloudSdk {
-    tag: String,
     exposed_port: u16,
     ready_condition: WaitFor,
 }
@@ -68,7 +67,7 @@ impl Image for CloudSdk {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
@@ -82,7 +81,6 @@ impl Image for CloudSdk {
 
 impl CloudSdk {
     fn new(port: u16, emulator: Emulator, ready_condition: WaitFor) -> (Self, CloudSdkArgs) {
-        let tag = DEFAULT_TAG.to_owned();
         let arguments = CloudSdkArgs {
             host: HOST.to_owned(),
             port,
@@ -91,7 +89,6 @@ impl CloudSdk {
         let exposed_port = port;
         (
             Self {
-                tag,
                 exposed_port,
                 ready_condition,
             },

--- a/src/images/hello_world.rs
+++ b/src/images/hello_world.rs
@@ -4,7 +4,7 @@ use crate::{core::WaitFor, Image};
 pub struct HelloWorld;
 
 impl Image for HelloWorld {
-    type Args = Vec<String>;
+    type Args = ();
 
     fn name(&self) -> String {
         "hello-world".to_owned()

--- a/src/images/kafka.rs
+++ b/src/images/kafka.rs
@@ -2,12 +2,12 @@ use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const NAME: &str = "confluentinc/cp-kafka";
-const DEFAULT_TAG: &str = "6.1.1";
+const TAG: &str = "6.1.1";
 
 pub const KAFKA_PORT: u16 = 9093;
 const ZOOKEEPER_PORT: u16 = 2181;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct KafkaArgs;
 
 impl IntoIterator for KafkaArgs {
@@ -37,7 +37,6 @@ zookeeper-server-start zookeeper.properties &
 #[derive(Debug)]
 pub struct Kafka {
     env_vars: HashMap<String, String>,
-    tag: String,
 }
 
 impl Default for Kafka {
@@ -73,10 +72,7 @@ impl Default for Kafka {
             "1".to_owned(),
         );
 
-        Self {
-            env_vars,
-            tag: DEFAULT_TAG.to_owned(),
-        }
+        Self { env_vars }
     }
 }
 
@@ -88,7 +84,7 @@ impl Image for Kafka {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/kafka.rs
+++ b/src/images/kafka.rs
@@ -36,7 +36,6 @@ zookeeper-server-start zookeeper.properties &
 
 #[derive(Debug)]
 pub struct Kafka {
-    arguments: KafkaArgs,
     env_vars: HashMap<String, String>,
     tag: String,
 }
@@ -75,7 +74,6 @@ impl Default for Kafka {
         );
 
         Self {
-            arguments: KafkaArgs::default(),
             env_vars,
             tag: DEFAULT_TAG.to_owned(),
         }

--- a/src/images/kafka.rs
+++ b/src/images/kafka.rs
@@ -1,4 +1,4 @@
-use crate::{core::WaitFor, Image};
+use crate::{core::WaitFor, Image, ImageArgs};
 use std::collections::HashMap;
 
 const NAME: &str = "confluentinc/cp-kafka";
@@ -10,16 +10,14 @@ const ZOOKEEPER_PORT: u16 = 2181;
 #[derive(Debug, Default, Clone)]
 pub struct KafkaArgs;
 
-impl IntoIterator for KafkaArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        vec![
-            "/bin/bash".to_owned(),
-            "-c".to_owned(),
-            format!(
-                r#"
+impl ImageArgs for KafkaArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(
+            vec![
+                "/bin/bash".to_owned(),
+                "-c".to_owned(),
+                format!(
+                    r#"
 echo 'clientPort={}' > zookeeper.properties;
 echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties;
 echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties;
@@ -27,10 +25,11 @@ zookeeper-server-start zookeeper.properties &
 . /etc/confluent/docker/bash-config &&
 /etc/confluent/docker/configure &&
 /etc/confluent/docker/launch"#,
-                ZOOKEEPER_PORT
-            ),
-        ]
-        .into_iter()
+                    ZOOKEEPER_PORT
+                ),
+            ]
+            .into_iter(),
+        )
     }
 }
 

--- a/src/images/mongo.rs
+++ b/src/images/mongo.rs
@@ -18,14 +18,12 @@ impl IntoIterator for MongoArgs {
 #[derive(Debug)]
 pub struct Mongo {
     tag: String,
-    arguments: MongoArgs,
 }
 
 impl Default for Mongo {
     fn default() -> Self {
         Mongo {
             tag: DEFAULT_TAG.to_string(),
-            arguments: MongoArgs {},
         }
     }
 }

--- a/src/images/mongo.rs
+++ b/src/images/mongo.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "mongo";
-const DEFAULT_TAG: &str = "4.0.17";
+const TAG: &str = "4.0.17";
 
 #[derive(Debug, Default, Clone)]
 pub struct MongoArgs;
@@ -15,18 +15,8 @@ impl IntoIterator for MongoArgs {
     }
 }
 
-#[derive(Debug)]
-pub struct Mongo {
-    tag: String,
-}
-
-impl Default for Mongo {
-    fn default() -> Self {
-        Mongo {
-            tag: DEFAULT_TAG.to_string(),
-        }
-    }
-}
+#[derive(Default, Debug)]
+pub struct Mongo;
 
 impl Image for Mongo {
     type Args = MongoArgs;
@@ -36,7 +26,7 @@ impl Image for Mongo {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/mongo.rs
+++ b/src/images/mongo.rs
@@ -3,23 +3,11 @@ use crate::{core::WaitFor, Image};
 const NAME: &str = "mongo";
 const TAG: &str = "4.0.17";
 
-#[derive(Debug, Default, Clone)]
-pub struct MongoArgs;
-
-impl IntoIterator for MongoArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 #[derive(Default, Debug)]
 pub struct Mongo;
 
 impl Image for Mongo {
-    type Args = MongoArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/images/orientdb.rs
+++ b/src/images/orientdb.rs
@@ -2,7 +2,7 @@ use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const NAME: &str = "orientdb";
-const DEFAULT_TAG: &str = "3.1.3";
+const TAG: &str = "3.1.3";
 
 #[derive(Debug, Default, Clone)]
 pub struct OrientDbArgs;
@@ -18,7 +18,6 @@ impl IntoIterator for OrientDbArgs {
 
 #[derive(Debug)]
 pub struct OrientDb {
-    tag: String,
     env_vars: HashMap<String, String>,
 }
 
@@ -27,10 +26,7 @@ impl Default for OrientDb {
         let mut env_vars = HashMap::new();
         env_vars.insert("ORIENTDB_ROOT_PASSWORD".to_owned(), "root".to_owned());
 
-        OrientDb {
-            tag: DEFAULT_TAG.to_string(),
-            env_vars,
-        }
+        OrientDb { env_vars }
     }
 }
 
@@ -42,7 +38,7 @@ impl Image for OrientDb {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/orientdb.rs
+++ b/src/images/orientdb.rs
@@ -19,7 +19,6 @@ impl IntoIterator for OrientDbArgs {
 #[derive(Debug)]
 pub struct OrientDb {
     tag: String,
-    arguments: OrientDbArgs,
     env_vars: HashMap<String, String>,
 }
 
@@ -30,7 +29,6 @@ impl Default for OrientDb {
 
         OrientDb {
             tag: DEFAULT_TAG.to_string(),
-            arguments: OrientDbArgs {},
             env_vars,
         }
     }

--- a/src/images/orientdb.rs
+++ b/src/images/orientdb.rs
@@ -4,18 +4,6 @@ use std::collections::HashMap;
 const NAME: &str = "orientdb";
 const TAG: &str = "3.1.3";
 
-#[derive(Debug, Default, Clone)]
-pub struct OrientDbArgs;
-
-impl IntoIterator for OrientDbArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 #[derive(Debug)]
 pub struct OrientDb {
     env_vars: HashMap<String, String>,
@@ -31,7 +19,7 @@ impl Default for OrientDb {
 }
 
 impl Image for OrientDb {
-    type Args = OrientDbArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/images/parity_parity.rs
+++ b/src/images/parity_parity.rs
@@ -1,4 +1,4 @@
-use crate::{core::WaitFor, Image};
+use crate::{core::WaitFor, Image, ImageArgs};
 
 const NAME: &str = "parity/parity";
 const TAG: &str = "v2.5.0";
@@ -9,18 +9,17 @@ pub struct ParityEthereum;
 #[derive(Debug, Default, Clone)]
 pub struct ParityEthereumArgs;
 
-impl IntoIterator for ParityEthereumArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        vec![
-            "--config=dev".to_string(),
-            "--jsonrpc-apis=all".to_string(),
-            "--unsafe-expose".to_string(),
-            "--tracing=on".to_string(),
-        ]
-        .into_iter()
+impl ImageArgs for ParityEthereumArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        Box::new(
+            vec![
+                "--config=dev".to_string(),
+                "--jsonrpc-apis=all".to_string(),
+                "--unsafe-expose".to_string(),
+                "--tracing=on".to_string(),
+            ]
+            .into_iter(),
+        )
     }
 }
 

--- a/src/images/parity_parity.rs
+++ b/src/images/parity_parity.rs
@@ -5,7 +5,6 @@ const DEFAULT_TAG: &str = "v2.5.0";
 
 #[derive(Debug)]
 pub struct ParityEthereum {
-    arguments: ParityEthereumArgs,
     tag: String,
 }
 
@@ -30,7 +29,6 @@ impl IntoIterator for ParityEthereumArgs {
 impl Default for ParityEthereum {
     fn default() -> Self {
         ParityEthereum {
-            arguments: ParityEthereumArgs {},
             tag: DEFAULT_TAG.to_string(),
         }
     }

--- a/src/images/parity_parity.rs
+++ b/src/images/parity_parity.rs
@@ -1,15 +1,13 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "parity/parity";
-const DEFAULT_TAG: &str = "v2.5.0";
+const TAG: &str = "v2.5.0";
 
-#[derive(Debug)]
-pub struct ParityEthereum {
-    tag: String,
-}
+#[derive(Debug, Default)]
+pub struct ParityEthereum;
 
-#[derive(Default, Debug, Clone)]
-pub struct ParityEthereumArgs {}
+#[derive(Debug, Default, Clone)]
+pub struct ParityEthereumArgs;
 
 impl IntoIterator for ParityEthereumArgs {
     type Item = String;
@@ -26,14 +24,6 @@ impl IntoIterator for ParityEthereumArgs {
     }
 }
 
-impl Default for ParityEthereum {
-    fn default() -> Self {
-        ParityEthereum {
-            tag: DEFAULT_TAG.to_string(),
-        }
-    }
-}
-
 impl Image for ParityEthereum {
     type Args = ParityEthereumArgs;
 
@@ -42,7 +32,7 @@ impl Image for ParityEthereum {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/postgres.rs
+++ b/src/images/postgres.rs
@@ -2,16 +2,15 @@ use crate::{core::WaitFor, Image};
 use std::collections::HashMap;
 
 const NAME: &str = "postgres";
-const DEFAULT_TAG: &str = "11-alpine";
+const TAG: &str = "11-alpine";
 
 #[derive(Debug)]
 pub struct Postgres {
-    tag: String,
     env_vars: HashMap<String, String>,
 }
 
-#[derive(Default, Debug, Clone)]
-pub struct PostgresArgs {}
+#[derive(Debug, Default, Clone)]
+pub struct PostgresArgs;
 
 impl IntoIterator for PostgresArgs {
     type Item = String;
@@ -28,10 +27,7 @@ impl Default for Postgres {
         env_vars.insert("POSTGRES_DB".to_owned(), "postgres".to_owned());
         env_vars.insert("POSTGRES_HOST_AUTH_METHOD".into(), "trust".into());
 
-        Self {
-            tag: DEFAULT_TAG.to_owned(),
-            env_vars,
-        }
+        Self { env_vars }
     }
 }
 
@@ -43,7 +39,7 @@ impl Image for Postgres {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/postgres.rs
+++ b/src/images/postgres.rs
@@ -7,7 +7,6 @@ const DEFAULT_TAG: &str = "11-alpine";
 #[derive(Debug)]
 pub struct Postgres {
     tag: String,
-    arguments: PostgresArgs,
     env_vars: HashMap<String, String>,
 }
 
@@ -31,7 +30,6 @@ impl Default for Postgres {
 
         Self {
             tag: DEFAULT_TAG.to_owned(),
-            arguments: PostgresArgs::default(),
             env_vars,
         }
     }

--- a/src/images/postgres.rs
+++ b/src/images/postgres.rs
@@ -9,18 +9,6 @@ pub struct Postgres {
     env_vars: HashMap<String, String>,
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct PostgresArgs;
-
-impl IntoIterator for PostgresArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 impl Default for Postgres {
     fn default() -> Self {
         let mut env_vars = HashMap::new();
@@ -32,7 +20,7 @@ impl Default for Postgres {
 }
 
 impl Image for Postgres {
-    type Args = PostgresArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/images/redis.rs
+++ b/src/images/redis.rs
@@ -1,7 +1,7 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "redis";
-const DEFAULT_TAG: &str = "5.0";
+const TAG: &str = "5.0";
 
 #[derive(Debug, Default, Clone)]
 pub struct RedisArgs;
@@ -15,18 +15,8 @@ impl IntoIterator for RedisArgs {
     }
 }
 
-#[derive(Debug)]
-pub struct Redis {
-    tag: String,
-}
-
-impl Default for Redis {
-    fn default() -> Self {
-        Redis {
-            tag: DEFAULT_TAG.to_string(),
-        }
-    }
-}
+#[derive(Debug, Default)]
+pub struct Redis;
 
 impl Image for Redis {
     type Args = RedisArgs;
@@ -36,7 +26,7 @@ impl Image for Redis {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/redis.rs
+++ b/src/images/redis.rs
@@ -18,14 +18,12 @@ impl IntoIterator for RedisArgs {
 #[derive(Debug)]
 pub struct Redis {
     tag: String,
-    arguments: RedisArgs,
 }
 
 impl Default for Redis {
     fn default() -> Self {
         Redis {
             tag: DEFAULT_TAG.to_string(),
-            arguments: RedisArgs {},
         }
     }
 }

--- a/src/images/redis.rs
+++ b/src/images/redis.rs
@@ -3,23 +3,11 @@ use crate::{core::WaitFor, Image};
 const NAME: &str = "redis";
 const TAG: &str = "5.0";
 
-#[derive(Debug, Default, Clone)]
-pub struct RedisArgs;
-
-impl IntoIterator for RedisArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct Redis;
 
 impl Image for Redis {
-    type Args = RedisArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/images/trufflesuite_ganachecli.rs
+++ b/src/images/trufflesuite_ganachecli.rs
@@ -1,26 +1,16 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "trufflesuite/ganache-cli";
-const DEFAULT_TAG: &str = "v6.1.3";
+const TAG: &str = "v6.1.3";
 
-#[derive(Debug)]
-pub struct GanacheCli {
-    tag: String,
-}
+#[derive(Debug, Default)]
+pub struct GanacheCli;
 
 #[derive(Debug, Clone)]
 pub struct GanacheCliArgs {
     pub network_id: u32,
     pub number_of_accounts: u32,
     pub mnemonic: String,
-}
-
-impl Default for GanacheCli {
-    fn default() -> Self {
-        GanacheCli {
-            tag: DEFAULT_TAG.to_owned(),
-        }
-    }
 }
 
 impl Default for GanacheCliArgs {
@@ -62,7 +52,7 @@ impl Image for GanacheCli {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/trufflesuite_ganachecli.rs
+++ b/src/images/trufflesuite_ganachecli.rs
@@ -6,7 +6,6 @@ const DEFAULT_TAG: &str = "v6.1.3";
 #[derive(Debug)]
 pub struct GanacheCli {
     tag: String,
-    arguments: GanacheCliArgs,
 }
 
 #[derive(Debug, Clone)]
@@ -20,7 +19,6 @@ impl Default for GanacheCli {
     fn default() -> Self {
         GanacheCli {
             tag: DEFAULT_TAG.to_owned(),
-            arguments: GanacheCliArgs::default(),
         }
     }
 }

--- a/src/images/trufflesuite_ganachecli.rs
+++ b/src/images/trufflesuite_ganachecli.rs
@@ -1,4 +1,4 @@
-use crate::{core::WaitFor, Image};
+use crate::{core::WaitFor, Image, ImageArgs};
 
 const NAME: &str = "trufflesuite/ganache-cli";
 const TAG: &str = "v6.1.3";
@@ -23,11 +23,8 @@ impl Default for GanacheCliArgs {
     }
 }
 
-impl IntoIterator for GanacheCliArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
+impl ImageArgs for GanacheCliArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
         let mut args = Vec::new();
 
         if !self.mnemonic.is_empty() {
@@ -40,7 +37,7 @@ impl IntoIterator for GanacheCliArgs {
         args.push("-i".to_string());
         args.push(self.network_id.to_string());
 
-        args.into_iter()
+        Box::new(args.into_iter())
     }
 }
 

--- a/src/images/zookeeper.rs
+++ b/src/images/zookeeper.rs
@@ -1,10 +1,11 @@
 use crate::{core::WaitFor, Image};
 
 const NAME: &str = "zookeeper";
-const DEFAULT_TAG: &str = "3.6.2";
+const TAG: &str = "3.6.2";
 
 #[derive(Debug, Default, Clone)]
 pub struct ZookeeperArgs;
+
 impl IntoIterator for ZookeeperArgs {
     type Item = String;
     type IntoIter = ::std::vec::IntoIter<String>;
@@ -14,18 +15,9 @@ impl IntoIterator for ZookeeperArgs {
     }
 }
 
-#[derive(Debug)]
-pub struct Zookeeper {
-    tag: String,
-}
+#[derive(Debug, Default)]
+pub struct Zookeeper;
 
-impl Default for Zookeeper {
-    fn default() -> Self {
-        Zookeeper {
-            tag: DEFAULT_TAG.to_string(),
-        }
-    }
-}
 impl Image for Zookeeper {
     type Args = ZookeeperArgs;
 
@@ -34,7 +26,7 @@ impl Image for Zookeeper {
     }
 
     fn tag(&self) -> String {
-        self.tag.clone()
+        TAG.to_owned()
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/src/images/zookeeper.rs
+++ b/src/images/zookeeper.rs
@@ -17,14 +17,12 @@ impl IntoIterator for ZookeeperArgs {
 #[derive(Debug)]
 pub struct Zookeeper {
     tag: String,
-    arguments: ZookeeperArgs,
 }
 
 impl Default for Zookeeper {
     fn default() -> Self {
         Zookeeper {
             tag: DEFAULT_TAG.to_string(),
-            arguments: ZookeeperArgs {},
         }
     }
 }

--- a/src/images/zookeeper.rs
+++ b/src/images/zookeeper.rs
@@ -3,23 +3,11 @@ use crate::{core::WaitFor, Image};
 const NAME: &str = "zookeeper";
 const TAG: &str = "3.6.2";
 
-#[derive(Debug, Default, Clone)]
-pub struct ZookeeperArgs;
-
-impl IntoIterator for ZookeeperArgs {
-    type Item = String;
-    type IntoIter = ::std::vec::IntoIter<String>;
-
-    fn into_iter(self) -> <Self as IntoIterator>::IntoIter {
-        vec![].into_iter()
-    }
-}
-
 #[derive(Debug, Default)]
 pub struct Zookeeper;
 
 impl Image for Zookeeper {
-    type Args = ZookeeperArgs;
+    type Args = ();
 
     fn name(&self) -> String {
         NAME.to_owned()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,7 @@
 //! [`Client`]: trait.Docker.html#implementors
 //! [`Images`]: trait.Image.html#implementors
 //! [`Container`]: struct.Container.html
-
-pub use crate::core::{Container, Image, RunnableImage};
+pub use crate::core::{Container, Image, ImageArgs, RunnableImage};
 
 #[cfg(feature = "experimental")]
 pub use crate::core::ContainerAsync;


### PR DESCRIPTION
Attempt to resolve https://github.com/testcontainers/testcontainers-rs/pull/295#issuecomment-924628336 that also inspired me to further simplify a few things, which also includes addressing https://github.com/testcontainers/testcontainers-rs/pull/295#discussion_r700707178 
> Images that don't need arguments can just leave them as (). We can make our own trait to go from args -> string iterator so we can provide a default impl here.