### PR TITLE
Remove Container lifetime

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -24,7 +24,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> Container<'_, I> {
+    pub fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> Container<I> {
         let image = image.into();
 
         if let Some(network) = image.network() {

--- a/testcontainers/src/clients/http.rs
+++ b/testcontainers/src/clients/http.rs
@@ -47,7 +47,7 @@ impl Default for Http {
 
 // public API
 impl Http {
-    pub async fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> ContainerAsync<'_, I> {
+    pub async fn run<I: Image>(&self, image: impl Into<RunnableImage<I>>) -> ContainerAsync<I> {
         let image = image.into();
         let mut create_options: Option<CreateContainerOptions<String>> = None;
         let mut config: Config<String> = Config {

--- a/testcontainers/src/core/container.rs
+++ b/testcontainers/src/core/container.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use bollard_stubs::models::ContainerInspectResponse;
 
-use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
+use std::{fmt, net::IpAddr, str::FromStr};
 
 /// Represents a running docker container.
 ///
@@ -26,17 +26,15 @@ use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr};
 /// ```
 ///
 /// [drop_impl]: struct.Container.html#impl-Drop
-pub struct Container<'d, I: Image> {
+pub struct Container<I: Image> {
     id: String,
     docker_client: Box<dyn Docker>,
     image: RunnableImage<I>,
     command: Command,
     ports: Ports,
-    /// Tracks the lifetime of the client to make sure the container is dropped before the client.
-    client_lifetime: PhantomData<&'d ()>,
 }
 
-impl<'d, I> fmt::Debug for Container<'d, I>
+impl<I> fmt::Debug for Container<I>
 where
     I: fmt::Debug + Image,
 {
@@ -49,7 +47,7 @@ where
     }
 }
 
-impl<'d, I> Container<'d, I>
+impl<I> Container<I>
 where
     I: Image,
 {
@@ -71,7 +69,6 @@ where
             image,
             command,
             ports,
-            client_lifetime: PhantomData,
         }
     }
 
@@ -97,7 +94,7 @@ where
     }
 }
 
-impl<'d, I> Container<'d, I>
+impl<I> Container<I>
 where
     I: Image,
 {
@@ -247,7 +244,7 @@ pub struct ExecOutput {
 ///
 /// Setting it to `keep` will stop container.
 /// Setting it to `remove` will remove it.
-impl<'d, I> Drop for Container<'d, I>
+impl<I> Drop for Container<I>
 where
     I: Image,
 {
@@ -302,7 +299,7 @@ mod test {
 
     #[test]
     fn container_should_be_send_and_sync() {
-        assert_send_and_sync::<Container<'_, HelloWorld>>();
+        assert_send_and_sync::<Container<HelloWorld>>();
     }
 
     fn assert_send_and_sync<T: Send + Sync>() {}

--- a/testcontainers/src/core/container_async.rs
+++ b/testcontainers/src/core/container_async.rs
@@ -5,7 +5,7 @@ use crate::{
 use async_trait::async_trait;
 use bollard::models::{ContainerInspectResponse, HealthStatusEnum};
 use futures::executor::block_on;
-use std::{fmt, marker::PhantomData, net::IpAddr, str::FromStr, time::Duration};
+use std::{fmt, net::IpAddr, str::FromStr, time::Duration};
 use tokio::time::sleep;
 
 /// Represents a running docker container that has been started using an async client..
@@ -31,17 +31,14 @@ use tokio::time::sleep;
 /// ```
 ///
 /// [drop_impl]: struct.ContainerAsync.html#impl-Drop
-pub struct ContainerAsync<'d, I: Image> {
+pub struct ContainerAsync<I: Image> {
     id: String,
     docker_client: Box<dyn DockerAsync>,
     image: RunnableImage<I>,
     command: Command,
-
-    /// Tracks the lifetime of the client to make sure the container is dropped before the client.
-    client_lifetime: PhantomData<&'d ()>,
 }
 
-impl<'d, I> ContainerAsync<'d, I>
+impl<I> ContainerAsync<I>
 where
     I: Image,
 {
@@ -171,7 +168,7 @@ where
     }
 }
 
-impl<'d, I> fmt::Debug for ContainerAsync<'d, I>
+impl<I> fmt::Debug for ContainerAsync<I>
 where
     I: fmt::Debug + Image,
 {
@@ -190,7 +187,7 @@ where
 #[async_trait]
 pub(crate) trait DockerAsync
 where
-    Self: Sync,
+    Self: Sync + Send,
 {
     fn stdout_logs(&self, id: &str) -> LogStreamAsync<'_>;
     fn stderr_logs(&self, id: &str) -> LogStreamAsync<'_>;
@@ -201,7 +198,7 @@ where
     async fn start(&self, id: &str);
 }
 
-impl<'d, I> ContainerAsync<'d, I>
+impl<I> ContainerAsync<I>
 where
     I: Image,
 {
@@ -212,13 +209,12 @@ where
         docker_client: impl DockerAsync + 'static,
         image: RunnableImage<I>,
         command: env::Command,
-    ) -> ContainerAsync<'d, I> {
+    ) -> ContainerAsync<I> {
         let container = ContainerAsync {
             id,
             docker_client: Box::new(docker_client),
             image,
             command,
-            client_lifetime: PhantomData,
         };
 
         container.block_until_ready().await;
@@ -277,7 +273,7 @@ where
     }
 }
 
-impl<'d, I> Drop for ContainerAsync<'d, I>
+impl<I> Drop for ContainerAsync<I>
 where
     I: Image,
 {


### PR DESCRIPTION
The lifetime on the `Container` struct is useless because the container owns the Cli, so Rust guarantees that the client cannot be dropped while the container is in scope.
This makes also the Container Send and Sync which can be useful in some complex test scenarios 