### PR TITLE
Bump MSRV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `Container::exec` changed to be synchronous and return `ExecOutput`
+- MSRV is now 1.63.
 
 ### Removed
 

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 keywords = [ "docker", "testcontainers" ]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/testcontainers/testcontainers-rs"
-rust-version = "1.60.0"
+rust-version = "1.63"
 description = "A library for integration-testing against docker containers from within Rust."
 
 [dependencies]


### PR DESCRIPTION
Bump MSRV to 1.61 due to CI failure: https://github.com/testcontainers/testcontainers-rs/actions/runs/6084515037/job/16507363360