### PR TITLE
Fix errors when building with `--all-features`

### DIFF
--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -172,7 +172,7 @@ impl Http {
 
         #[cfg(feature = "watchdog")]
         if self.inner.command == env::Command::Remove {
-            crate::watchdog::Watchdog::register(container_id.clone());
+            crate::watchdog::register(container_id.clone());
         }
 
         self.inner

--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -148,7 +148,7 @@ impl Http {
         let container_id = {
             match create_result {
                 Ok(container) => container.id,
-                Err(bollard::errors::Error::DockerResponseNotFoundError { message: _ }) => {
+                Err(bollard::errors::Error::DockerResponseServerError { status_code: 404, .. }) => {
                     {
                         let pull_options = Some(CreateImageOptions {
                             from_image: image.descriptor(),

--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -145,7 +145,7 @@ impl Http {
         let create_result = self
             .create_container(create_options.clone(), config.clone())
             .await;
-        let id = {
+        let container_id = {
             match create_result {
                 Ok(container) => container.id,
                 Err(bollard::errors::Error::DockerResponseNotFoundError { message: _ }) => {
@@ -177,7 +177,7 @@ impl Http {
 
         self.inner
             .bollard
-            .start_container::<String>(&id, None)
+            .start_container::<String>(&container_id, None)
             .await
             .unwrap();
 
@@ -185,7 +185,7 @@ impl Http {
             inner: self.inner.clone(),
         };
 
-        ContainerAsync::new(id, client, image, self.inner.command).await
+        ContainerAsync::new(container_id, client, image, self.inner.command).await
     }
 }
 

--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -148,7 +148,9 @@ impl Http {
         let container_id = {
             match create_result {
                 Ok(container) => container.id,
-                Err(bollard::errors::Error::DockerResponseServerError { status_code: 404, .. }) => {
+                Err(bollard::errors::Error::DockerResponseServerError {
+                    status_code: 404, ..
+                }) => {
                     {
                         let pull_options = Some(CreateImageOptions {
                             from_image: image.descriptor(),


### PR DESCRIPTION
Fix compilation errors encountered when running `cargo build --all-features`. 

Fixes #397 (see issue for more details on the encountered errors).