### PR TITLE
Fix race condition when creating docker network

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -212,7 +212,13 @@ impl Client {
         docker.args(["network", "create", name]);
 
         let output = docker.output().expect("failed to create docker network");
-        assert!(output.status.success(), "failed to create docker network");
+        if !output.status.success() {
+            // In case another thread creates this network after our first check.
+            if self.network_exists(name) {
+                return false;
+            }
+            panic!("failed to create docker network")
+        }
 
         true
     }


### PR DESCRIPTION
When multiple threads are starting containers with the same network, `docker network create` call often fails due to network already existing. I've added an extra check to fix that.

EDIT: Seems like I'm still getting errors, so I'm going to test it a bit more.