### PR TITLE
Allow setting shared memory size

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -147,6 +147,10 @@ impl Client {
             command.arg("--privileged");
         }
 
+        if let Some(bytes) = image.shm_size() {
+            command.arg(format!("--shm-size={}", bytes));
+        }
+
         if let Some(network) = image.network() {
             command.arg(format!("--network={}", network));
         }
@@ -612,6 +616,18 @@ mod tests {
         assert_eq!(
             format!("{:?}", command),
             r#""docker" "run" "--privileged" "-P" "-d" "hello:0.0""#
+        );
+    }
+
+    #[test]
+    fn cli_run_command_should_include_shm_size() {
+        let image = GenericImage::new("hello", "0.0");
+        let image = RunnableImage::from(image).with_shm_size(1_000_000);
+        let command = Client::build_run_command(&image, Command::new("docker"));
+
+        assert_eq!(
+            format!("{:?}", command),
+            r#""docker" "run" "--shm-size=1000000" "-P" "-d" "hello:0.0""#
         );
     }
 

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -164,6 +164,7 @@ pub struct RunnableImage<I: Image> {
     volumes: BTreeMap<String, String>,
     ports: Option<Vec<Port>>,
     privileged: bool,
+    shm_size: Option<u64>,
 }
 
 impl<I: Image> RunnableImage<I> {
@@ -197,6 +198,11 @@ impl<I: Image> RunnableImage<I> {
 
     pub fn privileged(&self) -> bool {
         self.privileged
+    }
+
+    /// Shared memory size in bytes
+    pub fn shm_size(&self) -> Option<u64> {
+        self.shm_size
     }
 
     pub fn entrypoint(&self) -> Option<String> {
@@ -273,6 +279,13 @@ impl<I: Image> RunnableImage<I> {
     pub fn with_privileged(self, privileged: bool) -> Self {
         Self { privileged, ..self }
     }
+
+    pub fn with_shm_size(self, bytes: u64) -> Self {
+        Self {
+            shm_size: Some(bytes),
+            ..self
+        }
+    }
 }
 
 impl<I> From<I> for RunnableImage<I>
@@ -297,6 +310,7 @@ impl<I: Image> From<(I, I::Args)> for RunnableImage<I> {
             volumes: BTreeMap::default(),
             ports: None,
             privileged: false,
+            shm_size: None,
         }
     }
 }


### PR DESCRIPTION
Allow setting shared memory size (`--shm-size`) in bytes when creating an image.

Fixes #395.