### PR TITLE
docs: mention `testcontainers-modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Testcontainers-rs is the official Rust language fork of [http://testcontainers.o
 
 Check [the integration tests](./testcontainers/tests) on how to use the library.
 
+A set of ready-to-use images (aka modules) is available as a community-maintained crate: [testcontainers-modules](https://github.com/testcontainers/testcontainers-rs-modules-community)
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -11,12 +11,19 @@ Testcontainers-rs is the official Rust language fork of [http://testcontainers.o
 
 ## Usage
 
+### `testcontainers` is the core crate
+
+The crate provides an API for working with containers in a test environment.
+
 1. Depend on `testcontainers`
-2. Import `use testcontainers::*`.
+2. Implement `testcontainers::core::Image` for necessary docker-images
+3. Run it with any available client `testcontainers::clients::*`
 
-Check [the integration tests](./testcontainers/tests) on how to use the library.
+### Ready-to-use images
 
-A set of ready-to-use images (aka modules) is available as a community-maintained crate: [testcontainers-modules](https://github.com/testcontainers/testcontainers-rs-modules-community)
+The easiest way to use `testcontainers` is to depend on ready-to-use images (aka modules).
+
+Modules are available as a community-maintained crate: [testcontainers-modules](https://github.com/testcontainers/testcontainers-rs-modules-community)
 
 ## License
 

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -27,7 +27,8 @@
 //!
 //! # Ecosystem
 //!
-//! The testcontainers ecosystem is split into multiple crates, however, the `testcontainers` crate itself is a meta-crate, re-exporting the others. Usually, depending on `testcontainers` should be sufficient for most users needs.
+//! `testcontainers` is the core crate that provides an API for working with containers in a test environment.
+//!  However, it does not provide ready-to-use modules, you can implement your [`Image`]s using the library directly or use community supported [`testcontainers-modules`].
 //!
 //! [tc_website]: https://testcontainers.org
 //! [`Docker`]: https://docker.com
@@ -35,6 +36,7 @@
 //! [`Client`]: trait.Docker.html#implementors
 //! [`Images`]: trait.Image.html#implementors
 //! [`Container`]: struct.Container.html
+//! [`testcontainers-modules`]: https://crates.io/crates/testcontainers-modules
 pub use crate::core::{Container, Image, ImageArgs, RunnableImage};
 
 #[cfg(feature = "experimental")]


### PR DESCRIPTION
It would be nice to mention the new location of ready-to-use images, because of https://github.com/testcontainers/testcontainers-rs/issues/471

It will helpful for users once `0.15.0` is released.