### PR TITLE
More robust bollard interface for http client

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -25,11 +25,13 @@ serde_json = "1"
 sha2 = "0.10"
 signal-hook = { version = "0.3", optional = true }
 tokio = { version = "1", features = [ "macros" ], optional = true }
+url = { version = "2.4", optional = true }
 
 [features]
 default = [ ]
 watchdog = [ "signal-hook", "conquer-once" ]
-experimental = [ "async-trait", "bollard", "tokio" ]
+experimental = [ "async-trait", "bollard", "tokio", "url" ]
+ssl = [ "bollard/ssl" ]
 
 [dev-dependencies]
 pretty_env_logger = "0.5"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -12,7 +12,7 @@ description = "A library for integration-testing against docker containers from 
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-bollard = { version = "0.13.0", optional = true }
+bollard = { version = "0.13.0", features = [ "ssl" ], optional = true }
 bollard-stubs = "=1.42.0-rc.3"
 conquer-once = { version = "0.4", optional = true }
 futures = "0.3"
@@ -31,7 +31,6 @@ url = { version = "2.4", optional = true }
 default = [ ]
 watchdog = [ "signal-hook", "conquer-once" ]
 experimental = [ "async-trait", "bollard", "tokio", "url" ]
-ssl = [ "bollard/ssl" ]
 
 [dev-dependencies]
 pretty_env_logger = "0.5"


### PR DESCRIPTION
~~The experimental http client's `new` method is promoted to public which allows the user to select the appropriate inner bollard implementation for its docker client.  In the dev branch the experimental client can only talk to to daemons over tcp, but this can be easily widened.  This PR allows the experimental client to work both with local/remote docker daemons exposed as tcp endpoints, unix domain sockets or windows named pipes.~~

The experimental http client uses the DOCKER_HOST environment variable to choose the right bollard interface to talk to the docker http daemon (npipe, unix, tcp, tcp+tls). 