### PR TITLE
Refactor dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ rand = "0.8"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sha2 = "0.10"
-tokio = { version = "1", features = [ "macros" ] }
+tokio = { version = "1", features = [ "macros" ], optional = true }
 
 [features]
-experimental = [ "async-trait", "bollard" ]
+experimental = [ "async-trait", "bollard", "tokio" ]
 
 [dev-dependencies]
 bitcoincore-rpc = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/testcontainers/testcontainers-rs"
 description = "A library for integration-testing against docker containers from within Rust."
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { version = "0.1", optional = true }
 bollard = { version = "0.11", optional = true }
 bollard-stubs = "1.41"
 futures = "0.3"
@@ -24,7 +24,7 @@ sha2 = "0.10"
 tokio = { version = "1", features = [ "macros" ] }
 
 [features]
-experimental = [ "bollard" ]
+experimental = [ "async-trait", "bollard" ]
 
 [dev-dependencies]
 bitcoincore-rpc = "0.14"


### PR DESCRIPTION
This PR aims to reduce the build time for the users who don't need the experimental features and don't need the bitcoincore image.