### PR TITLE
Update integration tests link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Testcontainers-rs is the official Rust language fork of [http://testcontainers.o
 1. Depend on `testcontainers`
 2. Import `use testcontainers::*`.
 
-Check [the integration tests](./tests) on how to use the library.
+Check [the integration tests](./testcontainers/tests) on how to use the library.
 
 ## License
 


### PR DESCRIPTION
The integration tests link in the README.md file is broken, update to the correct directory