### PR TITLE
Use emulators tag for google cloud-sdk

### DIFF
--- a/src/images.rs
+++ b/src/images.rs
@@ -2,7 +2,7 @@ pub mod coblox_bitcoincore;
 pub mod dynamodb_local;
 pub mod elasticmq;
 pub mod generic;
-pub mod google_cloud_sdk;
+pub mod google_cloud_sdk_emulators;
 pub mod hello_world;
 pub mod kafka;
 pub mod mongo;

--- a/src/images/google_cloud_sdk_emulators.rs
+++ b/src/images/google_cloud_sdk_emulators.rs
@@ -1,13 +1,14 @@
 use crate::{core::WaitFor, Image, ImageArgs};
 
 const NAME: &str = "google/cloud-sdk";
-const TAG: &str = "353.0.0";
+const TAG: &str = "362.0.0-emulators";
 
 const HOST: &str = "0.0.0.0";
 pub const BIGTABLE_PORT: u16 = 8086;
 pub const DATASTORE_PORT: u16 = 8081;
 pub const FIRESTORE_PORT: u16 = 8080;
 pub const PUBSUB_PORT: u16 = 8085;
+pub const SPANNER_PORT: u16 = 9010;
 
 #[derive(Debug, Clone)]
 pub struct CloudSdkArgs {
@@ -22,6 +23,7 @@ pub enum Emulator {
     Datastore { project: String },
     Firestore,
     PubSub,
+    Spanner,
 }
 
 impl ImageArgs for CloudSdkArgs {
@@ -31,6 +33,7 @@ impl ImageArgs for CloudSdkArgs {
             Emulator::Datastore { project } => ("datastore", Some(project)),
             Emulator::Firestore => ("firestore", None),
             Emulator::PubSub => ("pubsub", None),
+            Emulator::Spanner => ("spanner", None),
         };
         let mut args = vec![
             "gcloud".to_owned(),
@@ -123,6 +126,14 @@ impl CloudSdk {
             PUBSUB_PORT,
             Emulator::PubSub,
             WaitFor::message_on_stderr("[pubsub] INFO: Server started, listening on"),
+        )
+    }
+
+    pub fn spanner() -> (Self, CloudSdkArgs) {
+        Self::new(
+            SPANNER_PORT, // gRPC port
+            Emulator::Spanner,
+            WaitFor::message_on_stderr("Cloud Spanner emulator running"),
         )
     }
 }

--- a/tests/images.rs
+++ b/tests/images.rs
@@ -45,32 +45,48 @@ fn coblox_bitcoincore_getnewaddress() {
 fn bigtable_emulator_expose_port() {
     let _ = pretty_env_logger::try_init();
     let docker = clients::Cli::default();
-    let node = docker.run(images::google_cloud_sdk::CloudSdk::bigtable());
-    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::BIGTABLE_PORT)));
+    let node = docker.run(images::google_cloud_sdk_emulators::CloudSdk::bigtable());
+    assert!(RANDOM_PORTS
+        .contains(&node.get_host_port(images::google_cloud_sdk_emulators::BIGTABLE_PORT)));
 }
 
 #[test]
 fn datastore_emulator_expose_port() {
     let _ = pretty_env_logger::try_init();
     let docker = clients::Cli::default();
-    let node = docker.run(images::google_cloud_sdk::CloudSdk::datastore("test"));
-    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::DATASTORE_PORT)));
+    let node = docker.run(images::google_cloud_sdk_emulators::CloudSdk::datastore(
+        "test",
+    ));
+    assert!(RANDOM_PORTS
+        .contains(&node.get_host_port(images::google_cloud_sdk_emulators::DATASTORE_PORT)));
 }
 
 #[test]
 fn firestore_emulator_expose_port() {
     let _ = pretty_env_logger::try_init();
     let docker = clients::Cli::default();
-    let node = docker.run(images::google_cloud_sdk::CloudSdk::firestore());
-    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::FIRESTORE_PORT)));
+    let node = docker.run(images::google_cloud_sdk_emulators::CloudSdk::firestore());
+    assert!(RANDOM_PORTS
+        .contains(&node.get_host_port(images::google_cloud_sdk_emulators::FIRESTORE_PORT)));
 }
 
 #[test]
 fn pubsub_emulator_expose_port() {
     let _ = pretty_env_logger::try_init();
     let docker = clients::Cli::default();
-    let node = docker.run(images::google_cloud_sdk::CloudSdk::pubsub());
-    assert!(RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk::PUBSUB_PORT)));
+    let node = docker.run(images::google_cloud_sdk_emulators::CloudSdk::pubsub());
+    assert!(
+        RANDOM_PORTS.contains(&node.get_host_port(images::google_cloud_sdk_emulators::PUBSUB_PORT))
+    );
+}
+
+#[test]
+fn spanner_emulator_expose_port() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::google_cloud_sdk_emulators::CloudSdk::spanner());
+    assert!(RANDOM_PORTS
+        .contains(&node.get_host_port(images::google_cloud_sdk_emulators::SPANNER_PORT)));
 }
 
 #[test]


### PR DESCRIPTION
To keep things lightweight, it is better to use the image that
has only the emulators and its dependencies. Also, included
support for Spanner emulator which was missed out earlier.