### PR TITLE
Suppress non-captured output from Cli::stdout_logs

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -272,6 +272,7 @@ impl Docker for Cli {
             .arg("-f")
             .arg(id)
             .stdout(Stdio::piped())
+            .stderr(Stdio::null())
             .spawn()
             .expect("Failed to execute docker command");
 
@@ -288,6 +289,7 @@ impl Docker for Cli {
             .arg("logs")
             .arg("-f")
             .arg(id)
+            .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
             .expect("Failed to execute docker command");


### PR DESCRIPTION
The implementations of `<Cli as Docker>::stdout_logs()` and `<Cli as Docker>::stderr_logs()` each invoke `docker logs -f <id>`, and capture one of stdout or stderr, for use in wait conditions. However, each method leaves one of the two streams from the `docker logs` process to follow the default behavior, `Stdio::inherit()`, which may result in container logs being printed to the TTY.

As an example, the postgres image prints to both stdout and stderr, and has a condition using `WaitFor::message_on_stderr()`. When this condition is checked, the container's stdout logs will be printed to the TTY.

This change adds redirection to the remaining streams in these two methods. With these changes, tests using the postgres container no longer print anything.