### PR TITLE
Add MSRV to Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Get current MSRV from Cargo.toml
+        id: current_msrv
+        run: |
+          msrv=$(cat Cargo.toml | grep rust-version | sed 's/.* = "//; s/"//')
+          echo "::set-output name=msrv::$msrv"
       - uses: actions-rs/toolchain@v1
         id: toolchain
         with:
           profile: minimal
-          toolchain: 1.46.0
+          toolchain: ${{steps.current_msrv.outputs.msrv}}
           override: true
       - uses: Swatinem/rust-cache@v1.3.0
       - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 keywords = [ "docker", "testcontainers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"
+rust-version = "1.46.0"
 description = "A library for integration-testing against docker containers from within Rust."
 
 [dependencies]


### PR DESCRIPTION
cargo officially allows key `rust-version` starting from Rust 1.56.0. In the older versions, the key will be ignored (though a warning will be displayed).

Having this value defined in Cargo.toml provides better visibility within the ecosystem. And it's just nicer to have this value specified in the config and not in a Github Workflow, even if reading it inside the workflow is a bit clunky :)