### PR TITLE
Log error when starting a container fails

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -44,8 +44,13 @@ impl Cli {
         log::debug!("Executing command: {:?}", command);
 
         let output = command.output().expect("Failed to execute docker command");
+        if !output.status.success() {
+            let stdout = std::str::from_utf8(&output.stdout).unwrap_or("{not utf8}");
+            let stderr = std::str::from_utf8(&output.stderr).unwrap_or("{not utf8}");
+            log::error!("Failed to start container.\nContainer stdout: {stdout}\nContainer stderr: {stderr}");
+            panic!("Failed to start container, check log for details")
+        }
 
-        assert!(output.status.success(), "failed to start container");
         let container_id = String::from_utf8(output.stdout)
             .expect("output is not valid utf8")
             .trim()


### PR DESCRIPTION
When container fails to start all you get is `failed to start container` message, and it's not always easy to guess why it failed. This PR includes command output in panic message.

Example:

`dev`:
> ```thread '<unnamed>' panicked at 'failed to start container'```

PR:
> ```thread '<unnamed>' panicked at 'failed to start container, output = Output { status:  ExitStatus(unix_wait_status(32000)), stdout: "e5866b9407496bc9a88b63528370de91ec43358a6a40e1262fb3cae9dd3a8ec1\n", stderr: "docker: Error response from daemon: driver failed programming external connectivity on endpoint dazzling_elbakyan (85503e92065801ce10c86a95ba9af00c53e0e9a3ec4eb0ad78e55e306fbf8434): Bind for 0.0.0.0:13306 failed: port is already allocated.\n" }'```