### PR TITLE
Support "logs since" for Docker Cli

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -14,6 +14,7 @@ description = "A library for integration-testing against docker containers from 
 async-trait = { version = "0.1", optional = true }
 bollard = { version = "0.13.0", optional = true }
 bollard-stubs = "=1.42.0-rc.3"
+chrono = { version = "0.4", features = ["alloc", "std"] }
 conquer-once = { version = "0.3", optional = true }
 futures = "0.3"
 hex = "0.4"

--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -24,7 +24,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> Container<'_, I> {
+    pub fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> Container<I> {
         let image = image.into();
 
         if let Some(network) = image.network() {

--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -47,7 +47,7 @@ impl Default for Http {
 
 // public API
 impl Http {
-    pub async fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> ContainerAsync<'_, I> {
+    pub async fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> ContainerAsync<I> {
         let image = image.into();
         let mut create_options: Option<CreateContainerOptions<String>> = None;
         let mut config: Config<String> = Config {

--- a/testcontainers/src/core/container.rs
+++ b/testcontainers/src/core/container.rs
@@ -3,7 +3,7 @@ use crate::{
     Image, RunnableImage,
 };
 use bollard_stubs::models::ContainerInspectResponse;
-use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
+use std::{fmt, net::IpAddr, str::FromStr};
 
 /// Represents a running docker container.
 ///
@@ -23,19 +23,16 @@ use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
 /// }
 ///
 /// ```
-///
 /// [drop_impl]: struct.Container.html#impl-Drop
-pub struct Container<'d, I: Image> {
+pub struct Container<I: Image> {
     id: String,
     docker_client: Box<dyn Docker>,
     image: RunnableImage<I>,
     command: Command,
     ports: Ports,
-    /// Tracks the lifetime of the client to make sure the container is dropped before the client.
-    client_lifetime: PhantomData<&'d ()>,
 }
 
-impl<'d, I> fmt::Debug for Container<'d, I>
+impl<I> fmt::Debug for Container<I>
 where
     I: fmt::Debug + Image,
 {
@@ -48,7 +45,7 @@ where
     }
 }
 
-impl<'d, I> Container<'d, I>
+impl<I> Container<I>
 where
     I: Image,
 {
@@ -70,7 +67,6 @@ where
             image,
             command,
             ports,
-            client_lifetime: PhantomData,
         }
     }
 
@@ -96,7 +92,7 @@ where
     }
 }
 
-impl<'d, I> Container<'d, I>
+impl<I> Container<I>
 where
     I: Image,
 {
@@ -219,7 +215,7 @@ where
 ///
 /// Setting it to `keep` will stop container.
 /// Setting it to `remove` will remove it.
-impl<'d, I> Drop for Container<'d, I>
+impl<I> Drop for Container<I>
 where
     I: Image,
 {
@@ -257,7 +253,7 @@ mod test {
 
     #[test]
     fn container_should_be_send_and_sync() {
-        assert_send_and_sync::<Container<'_, HelloWorld>>();
+        assert_send_and_sync::<Container<HelloWorld>>();
     }
 
     fn assert_send_and_sync<T: Send + Sync>() {}

--- a/testcontainers/src/core/container_async.rs
+++ b/testcontainers/src/core/container_async.rs
@@ -5,7 +5,7 @@ use crate::{
 use async_trait::async_trait;
 use bollard::models::{ContainerInspectResponse, HealthStatusEnum};
 use futures::{executor::block_on, FutureExt};
-use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr, time::Duration};
+use std::{fmt, net::IpAddr, str::FromStr, time::Duration};
 use tokio::time::sleep;
 
 /// Represents a running docker container that has been started using an async client..
@@ -31,17 +31,14 @@ use tokio::time::sleep;
 /// ```
 ///
 /// [drop_impl]: struct.ContainerAsync.html#impl-Drop
-pub struct ContainerAsync<'d, I: Image> {
+pub struct ContainerAsync<I: Image> {
     id: String,
     docker_client: Box<dyn DockerAsync>,
     image: RunnableImage<I>,
     command: Command,
-
-    /// Tracks the lifetime of the client to make sure the container is dropped before the client.
-    client_lifetime: PhantomData<&'d ()>,
 }
 
-impl<'d, I> ContainerAsync<'d, I>
+impl<I> ContainerAsync<I>
 where
     I: Image,
 {
@@ -162,7 +159,7 @@ where
     }
 }
 
-impl<'d, I> fmt::Debug for ContainerAsync<'d, I>
+impl<I> fmt::Debug for ContainerAsync<I>
 where
     I: fmt::Debug + Image,
 {
@@ -192,7 +189,7 @@ where
     async fn start(&self, id: &str);
 }
 
-impl<'d, I> ContainerAsync<'d, I>
+impl<I> ContainerAsync<I>
 where
     I: Image,
 {
@@ -203,13 +200,12 @@ where
         docker_client: impl DockerAsync + 'static,
         image: RunnableImage<I>,
         command: env::Command,
-    ) -> ContainerAsync<'d, I> {
+    ) -> ContainerAsync<I> {
         let container = ContainerAsync {
             id,
             docker_client: Box::new(docker_client),
             image,
             command,
-            client_lifetime: PhantomData,
         };
 
         container.block_until_ready().await;
@@ -268,7 +264,7 @@ where
     }
 }
 
-impl<'d, I> Drop for ContainerAsync<'d, I>
+impl<I> Drop for ContainerAsync<I>
 where
     I: Image,
 {

--- a/testcontainers/src/core/container_async.rs
+++ b/testcontainers/src/core/container_async.rs
@@ -257,6 +257,7 @@ where
                     panic!("Healthcheck for the container is not configured");
                 },
                 WaitFor::Nothing => {}
+                _ => unimplemented!("WaitFor since not yet supported for async container"),
             }
         }
 

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeMap, env::var, fmt::Debug, time::Duration};
 
+use chrono::{DateTime, FixedOffset};
+
 use super::ports::Ports;
 
 /// Represents a docker image.
@@ -329,8 +331,18 @@ pub enum WaitFor {
     Nothing,
     /// Wait for a message on the stdout stream of the container's logs.
     StdOutMessage { message: String },
+    /// Wait for a message on the stdout stream of the container's logs older than `since`.
+    StdOutMessageSince {
+        message: String,
+        since: DateTime<FixedOffset>,
+    },
     /// Wait for a message on the stderr stream of the container's logs.
     StdErrMessage { message: String },
+    /// Wait for a message on the stderr stream of the container's logs older than `since.
+    StdErrMessageSince {
+        message: String,
+        since: DateTime<FixedOffset>,
+    },
     /// Wait for a certain amount of time.
     Duration { length: Duration },
     /// Wait for the container's status to become `healthy`.
@@ -344,9 +356,29 @@ impl WaitFor {
         }
     }
 
+    pub fn message_on_stdout_since<S: Into<String>>(
+        message: S,
+        since: DateTime<FixedOffset>,
+    ) -> WaitFor {
+        WaitFor::StdOutMessageSince {
+            message: message.into(),
+            since,
+        }
+    }
+
     pub fn message_on_stderr<S: Into<String>>(message: S) -> WaitFor {
         WaitFor::StdErrMessage {
             message: message.into(),
+        }
+    }
+
+    pub fn message_on_stderr_since<S: Into<String>>(
+        message: S,
+        since: DateTime<FixedOffset>,
+    ) -> WaitFor {
+        WaitFor::StdErrMessageSince {
+            message: message.into(),
+            since,
         }
     }
 


### PR DESCRIPTION
This PR extends the Docker trait by the following functions:

- `stdout_logs_since`
- `stderr_logs_since`
- `exec_no_spawn`

The main use case is to allow reading docker logs starting at a given time. The time is provided via `chrono::DateTime<FixedOffset>` to avoid formatting and timezone issues.

*It is the responsibility of the respective container implementation to provide a way to get the current container time, since this varies depending on the image*

Note that there is currently only the `Cli` implementation supported, support for the Http client will be added at a later point in time.