### PR TITLE
Enhance: support mapping port to specified host ip:port

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -180,7 +180,7 @@ impl Client {
             for port in ports {
                 command
                     .arg("-p")
-                    .arg(format!("{}:{}", port.local, port.internal));
+                    .arg(port.to_string());
             }
         } else if !is_container_networked {
             for port in image.expose_ports() {


### PR DESCRIPTION
Support to build run command with args like `-p 127.0.0.1:8000:8000`, and make struct `Port` can be converted from `(SocketAddr, u16)`. 
e.g.
```rust
let localhost_8000 = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 8000);
some_runnable_image.with_mapped_port((localhost_8000 , 8000));
```