### PR TITLE
Add WaitFor::Healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `expose_port` functionality to `Image` trait.
 - `Google Cloud SDK` image
 - `RabbitMQ` image
+- `WaitFor::Healthcheck` container ready condition, which corresponds with the [healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) status.
 
 ### Changed
 

--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -289,6 +289,8 @@ pub enum WaitFor {
     StdErrMessage { message: String },
     /// Wait for a certain amount of time.
     Duration { length: Duration },
+    /// Wait for the container's status to become `healthy`.
+    Healthcheck,
 }
 
 impl WaitFor {


### PR DESCRIPTION
In this PR, I added the most naive and simple implementation for the `WaitFor::Healthcheck`. The ideal option will be to remove `delay` from the Enum. Still, the current implementation gives some flexibility to the users and eliminates the need of hardcoding the delay inside the crate.

As always, I'm open to suggestions :)

Fixes #321.