### PR TITLE
Expose a ctor for Http client to accept custom bollard Docker client.

### DIFF
--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for Http {
 
 impl Default for Http {
     fn default() -> Self {
-        Self::new()
+        Self::new(Docker::connect_with_http_defaults().unwrap())
     }
 }
 
@@ -200,11 +200,11 @@ impl Http {
 }
 
 impl Http {
-    fn new() -> Self {
+    pub fn new(bollard: Docker) -> Self {
         Http {
             inner: Arc::new(Client {
                 command: env::command::<env::Os>().unwrap_or_default(),
-                bollard: Docker::connect_with_http_defaults().unwrap(),
+                bollard,
                 created_networks: RwLock::new(Vec::new()),
             }),
         }


### PR DESCRIPTION
I know it's an edge-case, but OSX folks using Podman  4.x can't currently use the CLI, due to `inspect` differences.

Using the HTTP API works perfectly (and is async, yay).  But it also is a non-default usage of Bollard.

By providing a way to customize the Bollard Docker client being used, this patch allows me to use a random, non-standard, OSX/m1->QEMU->podman stack with success.