### PR TITLE
Upgrade bollard to 0.13 and bollard-stubs to 1.42.0-rc.3

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -12,8 +12,8 @@ description = "A library for integration-testing against docker containers from 
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-bollard = { version = "0.11", optional = true }
-bollard-stubs = "1.41"
+bollard = { version = "0.13.0", optional = true }
+bollard-stubs = "=1.42.0-rc.3"
 conquer-once = { version = "0.3", optional = true }
 futures = "0.3"
 hex = "0.4"


### PR DESCRIPTION
Upgrade bollard and bollard-stubs.

Because bollard 0.13 depends on an RC version of bollard-stubs we have to specify it exactly for Cargo (since Cargo won't pick an RC version when resolving, even if you put `^1` )