### PR TITLE
Add MinIO image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Google Cloud SDK` image
 - `RabbitMQ` image
 - `WaitFor::Healthcheck` container ready condition, which corresponds with the [healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) status.
+- `MinIO` image
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { version = "0.11", features = [ "blocking" ] }
 rusoto_core = "0.47"
 rusoto_credential = "0.47"
 rusoto_dynamodb = "0.47"
+rusoto_s3 = "0.47"
 rusoto_sqs = "0.47"
 spectral = "0.6"
 tokio = { version = "1", features = [ "macros" ] }

--- a/src/images.rs
+++ b/src/images.rs
@@ -6,6 +6,7 @@ pub mod generic;
 pub mod google_cloud_sdk_emulators;
 pub mod hello_world;
 pub mod kafka;
+pub mod minio;
 pub mod mongo;
 pub mod orientdb;
 pub mod parity_parity;

--- a/src/images/minio.rs
+++ b/src/images/minio.rs
@@ -1,0 +1,79 @@
+use crate::{core::WaitFor, Image, ImageArgs};
+use std::collections::HashMap;
+
+const NAME: &str = "minio/minio";
+const TAG: &str = "RELEASE.2022-02-07T08-17-33Z";
+
+const DIR: &str = "/data";
+const CONSOLE_ADDRESS: &str = ":9001";
+
+#[derive(Debug)]
+pub struct MinIO {
+    env_vars: HashMap<String, String>,
+}
+
+impl Default for MinIO {
+    fn default() -> Self {
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            "MINIO_CONSOLE_ADDRESS".to_owned(),
+            CONSOLE_ADDRESS.to_owned(),
+        );
+
+        Self { env_vars }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MinIOServerArgs {
+    pub dir: String,
+    pub certs_dir: Option<String>,
+    pub json_log: bool,
+}
+
+impl Default for MinIOServerArgs {
+    fn default() -> Self {
+        Self {
+            dir: DIR.to_owned(),
+            certs_dir: None,
+            json_log: false,
+        }
+    }
+}
+
+impl ImageArgs for MinIOServerArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        let mut args = vec!["server".to_owned(), self.dir.to_owned()];
+
+        if let Some(ref certs_dir) = self.certs_dir {
+            args.push("--certs-dir".to_owned());
+            args.push(certs_dir.to_owned())
+        }
+
+        if self.json_log {
+            args.push("--json".to_owned());
+        }
+
+        Box::new(args.into_iter())
+    }
+}
+
+impl Image for MinIO {
+    type Args = MinIOServerArgs;
+
+    fn name(&self) -> String {
+        NAME.to_owned()
+    }
+
+    fn tag(&self) -> String {
+        TAG.to_owned()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stdout("API:")]
+    }
+
+    fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        Box::new(self.env_vars.iter())
+    }
+}


### PR DESCRIPTION
I think it should be pretty useful to have a `S3`-compatible default image.

Features:
- Specify server args via `MinIOServerArgs`

In addition, one test case was added.