### PR TITLE
Replace rusoto with aws-sdk-rust in tests

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -32,6 +32,12 @@ watchdog = [ "signal-hook", "conquer-once" ]
 experimental = [ "async-trait", "bollard", "tokio" ]
 
 [dev-dependencies]
+aws-config = "0.49.0"
+aws-sdk-dynamodb = "0.19.0"
+aws-sdk-s3 = "0.19.0"
+aws-sdk-sqs = "0.19.0"
+aws-smithy-http = "0.49.0"
+aws-types = "0.49.0"
 bitcoincore-rpc = "0.16"
 json = "0.12"
 lapin = "1.8.0"
@@ -42,11 +48,6 @@ pretty_env_logger = "0.4"
 rdkafka = "0.28"
 redis = "0.21"
 reqwest = { version = "0.11", features = [ "blocking" ] }
-rusoto_core = "0.47"
-rusoto_credential = "0.47"
-rusoto_dynamodb = "0.47"
-rusoto_s3 = "0.47"
-rusoto_sqs = "0.47"
 spectral = "0.6"
 testimages = { path = "../testimages" }
 tokio = { version = "1", features = [ "macros" ] }

--- a/testcontainers/tests/dynamodb_local.rs
+++ b/testcontainers/tests/dynamodb_local.rs
@@ -1,0 +1,68 @@
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_dynamodb::{
+    model::{
+        AttributeDefinition, KeySchemaElement, KeyType, ProvisionedThroughput, ScalarAttributeType,
+    },
+    Client, Endpoint,
+};
+use aws_types::Credentials;
+use spectral::prelude::*;
+use testcontainers::*;
+
+#[tokio::test]
+async fn dynamodb_local_create_table() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::dynamodb_local::DynamoDb::default());
+    let host_port = node.get_host_port_ipv4(8000);
+
+    let table_name = "books".to_string();
+
+    let key_schema = KeySchemaElement::builder()
+        .attribute_name("title".to_string())
+        .key_type(KeyType::Hash)
+        .build();
+
+    let attribute_def = AttributeDefinition::builder()
+        .attribute_name("title".to_string())
+        .attribute_type(ScalarAttributeType::S)
+        .build();
+
+    let provisioned_throughput = ProvisionedThroughput::builder()
+        .read_capacity_units(10)
+        .write_capacity_units(5)
+        .build();
+
+    let dynamodb = build_dynamodb_client(host_port).await;
+    let create_table_result = dynamodb
+        .create_table()
+        .table_name(table_name)
+        .key_schema(key_schema)
+        .attribute_definitions(attribute_def)
+        .provisioned_throughput(provisioned_throughput)
+        .send()
+        .await;
+    assert_that(&create_table_result).is_ok();
+
+    let req = dynamodb.list_tables().limit(10);
+    let list_tables_result = req.send().await.unwrap();
+
+    assert_eq!(list_tables_result.table_names().unwrap().len(), 1);
+}
+
+async fn build_dynamodb_client(host_port: u16) -> Client {
+    let endpoint_uri = format!("http://127.0.0.1:{}", host_port);
+    let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
+    let creds = Credentials::new("fakeKey", "fakeSecret", None, None, "test");
+
+    let shared_config = aws_config::from_env()
+        .region(region_provider)
+        .endpoint_resolver(Endpoint::immutable(
+            endpoint_uri.parse().expect("valid URI"),
+        ))
+        .credentials_provider(creds)
+        .load()
+        .await;
+
+    Client::new(&shared_config)
+}

--- a/testcontainers/tests/elasticmq.rs
+++ b/testcontainers/tests/elasticmq.rs
@@ -1,0 +1,32 @@
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_sqs::{Client, Endpoint};
+use aws_types::Credentials;
+use testcontainers::*;
+
+#[tokio::test]
+async fn sqs_list_queues() {
+    let docker = clients::Cli::default();
+    let node = docker.run(images::elasticmq::ElasticMq::default());
+    let host_port = node.get_host_port_ipv4(9324);
+    let client = build_sqs_client(host_port).await;
+
+    let result = client.list_queues().send().await.unwrap();
+    assert!(result.queue_urls.is_none());
+}
+
+async fn build_sqs_client(host_port: u16) -> Client {
+    let endpoint_uri = format!("http://127.0.0.1:{}", host_port);
+    let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
+    let creds = Credentials::new("fakeKey", "fakeSecret", None, None, "test");
+
+    let shared_config = aws_config::from_env()
+        .region(region_provider)
+        .endpoint_resolver(Endpoint::immutable(
+            endpoint_uri.parse().expect("valid URI"),
+        ))
+        .credentials_provider(creds)
+        .load()
+        .await;
+
+    Client::new(&shared_config)
+}

--- a/testcontainers/tests/minio.rs
+++ b/testcontainers/tests/minio.rs
@@ -1,0 +1,52 @@
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_s3::{Client, Endpoint};
+use aws_types::Credentials;
+use testcontainers::*;
+
+#[tokio::test]
+async fn minio_buckets() {
+    let docker = clients::Cli::default();
+    let minio = images::minio::MinIO::default();
+    let node = docker.run(minio);
+
+    let host_port = node.get_host_port_ipv4(9000);
+
+    let client = build_s3_client(host_port).await;
+
+    let bucket_name = "test-bucket";
+
+    client
+        .create_bucket()
+        .bucket(bucket_name)
+        .send()
+        .await
+        .expect("Failed to create test bucket");
+
+    let buckets = client
+        .list_buckets()
+        .send()
+        .await
+        .expect("Failed to get list of buckets")
+        .buckets
+        .unwrap();
+    assert_eq!(1, buckets.len());
+    assert_eq!(bucket_name, buckets[0].name.as_ref().unwrap());
+}
+
+async fn build_s3_client(host_port: u16) -> Client {
+    let endpoint_uri = format!("http://127.0.0.1:{}", host_port);
+    let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
+    let creds = Credentials::new("minioadmin", "minioadmin", None, None, "test");
+
+    // Default MinIO credentials (Can be overridden by ENV container variables)
+    let shared_config = aws_config::from_env()
+        .region(region_provider)
+        .endpoint_resolver(Endpoint::immutable(
+            endpoint_uri.parse().expect("valid URI"),
+        ))
+        .credentials_provider(creds)
+        .load()
+        .await;
+
+    Client::new(&shared_config)
+}


### PR DESCRIPTION
This PR removes [Rusoto](https://github.com/rusoto/rusoto), which is currently in maintenance mode, from the Integration test examples and replaces it with [aws-sdk-rust](https://github.com/awslabs/aws-sdk-rust). The AWS Rust SDK is still in developer preview but is [tracking to GA](https://github.com/awslabs/smithy-rs/milestone/11) and has more recent active downloads than Rusoto.

Includes:
- removes `rusoto` in favour of `aws-sdk-rust`
- refactored integration tests for DynamoDB, SQS and S3 SDK clients
- separated test files for `MinIO`, `ElasticMQ` and `DynamoDB Local`