### PR TITLE
Support container networking

### DIFF
--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -135,11 +135,14 @@ impl Client {
     }
 
     fn build_run_command<I: Image>(image: &RunnableImage<I>, mut command: Command) -> Command {
+        let mut is_container_networked = false;
         command.arg("run");
 
         if let Some(network) = image.network() {
             command.arg(format!("--network={}", network));
+            is_container_networked = network.starts_with("container:");
         }
+        let is_container_networked = is_container_networked;
 
         if let Some(name) = image.container_name() {
             command.arg(format!("--name={}", name));
@@ -163,7 +166,7 @@ impl Client {
                     .arg("-p")
                     .arg(format!("{}:{}", port.local, port.internal));
             }
-        } else {
+        } else if !is_container_networked {
             for port in image.expose_ports() {
                 command.arg(format!("--expose={}", port));
             }
@@ -545,6 +548,21 @@ mod tests {
             format!("{:?}", command),
             r#""docker" "run" "--name=hello_container" "-P" "-d" "hello:0.0""#
         );
+    }
+
+    #[test]
+    fn cli_run_command_with_container_network_should_not_expose_ports() {
+        let image = GenericImage::new("hello", "0.0");
+        let image = RunnableImage::from(image)
+            .with_container_name("hello_container")
+            .with_network("container:the_other_one");
+        let command = Client::build_run_command(&image, Command::new("docker"));
+
+        assert_eq!(
+            format!("{:?}", command),
+            r#""docker" "run" "--network=container:the_other_one" "--name=hello_container" "-d" "hello:0.0""#
+        );
+
     }
 
     #[test]

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -562,7 +562,6 @@ mod tests {
             format!("{:?}", command),
             r#""docker" "run" "--network=container:the_other_one" "--name=hello_container" "-d" "hello:0.0""#
         );
-
     }
 
     #[test]

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -135,14 +135,11 @@ impl Client {
     }
 
     fn build_run_command<I: Image>(image: &RunnableImage<I>, mut command: Command) -> Command {
-        let mut is_container_networked = false;
         command.arg("run");
 
         if let Some(network) = image.network() {
             command.arg(format!("--network={}", network));
-            is_container_networked = network.starts_with("container:");
         }
-        let is_container_networked = is_container_networked;
 
         if let Some(name) = image.container_name() {
             command.arg(format!("--name={}", name));
@@ -160,6 +157,11 @@ impl Client {
             command.arg("--entrypoint").arg(entrypoint);
         }
 
+        let is_container_networked = image
+            .network()
+            .as_ref()
+            .map(|network| network.starts_with("container:"))
+            .unwrap_or(false);
         if let Some(ports) = image.ports() {
             for port in ports {
                 command


### PR DESCRIPTION
This is simply a matter of only exposing ports if
the network does not start_with("container:").
Issue is https://github.com/testcontainers/testcontainers-rs/issues/319

Signed-off-by: Josh Hershberg <yehoshua@redis.com>