### PR TITLE
feat: add `registry` and `owner` parameters to `Image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `name` parameter to `RunnableImage`
+- Added optional `registry` and `owner` parameters to `Image`
+- Added `name`, `registry` and `owner` parameters to `RunnableImage`
 
 ## [0.15.0] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `name` parameter to `RunnableImage`
+
 ## [0.15.0] - 2023-09-28
 
 ### Added

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -207,7 +207,7 @@ impl<I: Image> RunnableImage<I> {
         let original_tag = self.image.tag();
 
         let name = self.image_name.as_ref().unwrap_or(&original_name);
-        let tag = self.image_name.as_ref().unwrap_or(&original_tag);
+        let tag = self.image_tag.as_ref().unwrap_or(&original_tag);
 
         format!("{name}:{tag}")
     }


### PR DESCRIPTION
It's alternative solution for https://github.com/testcontainers/testcontainers-rs/pull/549
A bit more user-friendly because operates with separate entities, but kinda redundant. Instead of configuring 1 parameter to override, users will have to split it to 3.

E.g: `gallery.ecr.aws/docker/library/redis` should be represented as:
- registry: `gallery.ecr.aws`
- owner: `docker/library`
- name: `redis`

But user actually can just pass `gallery.ecr.aws/docker/library/redis` to name, or `gallery.ecr.aws/docker/library` to owner. We can't protect it.

Adds ability to set registry and owner on per-Image basis, and override them with `RunnableImage`.

Closes #335