### PR TITLE
support for running with dragonfly - modern replacement for redis

### DIFF
--- a/testcontainers/src/images.rs
+++ b/testcontainers/src/images.rs
@@ -1,4 +1,5 @@
 pub mod coblox_bitcoincore;
+pub mod dragonfly;
 pub mod dynamodb_local;
 pub mod elastic_search;
 pub mod elasticmq;

--- a/testcontainers/src/images/dragonfly.rs
+++ b/testcontainers/src/images/dragonfly.rs
@@ -1,0 +1,38 @@
+use crate::{core::WaitFor, Image, ImageArgs};
+
+const NAME: &str = "docker.dragonflydb.io/dragonflydb/dragonfly";
+const TAG: &str = "latest";
+
+#[derive(Debug, Default)]
+pub struct Dragonfly;
+
+impl Image for Dragonfly {
+    type Args = DragonflyArgs;
+
+    fn name(&self) -> String {
+        NAME.to_owned()
+    }
+
+    fn tag(&self) -> String {
+        TAG.to_owned()
+    }
+
+    fn ready_conditions(&self) -> Vec<WaitFor> {
+        vec![WaitFor::message_on_stderr(
+            "AcceptServer - listening on port",
+        )]
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DragonflyArgs {}
+
+impl ImageArgs for DragonflyArgs {
+    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
+        let args = vec![
+            "--alsologtostderr".to_owned(),
+            "--logbuflevel=-1".to_owned(),
+        ];
+        Box::new(args.into_iter())
+    }
+}

--- a/testcontainers/tests/images.rs
+++ b/testcontainers/tests/images.rs
@@ -153,6 +153,21 @@ fn redis_fetch_an_integer() {
     assert_eq!(42, result);
 }
 
+#[test]
+fn dragonfly_fetch_an_integer() {
+    let _ = pretty_env_logger::try_init();
+    let docker = clients::Cli::default();
+    let node = docker.run(images::dragonfly::Dragonfly::default());
+    let host_port = node.get_host_port_ipv4(6379);
+    let url = format!("redis://127.0.0.1:{}", host_port);
+    let client = redis::Client::open(url.as_ref()).unwrap();
+    let mut con = client.get_connection().unwrap();
+
+    con.set::<_, _, ()>("my_key", 42).unwrap();
+    let result: i64 = con.get("my_key").unwrap();
+    assert_eq!(42, result);
+}
+
 #[tokio::test]
 async fn mongo_fetch_document() {
     let _ = pretty_env_logger::try_init();


### PR DESCRIPTION
This will add support for Dragonfly - see [dragonfly github](https://github.com/dragonflydb/dragonfly).
There is no requirement to add external dependencies as this uses the same Rust client code to connect.
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>