### PR TITLE
docs: change old contact link to the Slack one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ git config core.hookspath .githooks
 
 ## Contact
 
-Feel free to drop by in the [testcontainers-rust channel](https://testcontainers.slack.com/archives/C048EPGRCER) of our [Slack server](https://testcontainers.slack.com).
+Feel free to drop by in the [testcontainers-rust channel](https://testcontainers.slack.com/archives/C048EPGRCER) of our [Slack workspace](https://testcontainers.slack.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ git config core.hookspath .githooks
 
 ## Contact
 
-Feel free to drop by in our Slack: http://slack.testcontainers.org/
+Feel free to drop by in the [testcontainers-rust channel](https://testcontainers.slack.com/archives/C048EPGRCER) of our [Slack server](https://testcontainers.slack.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ git config core.hookspath .githooks
 
 ## Contact
 
-Feel free to drop by in our Matrix chat room: https://matrix.to/#/#testcontainers-rs:matrix.org
+Feel free to drop by in our Slack: http://slack.testcontainers.org/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs.rs](https://docs.rs/testcontainers/badge.svg)](https://docs.rs/testcontainers)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=testcontainers/testcontainers-rs)](https://dependabot.com)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/20716)
-[![Matrix](https://img.shields.io/matrix/testcontainers-rs:matrix.org?style=flat-square)](https://matrix.to/#/#testcontainers-rs:matrix.org)
+![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&link=https%3A%2F%2Fjoin.slack.com%2Ft%2Ftestcontainers%2Fshared_invite%2Fzt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
 
 Testcontainers-rs is the official Rust language fork of [http://testcontainers.org](http://testcontainers.org).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs.rs](https://docs.rs/testcontainers/badge.svg)](https://docs.rs/testcontainers)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=testcontainers/testcontainers-rs)](https://dependabot.com)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/20716)
-![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&link=https%3A%2F%2Fjoin.slack.com%2Ft%2Ftestcontainers%2Fshared_invite%2Fzt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
+[![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&)](link=https%3A%2F%2Fjoin.slack.com%2Ft%2Ftestcontainers%2Fshared_invite%2Fzt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
 
 Testcontainers-rs is the official Rust language fork of [http://testcontainers.org](http://testcontainers.org).
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ![Continuous Integration](https://github.com/testcontainers/testcontainers-rs/workflows/Continuous%20Integration/badge.svg?branch=dev)
 [![Crates.io](https://img.shields.io/crates/v/testcontainers.svg)](https://crates.io/crates/testcontainers)
 [![Docs.rs](https://docs.rs/testcontainers/badge.svg)](https://docs.rs/testcontainers)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=testcontainers/testcontainers-rs)](https://dependabot.com)
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/20716)
 [![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&)](https://join.slack.com/t/testcontainers/shared_invite/zt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
 
 Testcontainers-rs is the official Rust language fork of [http://testcontainers.org](http://testcontainers.org).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs.rs](https://docs.rs/testcontainers/badge.svg)](https://docs.rs/testcontainers)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=testcontainers/testcontainers-rs)](https://dependabot.com)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/20716)
-[![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&)](link=https%3A%2F%2Fjoin.slack.com%2Ft%2Ftestcontainers%2Fshared_invite%2Fzt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
+[![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&)](https://join.slack.com/t/testcontainers/shared_invite/zt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
 
 Testcontainers-rs is the official Rust language fork of [http://testcontainers.org](http://testcontainers.org).
 


### PR DESCRIPTION
Inside of the Matrix channel, it is mentioned that the official contact channel is now Slack.