### PR TITLE
Add dump command to allow container logs dumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `dump` value for the TESTCONTAINERS environment variable. With this setting, all container logs will be dumped into a ./testcontainers directory.
+
 ## [0.14.0] - 2022-05-30
 
 ### Added

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -14,7 +14,7 @@ description = "A library for integration-testing against docker containers from 
 async-trait = { version = "0.1", optional = true }
 bollard = { version = "0.13.0", optional = true }
 bollard-stubs = "=1.42.0-rc.3"
-conquer-once = { version = "0.3", optional = true }
+conquer-once = { version = "0.3" }
 futures = "0.3"
 hex = "0.4"
 hmac = "0.12"
@@ -29,7 +29,7 @@ tokio = { version = "1", features = [ "macros" ], optional = true }
 
 [features]
 default = [ ]
-watchdog = [ "signal-hook", "conquer-once" ]
+watchdog = [ "signal-hook" ]
 experimental = [ "async-trait", "bollard", "tokio" ]
 
 [dev-dependencies]

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sha2 = "0.10"
 signal-hook = { version = "0.3", optional = true }
+time = { version = "0.3.17", features = [ "formatting" ] }
 tokio = { version = "1", features = [ "macros" ], optional = true }
 
 [features]

--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -457,7 +457,7 @@ impl Drop for Client {
             env::Command::Remove if created_networks => {
                 self.delete_networks(networks.iter());
             }
-            env::Command::Remove => {
+            env::Command::Remove | env::Command::Dump => {
                 // nothing to do
             }
             env::Command::Keep => {

--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -264,7 +264,7 @@ async fn network_exists(client: &Docker, network: &str) -> bool {
 impl Drop for Client {
     fn drop(&mut self) {
         match self.command {
-            env::Command::Remove => {
+            env::Command::Remove | env::Command::Dump => {
                 let guard = self.created_networks.read().expect("failed to lock RwLock");
                 for network in guard.iter() {
                     block_on(async { self.bollard.remove_network(network).await.unwrap() });

--- a/testcontainers/src/core/container.rs
+++ b/testcontainers/src/core/container.rs
@@ -290,7 +290,13 @@ where
         .image
         .container_name()
         .to_owned()
-        .unwrap_or(container.image.inner().name());
+        .unwrap_or_else(|| {
+            format!(
+                "{}_{}",
+                container.image.inner().name(),
+                &container.id()[..12]
+            )
+        });
 
     get_log_dump_file_path(log_dump_dir, &container_name, stdtype)
 }

--- a/testcontainers/src/core/container.rs
+++ b/testcontainers/src/core/container.rs
@@ -247,7 +247,9 @@ where
             Command::Remove => self.rm(),
             Command::Dump => {
                 self.stop();
-                dump_logs(self).expect("Failed to dump logs to file");
+                if let Err(error) = dump_logs(self) {
+                    log::warn!("failed to dump logs to disk - {}", error);
+                }
                 self.rm()
             }
         }

--- a/testcontainers/src/core/container_async.rs
+++ b/testcontainers/src/core/container_async.rs
@@ -178,7 +178,9 @@ where
             env::Command::Remove => self.docker_client.rm(&self.id).await,
             env::Command::Dump => {
                 self.docker_client.stop(&self.id).await;
-                dump_logs(self).await.expect("Failed to dump logs to file");
+                if let Err(error) = dump_logs(self).await {
+                    log::warn!("failed to dump logs to disk - {}", error);
+                }
                 self.docker_client.rm(&self.id).await;
             }
             env::Command::Keep => {}

--- a/testcontainers/src/core/container_async.rs
+++ b/testcontainers/src/core/container_async.rs
@@ -347,7 +347,13 @@ where
         .image
         .container_name()
         .to_owned()
-        .unwrap_or(container.image.inner().name());
+        .unwrap_or_else(|| {
+            format!(
+                "{}_{}",
+                container.image.inner().name(),
+                &container.id()[..12]
+            )
+        });
 
     get_log_dump_file_path(log_dump_dir, &container_name, stdtype)
 }

--- a/testcontainers/src/core/env.rs
+++ b/testcontainers/src/core/env.rs
@@ -36,6 +36,7 @@ impl GetEnvValue for Os {
 pub enum Command {
     Keep,
     Remove,
+    Dump,
 }
 
 impl FromStr for Command {
@@ -45,6 +46,7 @@ impl FromStr for Command {
         match s {
             "keep" => Ok(Command::Keep),
             "remove" => Ok(Command::Remove),
+            "dump" => Ok(Command::Dump),
             other => panic!(
                 "unknown command '{}' provided via TESTCONTAINERS env variable",
                 other

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -65,6 +65,10 @@ impl LogStream {
 
         Err(end_of_stream(lines))
     }
+
+    pub fn into_inner(self) -> Box<dyn Read> {
+        self.inner
+    }
 }
 
 fn handle_line(line: String, message: &str, lines: &mut Vec<String>) -> bool {

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -142,7 +142,10 @@ pub(crate) fn get_log_dump_file_path(
     container_name: &str,
     stdtype: &str,
 ) -> PathBuf {
-    let log_file_name = format!("{container_name}_{stdtype}.log");
+    // handle container names with a "/" in them, for example image names with
+    // a namespace: minio/minio
+    let safe_container_name = container_name.replace("/", "_");
+    let log_file_name = format!("{safe_container_name}_{stdtype}.log");
 
     log_dump_dir.join(log_file_name)
 }


### PR DESCRIPTION
A common use case in integration tests development and debugging is inspecting created container logs. 
Currently the way to do so is to run the tests using the "keep" command and inspect the logs afterwards. This isn't a good fit for CI testing environment, and might not be ideal for local development as well.

This PR adds a new "dump" command that removes the containers just like "remove" but will dump container logs into a "./testcontainers" directory.

The logs filename is `{container_name/image_name}_{stdout/stderr}_{current date in ISO format}.log`

usage example: `TESTCONTAINERS=dump cargo test`