### PR TITLE
feat!: make `Container::exec` synchronous and return output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- `Container::exec` changed to be synchronous and return `ExecOutput`
+
 ## [0.14.0] - 2022-05-30
 
 ### Added

--- a/testcontainers/src/core/container.rs
+++ b/testcontainers/src/core/container.rs
@@ -3,6 +3,7 @@ use crate::{
     Image, RunnableImage,
 };
 use bollard_stubs::models::ContainerInspectResponse;
+
 use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
 
 /// Represents a running docker container.
@@ -182,7 +183,7 @@ where
         .unwrap_or_else(|_| panic!("container {} has missing or invalid bridge IP", self.id))
     }
 
-    pub fn exec(&self, cmd: ExecCommand) {
+    pub fn exec(&self, cmd: ExecCommand) -> ExecOutput {
         let ExecCommand {
             cmd,
             ready_conditions,
@@ -190,10 +191,15 @@ where
 
         log::debug!("Executing command {:?}", cmd);
 
-        self.docker_client.exec(self.id(), cmd);
+        let output = self.docker_client.exec(self.id(), cmd);
 
         self.docker_client
             .block_until_ready(self.id(), ready_conditions);
+
+        ExecOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+        }
     }
 
     pub fn stop(&self) {
@@ -211,6 +217,14 @@ where
 
         self.docker_client.rm(&self.id)
     }
+}
+
+/// Represents an output of `exec` command.
+/// `stdout` & `stderr` is represented as bytes because it might contain non-utf chars and responsibility should be on the caller end.
+#[derive(Debug)]
+pub struct ExecOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
 }
 
 /// The destructor implementation for a Container.
@@ -245,7 +259,7 @@ pub(crate) trait Docker: Sync + Send {
     fn rm(&self, id: &str);
     fn stop(&self, id: &str);
     fn start(&self, id: &str);
-    fn exec(&self, id: &str, cmd: String);
+    fn exec(&self, id: &str, cmd: String) -> std::process::Output;
     fn block_until_ready(&self, id: &str, ready_conditions: Vec<WaitFor>);
 }
 

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -97,7 +97,9 @@ where
 
 #[derive(Default, Debug)]
 pub struct ExecCommand {
+    /// Command to be executed
     pub cmd: String,
+    /// Conditions to be checked on related container
     pub ready_conditions: Vec<WaitFor>,
 }
 


### PR DESCRIPTION
Closes #344

Remove of `-d` argument for `Container::exec` to ensure command has finished.
It's extremely useful when you need to ensure that command was executed as expected, but container logs can't tell this.

It also now returns output of command.

Any comments are welcome, that's quite straightforward way to implement it.