### PR TITLE
Provide docker remote api with docker-in-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,13 @@ jobs:
       - name: Enable Docker Remote API on Localhost
         shell: bash
         run: |
-          sudo sed -i \
-            's#ExecStart=/usr/bin/dockerd#ExecStart=/usr/bin/dockerd -H tcp://127.0.0.1:2375#g' \
-            /lib/systemd/system/docker.service
-          sudo systemctl daemon-reload
-          sudo systemctl restart docker
+          docker run -d \
+            --privileged \
+            --publish 127.0.0.1:2375:2375 \
+            --entrypoint dockerd \
+            docker:20.10-dind \
+              --host=tcp://0.0.0.0:2375 \
+              --tls=false
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -75,4 +77,4 @@ jobs:
           override: true
           components: clippy
       - uses: Swatinem/rust-cache@v2.0.0
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-features --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
           - test --all-features
           - test --no-default-features
     steps:
+      - name: Enable Docker Remote API on Localhost
+        shell: bash
+        run: |
+          sudo sed -i \
+            's#ExecStart=/usr/bin/dockerd#ExecStart=/usr/bin/dockerd -H tcp://127.0.0.1:2375#g' \
+            /lib/systemd/system/docker.service
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         id: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,20 @@
 name: Continuous Integration
+
 on:
   pull_request:
   push:
     branches: [master, dev, trying, staging]
+
 jobs:
   msrv:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cargo-cmd:
+          - build
+          - build --all-features
+          - build --no-default-features
     steps:
       - uses: actions/checkout@v3
       - name: Get current MSRV from Cargo.toml
@@ -20,7 +29,8 @@ jobs:
           toolchain: ${{steps.current_msrv.outputs.msrv}}
           override: true
       - uses: Swatinem/rust-cache@v2.0.0
-      - run: cargo build
+      - run: cargo ${{ matrix['cargo-cmd'] }}
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dprint/check@v2.1
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         cargo-cmd:
-          - build
           - build --all-features
           - build --no-default-features
     steps:
@@ -37,7 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         cargo-cmd:
-          - test
           - test --all-features
           - test --no-default-features
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,13 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cargo-cmd:
+          - test
+          - test --all-features
+          - test --no-default-features
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -42,7 +49,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2.0.0
-      - run: cargo test
+      - run: cargo ${{ matrix['cargo-cmd'] }}
+
   style:
     runs-on: ubuntu-latest
     steps:

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,6 @@
 status = [
-    "msrv (build)",
     "msrv (build --all-features)",
     "msrv (build --no-default-features)",
-    "test (test)",
     "test (test --all-features)",
     "test (test --no-default-features)",
     "style",

--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,10 @@
-status = ["msrv", "test", "style", "lint"]
+status = [
+    "msrv (build)",
+    "msrv (build --all-features)",
+    "msrv (build --no-default-features)",
+    "test (test)",
+    "test (test --all-features)",
+    "test (test --no-default-features)",
+    "style",
+    "lint",
+]


### PR DESCRIPTION
This is an alternative approach to #403, running the test suite against a Docker Remote API in CI using Docker-in-Docker.

Unfortunately this approach leads to some tests failing.