### PR TITLE
Add missed args passthrough in the HTTP client

### DIFF
--- a/src/clients/http.rs
+++ b/src/clients/http.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{env, logs::LogStreamAsync, ports::Ports, DockerAsync},
-    ContainerAsync, Image, RunnableImage,
+    ContainerAsync, Image, ImageArgs, RunnableImage,
 };
 use async_trait::async_trait;
 use bollard::{
@@ -130,6 +130,15 @@ impl Http {
                 host_config.publish_all_ports = Some(true);
                 host_config
             });
+        }
+
+        let args = image
+            .args()
+            .clone()
+            .into_iterator()
+            .collect::<Vec<String>>();
+        if !args.is_empty() {
+            config.cmd = Some(args);
         }
 
         // create the container with options


### PR DESCRIPTION
Initially, I was trying to test if #271 was fixed after migrating to Bollard (and yes, it was!). I thought that the simplest way to test it is just run something like `docker run --rm ubuntu:latest bash -c 'sleep 10 && echo ready && sleep 10'`. It worked like a charm for the Cli client but started to fail as soon as I switched to the HTTP one. Long story short — #270 will be fixed with the changes in this PR, and #271 can already be closed.

You seem to just forget about the args when you were implementing the HTTP client :)

Fixes #270.