### PR TITLE
Switch to GH merge queue from bors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: Continuous Integration
 
 on:
   pull_request:
+  merge_group:
   push:
-    branches: [master, dev, trying, staging]
+    branches: [master, dev]
 
 jobs:
   msrv:

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,0 @@
-status = [
-    "msrv (build --all-features)",
-    "msrv (build --no-default-features)",
-    "test (test --all-features)",
-    "test (test --no-default-features)",
-    "style",
-    "lint",
-]


### PR DESCRIPTION
The public bors instance is going away and GitHub now has a merge-queue feature in public beta.