### PR TITLE
Replace all Shiplift usages with Bollard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "A library for integration-testing against docker containers from 
 
 [dependencies]
 async-trait = "0.1"
+bollard = "0.11"
 futures = "0.3"
 hex = "0.4"
 hmac = "0.12"
@@ -19,7 +20,6 @@ rand = "0.8"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sha2 = "0.10"
-shiplift = { version = "0.7", default-features = false, features = [ "chrono", "unix-socket" ] }
 tokio = { version = "1", features = [ "macros" ] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ description = "A library for integration-testing against docker containers from 
 
 [dependencies]
 async-trait = "0.1"
-bollard = "0.11"
+bollard = { version = "0.11", optional = true }
+bollard-stubs = "1.41"
 futures = "0.3"
 hex = "0.4"
 hmac = "0.12"
@@ -23,7 +24,7 @@ sha2 = "0.10"
 tokio = { version = "1", features = [ "macros" ] }
 
 [features]
-experimental = [ ]
+experimental = [ "bollard" ]
 
 [dev-dependencies]
 bitcoincore-rpc = "0.14"

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{env, env::GetEnvValue, logs::LogStream, ports::Ports, ContainerState, Docker, WaitFor},
     Container, Image, ImageArgs, RunnableImage,
 };
-use shiplift::rep::ContainerDetails;
+use bollard::models::ContainerInspectResponse;
 use std::{
     collections::HashMap,
     ffi::{OsStr, OsString},
@@ -298,12 +298,13 @@ impl Docker for Cli {
     fn ports(&self, id: &str) -> Ports {
         self.inspect(id)
             .network_settings
+            .unwrap_or_default()
             .ports
-            .map(Ports::new)
+            .map(Ports::from)
             .unwrap_or_default()
     }
 
-    fn inspect(&self, id: &str) -> ContainerDetails {
+    fn inspect(&self, id: &str) -> ContainerInspectResponse {
         let child = self
             .inner
             .command()
@@ -315,7 +316,7 @@ impl Docker for Cli {
 
         let stdout = child.stdout.unwrap();
 
-        let mut infos: Vec<ContainerDetails> = serde_json::from_reader(stdout).unwrap();
+        let mut infos: Vec<ContainerInspectResponse> = serde_json::from_reader(stdout).unwrap();
 
         let info = infos.remove(0);
 

--- a/src/clients/cli.rs
+++ b/src/clients/cli.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{env, env::GetEnvValue, logs::LogStream, ports::Ports, ContainerState, Docker, WaitFor},
     Container, Image, ImageArgs, RunnableImage,
 };
-use bollard::models::ContainerInspectResponse;
+use bollard_stubs::models::ContainerInspectResponse;
 use std::{
     collections::HashMap,
     ffi::{OsStr, OsString},

--- a/src/core/container.rs
+++ b/src/core/container.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{env::Command, logs::LogStream, ports::Ports, ExecCommand, WaitFor},
     Image, RunnableImage,
 };
-use bollard::models::ContainerInspectResponse;
+use bollard_stubs::models::ContainerInspectResponse;
 use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
 
 /// Represents a running docker container.

--- a/src/core/container.rs
+++ b/src/core/container.rs
@@ -2,7 +2,7 @@ use crate::{
     core::{env::Command, logs::LogStream, ports::Ports, ExecCommand, WaitFor},
     Image, RunnableImage,
 };
-use shiplift::rep::ContainerDetails;
+use bollard::models::ContainerInspectResponse;
 use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
 
 /// Represents a running docker container.
@@ -133,7 +133,9 @@ where
                 .docker_client
                 .inspect(&self.id)
                 .network_settings
-                .ip_address,
+                .unwrap_or_default()
+                .ip_address
+                .unwrap_or_default(),
         )
         .unwrap_or_else(|_| panic!("container {} has missing or invalid bridge IP", self.id))
     }
@@ -195,7 +197,7 @@ pub(crate) trait Docker {
     fn stdout_logs(&self, id: &str) -> LogStream;
     fn stderr_logs(&self, id: &str) -> LogStream;
     fn ports(&self, id: &str) -> Ports;
-    fn inspect(&self, id: &str) -> ContainerDetails;
+    fn inspect(&self, id: &str) -> ContainerInspectResponse;
     fn rm(&self, id: &str);
     fn stop(&self, id: &str);
     fn start(&self, id: &str);

--- a/src/core/ports.rs
+++ b/src/core/ports.rs
@@ -1,4 +1,4 @@
-use bollard::models::{PortBinding, PortMap};
+use bollard_stubs::models::{PortBinding, PortMap};
 use std::collections::HashMap;
 
 /// The exposed ports of a running container.
@@ -69,7 +69,7 @@ fn parse_port(port: &str) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bollard::models::ContainerInspectResponse;
+    use bollard_stubs::models::ContainerInspectResponse;
 
     #[test]
     fn can_deserialize_docker_inspect_response_into_api_ports() {

--- a/src/core/ports.rs
+++ b/src/core/ports.rs
@@ -1,3 +1,4 @@
+use bollard::models::{PortBinding, PortMap};
 use std::collections::HashMap;
 
 /// The exposed ports of a running container.
@@ -8,18 +9,47 @@ pub struct Ports {
 
 impl Ports {
     pub fn new(ports: HashMap<String, Option<Vec<HashMap<String, String>>>>) -> Self {
+        let port_binding = ports
+            .into_iter()
+            .filter_map(|(internal, external)| {
+                Some((
+                    internal,
+                    Some(
+                        external?
+                            .into_iter()
+                            .map(|external| PortBinding {
+                                host_ip: external.get("HostIp").cloned(),
+                                host_port: external.get("HostPort").cloned(),
+                            })
+                            .collect(),
+                    ),
+                ))
+            })
+            .collect::<HashMap<_, _>>();
+
+        Self::from(port_binding)
+    }
+
+    /// Returns the host port for the given internal port.
+    pub fn map_to_host_port(&self, internal_port: u16) -> Option<u16> {
+        self.mapping.get(&internal_port).cloned()
+    }
+}
+
+impl From<PortMap> for Ports {
+    fn from(ports: PortMap) -> Self {
         let mapping = ports
             .into_iter()
             .filter_map(|(internal, external)| {
                 // internal is '8332/tcp', split off the protocol ...
                 let internal = internal.split('/').next()?;
 
-                // external is a an optional list of maps: [ { "HostIp": "0.0.0.0", "HostPort": "33078" } ]
                 // get the first entry and get the value of the `HostPort` field
-                let external = external?.first()?.get("HostPort").cloned()?;
+                let external = external?;
+                let external_port = external.first()?.host_port.as_ref()?;
 
                 let internal = parse_port(internal);
-                let external = parse_port(&external);
+                let external = parse_port(external_port);
 
                 log::debug!("Registering port mapping: {} -> {}", internal, external);
 
@@ -28,11 +58,6 @@ impl Ports {
             .collect::<HashMap<_, _>>();
 
         Self { mapping }
-    }
-
-    /// Returns the host port for the given internal port.
-    pub fn map_to_host_port(&self, internal_port: u16) -> Option<u16> {
-        self.mapping.get(&internal_port).cloned()
     }
 }
 
@@ -44,11 +69,11 @@ fn parse_port(port: &str) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shiplift::rep::ContainerDetails;
+    use bollard::models::ContainerInspectResponse;
 
     #[test]
     fn can_deserialize_docker_inspect_response_into_api_ports() {
-        let container_details = serde_json::from_str::<ContainerDetails>(
+        let container_details = serde_json::from_str::<ContainerInspectResponse>(
             r#"{
   "Id": "1233c36b54a5bac19efbf92728aa33b2faf67f3364f24db506d90fd46a5d0e8c",
   "Created": "2021-02-19T04:57:38.081442827Z",
@@ -276,8 +301,9 @@ mod tests {
 
         let parsed_ports = container_details
             .network_settings
+            .unwrap_or_default()
             .ports
-            .map(Ports::new)
+            .map(Ports::from)
             .unwrap_or_default();
 
         let mut expected_ports = Ports::default();


### PR DESCRIPTION
Judging by the low activity in [shiplift](https://github.com/softprops/shiplift) (last commit on 1 Sep 2021, quite a few unmerged PRs after September and lack of response in the maintenance status clarification request softprops/shiplift#321), I think it's a good time to switch to a more actively maintained crate.

I picked Ballard because of the more active repo than `docker-api-rs`. And I liked the idea with the code generation from the API :)