### PR TITLE
Add #[must_use] for RunnableImage and GenericImage

### DIFF
--- a/src/core/image.rs
+++ b/src/core/image.rs
@@ -133,6 +133,7 @@ impl ImageArgs for () {
     }
 }
 
+#[must_use]
 #[derive(Debug)]
 pub struct RunnableImage<I: Image> {
     image: I,

--- a/src/images/generic.rs
+++ b/src/images/generic.rs
@@ -7,6 +7,7 @@ impl ImageArgs for Vec<String> {
     }
 }
 
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct GenericImage {
     name: String,


### PR DESCRIPTION
This PR fixes the errors reported by the nightly cargo: https://github.com/testcontainers/testcontainers-rs/runs/4847806082?check_suite_focus=true.

More info about the lint can be found here: https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use.

