### PR TITLE
feat: custom docker build options

### DIFF
--- a/testcontainers/src/clients/cli.rs
+++ b/testcontainers/src/clients/cli.rs
@@ -176,6 +176,8 @@ impl Client {
             command.arg("--entrypoint").arg(entrypoint);
         }
 
+
+
         let is_container_networked = image
             .network()
             .as_ref()
@@ -192,6 +194,10 @@ impl Client {
                 command.arg(format!("--expose={port}"));
             }
             command.arg("-P"); // publish all exposed ports
+        }
+
+        for (key, value) in image.options() {
+            command.arg(key).arg(value);
         }
 
         command


### PR DESCRIPTION
Provide extension points to facilitate users to add other container running parameters, such as --network-alias and --sig-proxy, etc.