### PR TITLE
Added health-cmd definition

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -176,6 +176,10 @@ impl Client {
             command.arg("--entrypoint").arg(entrypoint);
         }
 
+        if let Some(health_cmd) = image.health_cmd() {
+            command.arg("--health-cmd").arg(health_cmd);
+        }
+
         let is_container_networked = image
             .network()
             .as_ref()

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -84,6 +84,11 @@ where
         Default::default()
     }
 
+    /// Returns the healtcheck cmd this instance was created with.
+    fn health_cmd(&self) -> Option<String> {
+        None
+    }
+
     /// Returns the commands that needs to be executed after a container is started i.e. commands
     /// to be run in a running container.
     ///
@@ -219,6 +224,10 @@ impl<I: Image> RunnableImage<I> {
 
     pub fn exec_after_start(&self, cs: ContainerState) -> Vec<ExecCommand> {
         self.image.exec_after_start(cs)
+    }
+
+    pub fn health_cmd(&self) -> Option<String> {
+        self.image.health_cmd()
     }
 }
 

--- a/testcontainers/src/images/generic.rs
+++ b/testcontainers/src/images/generic.rs
@@ -17,6 +17,7 @@ pub struct GenericImage {
     wait_for: Vec<WaitFor>,
     entrypoint: Option<String>,
     exposed_ports: Vec<u16>,
+    health_cmd: Option<String>,
 }
 
 impl Default for GenericImage {
@@ -29,6 +30,7 @@ impl Default for GenericImage {
             wait_for: Vec::new(),
             entrypoint: None,
             exposed_ports: Vec::new(),
+            health_cmd: None,
         }
     }
 }
@@ -66,6 +68,11 @@ impl GenericImage {
         self.exposed_ports.push(port);
         self
     }
+
+    pub fn with_health_cmd(mut self, cmd: &str) -> Self {
+        self.health_cmd = Some(cmd.to_string());
+        self
+    }
 }
 
 impl Image for GenericImage {
@@ -97,6 +104,10 @@ impl Image for GenericImage {
 
     fn expose_ports(&self) -> Vec<u16> {
         self.exposed_ports.clone()
+    }
+
+    fn health_cmd(&self) -> Option<String> {
+        self.health_cmd.clone()
     }
 }
 

--- a/testimages/src/dockerfiles/no_expose_port.dockerfile
+++ b/testimages/src/dockerfiles/no_expose_port.dockerfile
@@ -18,7 +18,7 @@ RUN cargo build -v --release --bin no_expose_port
 FROM debian:bullseye-slim AS runtime
 WORKDIR /app
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends openssl curl\
+    && apt-get install -y --no-install-recommends openssl \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/testimages/src/dockerfiles/no_expose_port.dockerfile
+++ b/testimages/src/dockerfiles/no_expose_port.dockerfile
@@ -18,7 +18,7 @@ RUN cargo build -v --release --bin no_expose_port
 FROM debian:bullseye-slim AS runtime
 WORKDIR /app
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends openssl \
+    && apt-get install -y --no-install-recommends openssl curl\
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/testimages/src/dockerfiles/simple_web_server.dockerfile
+++ b/testimages/src/dockerfiles/simple_web_server.dockerfile
@@ -18,7 +18,7 @@ RUN cargo build -v --release --bin simple_web_server
 FROM debian:bullseye-slim AS runtime
 WORKDIR /app
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends openssl \
+    && apt-get install -y --no-install-recommends openssl curl\
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
Hello! Thanks for the project, love it!

I have been working in [adding mysql image to the community modules](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/50) and the basic WaitFor checks on stderr output are not enough and using a duration is a bit flacky.

I noticed that there is no way to specify a `health-cmd` as part of the container arguments so I added it. Many docker images would benefit from custom healthchecks.

I had to include curl as dependency for one of the testing images that maybe you prefer to do in a different way. In any case let me know what you think.