### PR TITLE
Fix nightly lints

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -204,7 +204,7 @@ impl Client {
         }
 
         let mut docker = self.command();
-        docker.args(&["network", "create", name]);
+        docker.args(["network", "create", name]);
 
         let output = docker.output().expect("failed to create docker network");
         assert!(output.status.success(), "failed to create docker network");
@@ -214,7 +214,7 @@ impl Client {
 
     fn network_exists(&self, name: &str) -> bool {
         let mut docker = self.command();
-        docker.args(&["network", "ls", "--format", "{{.Name}}"]);
+        docker.args(["network", "ls", "--format", "{{.Name}}"]);
 
         let output = docker.output().expect("failed to list docker networks");
         let output = String::from_utf8(output.stdout).expect("output is not valid utf-8");
@@ -228,7 +228,7 @@ impl Client {
         S: AsRef<OsStr>,
     {
         let mut docker = self.command();
-        docker.args(&["network", "rm"]);
+        docker.args(["network", "rm"]);
         docker.args(networks);
 
         let output = docker.output().expect("failed to delete docker networks");


### PR DESCRIPTION
Fix
```
error: the borrowed expression implements the required traits
   --> testcontainers/src/clients/cli.rs:207:21
    |
207 |         docker.args(&["network", "create", name]);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["network", "create", name]`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
   --> testcontainers/src/clients/cli.rs:217:21
    |
217 |         docker.args(&["network", "ls", "--format", "{{.Name}}"]);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["network", "ls", "--format", "{{.Name}}"]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
   --> testcontainers/src/clients/cli.rs:231:21
    |
231 |         docker.args(&["network", "rm"]);
    |                     ^^^^^^^^^^^^^^^^^^ help: change this to: `["network", "rm"]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

```