### PR TITLE
Include LICENSE file in published crates

### DIFF
--- a/testcontainers/LICENSE-Apache-2.0
+++ b/testcontainers/LICENSE-Apache-2.0
@@ -1,0 +1,1 @@
+../LICENSE-Apache-2.0

--- a/testcontainers/LICENSE-MIT
+++ b/testcontainers/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/testcontainers/README.md
+++ b/testcontainers/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
Apache-2.0 license term include a requirement that the (re)distributed
sources contain a copy of the license text. Similar conditions apply to
the MIT one. This is a problem for Linux distributions wanting to
include and package the crates from this projecs, affecting also
creates.io

This PR includes a symlink to the LICENSEs and README files in the
crate, which should make `cargo publish` include these files when
publishing to crates.io.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>