### PR TITLE
chore(deps): remove `spectral` from `dev-dependencies`

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -34,6 +34,5 @@ experimental = [ "async-trait", "bollard", "tokio" ]
 [dev-dependencies]
 pretty_env_logger = "0.5"
 reqwest = { version = "0.11.14", features = [ "blocking" ] }
-spectral = "0.6.0"
 testimages = { path = "../testimages" }
 tokio = { version = "1", features = [ "macros" ] }

--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -473,7 +473,6 @@ impl Drop for Client {
 mod tests {
     use super::*;
     use crate::{core::WaitFor, images::generic::GenericImage, Image};
-    use spectral::prelude::*;
     use std::collections::BTreeMap;
 
     #[derive(Default)]
@@ -702,7 +701,14 @@ mod tests {
         docker.stdout_logs(container.id());
         let after_logs = Instant::now();
 
-        assert_that(&(after_run - before_run)).is_greater_than(Duration::from_secs(1));
-        assert_that(&(after_logs - before_logs)).is_less_than(Duration::from_secs(1));
+        const ONE_SEC: Duration = Duration::from_secs(1);
+        assert!(
+            (after_run - before_run) > ONE_SEC,
+            "run completed in less than a second"
+        );
+        assert!(
+            (after_logs - before_logs) < ONE_SEC,
+            "log fetching took more than a second"
+        );
     }
 }


### PR DESCRIPTION
`spectral` is outdated (last update >7 years ago), it causes warning:

```
the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
```

And actually there is no need in it