### PR TITLE
feat(cli): support for docker cli flag `--add-host`

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -1,5 +1,10 @@
 use crate::{
-    core::{env, env::GetEnvValue, logs::LogStream, ports::Ports, ContainerState, Docker, WaitFor},
+    core::{
+        env::{self, GetEnvValue},
+        logs::LogStream,
+        ports::Ports,
+        ContainerState, Docker, WaitFor,
+    },
     Container, Image, ImageArgs, RunnableImage,
 };
 use bollard_stubs::models::{ContainerInspectResponse, HealthStatusEnum};
@@ -166,6 +171,10 @@ impl Client {
 
         for (key, value) in image.env_vars() {
             command.arg("-e").arg(format!("{key}={value}"));
+        }
+
+        for (key, value) in image.hosts() {
+            command.arg("--add-host").arg(format!("{key}={value}"));
         }
 
         for (orig, dest) in image.volumes() {

--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -174,7 +174,7 @@ impl Client {
         }
 
         for (key, value) in image.hosts() {
-            command.arg("--add-host").arg(format!("{key}={value}"));
+            command.arg("--add-host").arg(format!("{key}:{value}"));
         }
 
         for (orig, dest) in image.volumes() {

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -4,7 +4,7 @@ pub(crate) use container_async::DockerAsync;
 
 pub use self::{
     container::Container,
-    image::{ContainerState, ExecCommand, Image, ImageArgs, Port, RunnableImage, WaitFor},
+    image::{ContainerState, ExecCommand, Host, Image, ImageArgs, Port, RunnableImage, WaitFor},
 };
 
 #[cfg(feature = "experimental")]

--- a/testcontainers/tests/cli_client.rs
+++ b/testcontainers/tests/cli_client.rs
@@ -3,6 +3,11 @@ use testcontainers::{
     *,
 };
 
+fn get_server_container(msg: Option<WaitFor>) -> GenericImage {
+    let msg = msg.unwrap_or(WaitFor::message_on_stdout("server is ready"));
+    GenericImage::new("simple_web_server", "latest").with_wait_for(msg)
+}
+
 #[derive(Debug, Default)]
 pub struct HelloWorld;
 
@@ -34,9 +39,7 @@ async fn cli_can_run_hello_world() {
 #[test]
 fn generic_image_with_custom_entrypoint() {
     let docker = clients::Cli::default();
-    let msg = WaitFor::message_on_stdout("server is ready");
-
-    let generic = GenericImage::new("simple_web_server", "latest").with_wait_for(msg.clone());
+    let generic = get_server_container(None);
 
     let node = docker.run(generic);
     let port = node.get_host_port_ipv4(80);
@@ -48,9 +51,7 @@ fn generic_image_with_custom_entrypoint() {
             .unwrap()
     );
 
-    let generic = GenericImage::new("simple_web_server", "latest")
-        .with_wait_for(msg)
-        .with_entrypoint("./bar");
+    let generic = get_server_container(None).with_entrypoint("./bar");
 
     let node = docker.run(generic);
     let port = node.get_host_port_ipv4(80);
@@ -87,9 +88,8 @@ fn generic_image_exposed_ports() {
 #[test]
 fn generic_image_running_with_extra_hosts_added() {
     let docker = clients::Cli::default();
-    let msg = WaitFor::message_on_stdout("server is ready");
 
-    let server_1 = GenericImage::new("simple_web_server", "latest").with_wait_for(msg.clone());
+    let server_1 = get_server_container(None);
     let node = docker.run(server_1);
     let port = node.get_host_port_ipv4(80);
 

--- a/testcontainers/tests/cli_client.rs
+++ b/testcontainers/tests/cli_client.rs
@@ -95,7 +95,7 @@ fn generic_image_running_with_extra_hosts_added() {
 
     let msg = WaitFor::message_on_stdout("foo");
     let server_2 = GenericImage::new("curlimages/curl", "latest")
-        .with_wait_for(msg.clone())
+        .with_wait_for(msg)
         .with_entrypoint("curl");
 
     // Override hosts for server_2 adding


### PR DESCRIPTION
When spawning multiple docker containers in the same test, communication amongst them can be achieved over the docker default gateway.

In DinD environments, such as when running jobs on a CI pipeline, the docker [`--add-host`](https://docs.docker.com/engine/reference/commandline/container_run/#option) can be employed to basically enter new entries in the `/etc/hosts` files. This allows to avoid binding all container ports to the host environment.

The flag API counterpart is implemented on the `RunnableImage` struct instead of on the generic image since I reckon it makes more sense within this crate phylosophy, I hope !-).

A test runs 2 containers:

- an http_server
- a `curl` client

and the `curl` client completes when receiving `foo` from the server on the alias hostname. In case the hostname wasn't resolve it'd panic.