### PR TITLE
Introduce RabbitMQ image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Note: This release also removed the default wallet.
 - `expose_port` functionality to `Image` trait.
 - `Google Cloud SDK` image
+- `RabbitMQ` image
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ experimental = [ ]
 [dev-dependencies]
 bitcoincore-rpc = "0.13"
 json = "0.12"
+lapin = "1.8.0"
 mongodb = "2.0.0-beta"
 orientdb-client = "0.6"
 postgres = "0.19"
@@ -41,4 +42,5 @@ rusoto_dynamodb = "0.46"
 rusoto_sqs = "0.46"
 spectral = "0.6"
 tokio = { version = "1", features = [ "macros" ] }
+tokio-amqp = "1.0.0"
 zookeeper = "0.5"

--- a/src/images.rs
+++ b/src/images.rs
@@ -9,6 +9,7 @@ pub mod mongo;
 pub mod orientdb;
 pub mod parity_parity;
 pub mod postgres;
+pub mod rabbitmq;
 pub mod redis;
 pub mod trufflesuite_ganachecli;
 pub mod zookeeper;

--- a/src/images/rabbitmq.rs
+++ b/src/images/rabbitmq.rs
@@ -1,0 +1,25 @@
+use crate::{core::WaitFor, Image};
+
+const NAME: &str = "rabbitmq";
+const TAG: &str = "3.8.22-management";
+
+#[derive(Debug, Default, Clone)]
+pub struct RabbitMq;
+
+impl Image for RabbitMq {
+    type Args = ();
+
+    fn name(&self) -> String {
+        NAME.to_owned()
+    }
+
+    fn tag(&self) -> String {
+        TAG.to_owned()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout(
+            "Server startup complete; 4 plugins started.",
+        )]
+    }
+}

--- a/tests/rabbitmq.rs
+++ b/tests/rabbitmq.rs
@@ -1,0 +1,96 @@
+use futures::StreamExt;
+use lapin::{
+    options::{
+        BasicConsumeOptions, BasicPublishOptions, ExchangeDeclareOptions, QueueBindOptions,
+        QueueDeclareOptions,
+    },
+    types::FieldTable,
+    BasicProperties, Connection, ConnectionProperties, ExchangeKind,
+};
+use std::time::Duration;
+use testcontainers::{clients, images::rabbitmq};
+use tokio_amqp::LapinTokioExt;
+
+#[tokio::test]
+async fn rabbitmq_produce_and_consume_messages() {
+    let _ = pretty_env_logger::try_init().unwrap();
+    let docker = clients::Cli::default();
+    let rabbit_node = docker.run(rabbitmq::RabbitMq::default());
+
+    let amqp_url = format!("amqp://localhost:{}", rabbit_node.get_host_port(5672));
+
+    let connection = Connection::connect(
+        amqp_url.as_str(),
+        ConnectionProperties::default().with_tokio(),
+    )
+    .await
+    .unwrap();
+
+    let channel = connection.create_channel().await.unwrap();
+
+    assert!(channel.status().connected());
+
+    channel
+        .exchange_declare(
+            "test_exchange",
+            ExchangeKind::Topic,
+            ExchangeDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    let queue = channel
+        .queue_declare(
+            "test_queue",
+            QueueDeclareOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    channel
+        .queue_bind(
+            queue.name().as_str(),
+            "test_exchange",
+            "#",
+            QueueBindOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    let mut consumer = channel
+        .basic_consume(
+            queue.name().as_str(),
+            "test_consumer_tag",
+            BasicConsumeOptions::default(),
+            FieldTable::default(),
+        )
+        .await
+        .unwrap();
+
+    channel
+        .basic_publish(
+            "test_exchange",
+            "routing-key",
+            BasicPublishOptions::default(),
+            b"Test Payload".to_vec(),
+            BasicProperties::default(),
+        )
+        .await
+        .unwrap();
+
+    let consumed = tokio::time::timeout(Duration::from_secs(10), consumer.next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    let (_, delivery) = consumed.expect("Failed to consume delivery!");
+    assert_eq!(
+        String::from_utf8(delivery.data.clone()).unwrap(),
+        "Test Payload"
+    );
+    assert_eq!(delivery.exchange.as_str(), "test_exchange");
+    assert_eq!(delivery.routing_key.as_str(), "routing-key");
+}


### PR DESCRIPTION
Introduce an image for `RabbitMQ`.
It uses the `-management` tag so you also can use the management API in tests (e.g. to create VHosts).