### PR TITLE
refactor!: api for mounts and volumes

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -22,6 +22,7 @@ conquer-once = { version = "0.4", optional = true }
 dirs = "5.0.1"
 futures = "0.3"
 log = "0.4"
+parse-display = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde-java-properties = "0.1.1"
 serde_json = "1"

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,6 +1,8 @@
 pub use self::{
     containers::*,
-    image::{ContainerState, ExecCommand, Host, Image, ImageArgs, Port, RunnableImage, WaitFor},
+    image::{
+        ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping, RunnableImage, WaitFor,
+    },
 };
 
 mod image;
@@ -10,5 +12,6 @@ pub(crate) mod containers;
 pub(crate) mod env;
 pub(crate) mod logs;
 pub(crate) mod macros;
+pub(crate) mod mounts;
 pub(crate) mod network;
 pub(crate) mod ports;

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,12 +1,15 @@
-use std::{
-    collections::BTreeMap,
-    env::var,
-    fmt::{Debug, Display},
-    net::IpAddr,
-    time::Duration,
-};
+use std::fmt::Debug;
+
+pub use exec_command::ExecCommand;
+pub use runnable_image::{Host, PortMapping, RunnableImage};
+pub use wait_for::WaitFor;
 
 use super::ports::Ports;
+use crate::core::mounts::Mount;
+
+mod exec_command;
+mod runnable_image;
+mod wait_for;
 
 /// Represents a docker image.
 ///
@@ -65,15 +68,15 @@ where
         Box::new(std::iter::empty())
     }
 
-    /// There are a couple of things regarding the volumes of images:
+    /// There are a couple of things regarding the mounts of images:
     ///
     /// 1. Similar to the Default implementation of an Image, the Default instance
-    /// of its volumes should be meaningful!
-    /// 2. Implementations should be conservative about which volumes they expose. Many times,
+    /// of its mounts should be meaningful!
+    /// 2. Implementations should be conservative about which mounts they expose or require. Many times,
     /// users will either go with the default ones or just override one or two. When defining
     /// the volumes of your image, consider that the whole purpose is to facilitate integration
     /// testing. Only expose those that actually make sense for this case.
-    fn volumes(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+    fn mounts(&self) -> Box<dyn Iterator<Item = &Mount> + '_> {
         Box::new(std::iter::empty())
     }
 
@@ -98,42 +101,6 @@ where
     #[allow(unused_variables)]
     fn exec_after_start(&self, cs: ContainerState) -> Vec<ExecCommand> {
         Default::default()
-    }
-}
-
-#[derive(Debug)]
-pub struct ExecCommand {
-    pub(super) cmd: Vec<String>,
-    pub(super) cmd_ready_condition: WaitFor,
-    pub(super) container_ready_conditions: Vec<WaitFor>,
-}
-
-impl ExecCommand {
-    /// Command to be executed
-    pub fn new(cmd: Vec<String>) -> Self {
-        Self {
-            cmd,
-            cmd_ready_condition: WaitFor::Nothing,
-            container_ready_conditions: vec![],
-        }
-    }
-
-    /// Conditions to be checked on related container
-    pub fn with_container_ready_conditions(mut self, ready_conditions: Vec<WaitFor>) -> Self {
-        self.container_ready_conditions = ready_conditions;
-        self
-    }
-
-    /// Conditions to be checked on executed command output
-    pub fn with_cmd_ready_condition(mut self, ready_conditions: WaitFor) -> Self {
-        self.cmd_ready_condition = ready_conditions;
-        self
-    }
-}
-
-impl Default for ExecCommand {
-    fn default() -> Self {
-        Self::new(vec![])
     }
 }
 
@@ -167,298 +134,5 @@ pub trait ImageArgs {
 impl ImageArgs for () {
     fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
         Box::new(vec![].into_iter())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum Host {
-    Addr(IpAddr),
-    HostGateway,
-}
-
-impl Display for Host {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Host::Addr(addr) => write!(f, "{addr}"),
-            Host::HostGateway => write!(f, "host-gateway"),
-        }
-    }
-}
-
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct RunnableImage<I: Image> {
-    image: I,
-    image_args: I::Args,
-    image_name: Option<String>,
-    image_tag: Option<String>,
-    container_name: Option<String>,
-    network: Option<String>,
-    env_vars: BTreeMap<String, String>,
-    hosts: BTreeMap<String, Host>,
-    volumes: BTreeMap<String, String>,
-    ports: Option<Vec<Port>>,
-    privileged: bool,
-    shm_size: Option<u64>,
-}
-
-impl<I: Image> RunnableImage<I> {
-    pub fn image(&self) -> &I {
-        &self.image
-    }
-
-    pub fn args(&self) -> &I::Args {
-        &self.image_args
-    }
-
-    pub fn network(&self) -> &Option<String> {
-        &self.network
-    }
-
-    pub fn container_name(&self) -> &Option<String> {
-        &self.container_name
-    }
-
-    pub fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
-        Box::new(self.image.env_vars().chain(self.env_vars.iter()))
-    }
-
-    pub fn hosts(&self) -> Box<dyn Iterator<Item = (&String, &Host)> + '_> {
-        Box::new(self.hosts.iter())
-    }
-
-    pub fn volumes(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
-        Box::new(self.image.volumes().chain(self.volumes.iter()))
-    }
-
-    pub fn ports(&self) -> &Option<Vec<Port>> {
-        &self.ports
-    }
-
-    pub fn privileged(&self) -> bool {
-        self.privileged
-    }
-
-    /// Shared memory size in bytes
-    pub fn shm_size(&self) -> Option<u64> {
-        self.shm_size
-    }
-
-    pub fn entrypoint(&self) -> Option<String> {
-        self.image.entrypoint()
-    }
-
-    pub fn descriptor(&self) -> String {
-        let original_name = self.image.name();
-        let original_tag = self.image.tag();
-
-        let name = self.image_name.as_ref().unwrap_or(&original_name);
-        let tag = self.image_tag.as_ref().unwrap_or(&original_tag);
-
-        format!("{name}:{tag}")
-    }
-
-    pub fn ready_conditions(&self) -> Vec<WaitFor> {
-        self.image.ready_conditions()
-    }
-
-    pub fn expose_ports(&self) -> Vec<u16> {
-        self.image.expose_ports()
-    }
-
-    pub fn exec_after_start(&self, cs: ContainerState) -> Vec<ExecCommand> {
-        self.image.exec_after_start(cs)
-    }
-}
-
-impl<I: Image> RunnableImage<I> {
-    /// Returns a new RunnableImage with the specified arguments.
-
-    /// # Examples
-    /// ```
-    /// use testcontainers::{core::RunnableImage, GenericImage};
-    ///
-    /// let image = GenericImage::default();
-    /// let args = vec!["arg1".to_string(), "arg2".to_string()];
-    /// let runnable_image = RunnableImage::from(image.clone()).with_args(args.clone());
-    ///
-    /// assert_eq!(runnable_image.args(), &args);
-    ///
-    /// let another_runnable_image = RunnableImage::from((image, args));
-    ///
-    /// assert_eq!(another_runnable_image.args(), runnable_image.args());
-    /// ```
-    pub fn with_args(self, args: I::Args) -> Self {
-        Self {
-            image_args: args,
-            ..self
-        }
-    }
-
-    /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
-    /// Can be used to specify a custom registry or owner.
-    pub fn with_name(self, name: impl Into<String>) -> Self {
-        Self {
-            image_name: Some(name.into()),
-            ..self
-        }
-    }
-
-    /// There is no guarantee that the specified tag for an image would result in a
-    /// running container. Users of this API are advised to use this at their own risk.
-    pub fn with_tag(self, tag: impl Into<String>) -> Self {
-        Self {
-            image_tag: Some(tag.into()),
-            ..self
-        }
-    }
-
-    pub fn with_container_name(self, name: impl Into<String>) -> Self {
-        Self {
-            container_name: Some(name.into()),
-            ..self
-        }
-    }
-
-    pub fn with_network(self, network: impl Into<String>) -> Self {
-        Self {
-            network: Some(network.into()),
-            ..self
-        }
-    }
-
-    pub fn with_env_var(self, (key, value): (impl Into<String>, impl Into<String>)) -> Self {
-        let mut env_vars = self.env_vars;
-        env_vars.insert(key.into(), value.into());
-        Self { env_vars, ..self }
-    }
-
-    pub fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> Self {
-        let mut hosts = self.hosts;
-        hosts.insert(key.into(), value.into());
-        Self { hosts, ..self }
-    }
-
-    pub fn with_volume(self, (orig, dest): (impl Into<String>, impl Into<String>)) -> Self {
-        let mut volumes = self.volumes;
-        volumes.insert(orig.into(), dest.into());
-        Self { volumes, ..self }
-    }
-
-    pub fn with_mapped_port<P: Into<Port>>(self, port: P) -> Self {
-        let mut ports = self.ports.unwrap_or_default();
-        ports.push(port.into());
-
-        Self {
-            ports: Some(ports),
-            ..self
-        }
-    }
-
-    pub fn with_privileged(self, privileged: bool) -> Self {
-        Self { privileged, ..self }
-    }
-
-    pub fn with_shm_size(self, bytes: u64) -> Self {
-        Self {
-            shm_size: Some(bytes),
-            ..self
-        }
-    }
-}
-
-impl<I> From<I> for RunnableImage<I>
-where
-    I: Image,
-    I::Args: Default,
-{
-    fn from(image: I) -> Self {
-        Self::from((image, I::Args::default()))
-    }
-}
-
-impl<I: Image> From<(I, I::Args)> for RunnableImage<I> {
-    fn from((image, image_args): (I, I::Args)) -> Self {
-        Self {
-            image,
-            image_args,
-            image_name: None,
-            image_tag: None,
-            container_name: None,
-            network: None,
-            env_vars: BTreeMap::default(),
-            hosts: BTreeMap::default(),
-            volumes: BTreeMap::default(),
-            ports: None,
-            privileged: false,
-            shm_size: None,
-        }
-    }
-}
-
-/// Represents a port mapping between a local port and the internal port of a container.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Port {
-    pub local: u16,
-    pub internal: u16,
-}
-
-/// Represents a condition that needs to be met before a container is considered ready.
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum WaitFor {
-    /// An empty condition. Useful for default cases or fallbacks.
-    Nothing,
-    /// Wait for a message on the stdout stream of the container's logs.
-    StdOutMessage { message: String },
-    /// Wait for a message on the stderr stream of the container's logs.
-    StdErrMessage { message: String },
-    /// Wait for a certain amount of time.
-    Duration { length: Duration },
-    /// Wait for the container's status to become `healthy`.
-    Healthcheck,
-}
-
-impl WaitFor {
-    pub fn message_on_stdout<S: Into<String>>(message: S) -> WaitFor {
-        WaitFor::StdOutMessage {
-            message: message.into(),
-        }
-    }
-
-    pub fn message_on_stderr<S: Into<String>>(message: S) -> WaitFor {
-        WaitFor::StdErrMessage {
-            message: message.into(),
-        }
-    }
-
-    pub fn seconds(length: u64) -> WaitFor {
-        WaitFor::Duration {
-            length: Duration::from_secs(length),
-        }
-    }
-
-    pub fn millis(length: u64) -> WaitFor {
-        WaitFor::Duration {
-            length: Duration::from_millis(length),
-        }
-    }
-
-    pub fn millis_in_env_var(name: &'static str) -> WaitFor {
-        let additional_sleep_period = var(name).map(|value| value.parse());
-
-        (|| {
-            let length = additional_sleep_period.ok()?.ok()?;
-
-            Some(WaitFor::Duration {
-                length: Duration::from_millis(length),
-            })
-        })()
-        .unwrap_or(WaitFor::Nothing)
-    }
-}
-
-impl From<(u16, u16)> for Port {
-    fn from((local, internal): (u16, u16)) -> Self {
-        Port { local, internal }
     }
 }

--- a/testcontainers/src/core/image/exec_command.rs
+++ b/testcontainers/src/core/image/exec_command.rs
@@ -1,0 +1,37 @@
+use crate::core::WaitFor;
+
+#[derive(Debug)]
+pub struct ExecCommand {
+    pub(crate) cmd: Vec<String>,
+    pub(crate) cmd_ready_condition: WaitFor,
+    pub(crate) container_ready_conditions: Vec<WaitFor>,
+}
+
+impl ExecCommand {
+    /// Command to be executed
+    pub fn new(cmd: Vec<String>) -> Self {
+        Self {
+            cmd,
+            cmd_ready_condition: WaitFor::Nothing,
+            container_ready_conditions: vec![],
+        }
+    }
+
+    /// Conditions to be checked on related container
+    pub fn with_container_ready_conditions(mut self, ready_conditions: Vec<WaitFor>) -> Self {
+        self.container_ready_conditions = ready_conditions;
+        self
+    }
+
+    /// Conditions to be checked on executed command output
+    pub fn with_cmd_ready_condition(mut self, ready_conditions: WaitFor) -> Self {
+        self.cmd_ready_condition = ready_conditions;
+        self
+    }
+}
+
+impl Default for ExecCommand {
+    fn default() -> Self {
+        Self::new(vec![])
+    }
+}

--- a/testcontainers/src/core/image/runnable_image.rs
+++ b/testcontainers/src/core/image/runnable_image.rs
@@ -1,0 +1,246 @@
+use std::{collections::BTreeMap, net::IpAddr};
+
+use crate::{
+    core::{mounts::Mount, ContainerState, ExecCommand, WaitFor},
+    Image,
+};
+
+/// Image wrapper that allows to override some of the image properties.
+#[must_use]
+#[derive(Debug, Clone)]
+pub struct RunnableImage<I: Image> {
+    image: I,
+    image_args: I::Args,
+    image_name: Option<String>,
+    image_tag: Option<String>,
+    container_name: Option<String>,
+    network: Option<String>,
+    env_vars: BTreeMap<String, String>,
+    hosts: BTreeMap<String, Host>,
+    mounts: Vec<Mount>,
+    ports: Option<Vec<PortMapping>>,
+    privileged: bool,
+    shm_size: Option<u64>,
+}
+
+/// Represents a port mapping between a local port and the internal port of a container.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortMapping {
+    pub local: u16,
+    pub internal: u16,
+}
+
+#[derive(parse_display::Display, Debug, Clone)]
+pub enum Host {
+    #[display("{0}")]
+    Addr(IpAddr),
+    #[display("host-gateway")]
+    HostGateway,
+}
+
+impl<I: Image> RunnableImage<I> {
+    pub fn image(&self) -> &I {
+        &self.image
+    }
+
+    pub fn args(&self) -> &I::Args {
+        &self.image_args
+    }
+
+    pub fn network(&self) -> &Option<String> {
+        &self.network
+    }
+
+    pub fn container_name(&self) -> &Option<String> {
+        &self.container_name
+    }
+
+    pub fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        Box::new(self.image.env_vars().chain(self.env_vars.iter()))
+    }
+
+    pub fn hosts(&self) -> Box<dyn Iterator<Item = (&String, &Host)> + '_> {
+        Box::new(self.hosts.iter())
+    }
+
+    pub fn mounts(&self) -> Box<dyn Iterator<Item = &Mount> + '_> {
+        Box::new(self.image.mounts().chain(self.mounts.iter()))
+    }
+
+    pub fn ports(&self) -> &Option<Vec<PortMapping>> {
+        &self.ports
+    }
+
+    pub fn privileged(&self) -> bool {
+        self.privileged
+    }
+
+    /// Shared memory size in bytes
+    pub fn shm_size(&self) -> Option<u64> {
+        self.shm_size
+    }
+
+    pub fn entrypoint(&self) -> Option<String> {
+        self.image.entrypoint()
+    }
+
+    pub fn descriptor(&self) -> String {
+        let original_name = self.image.name();
+        let original_tag = self.image.tag();
+
+        let name = self.image_name.as_ref().unwrap_or(&original_name);
+        let tag = self.image_tag.as_ref().unwrap_or(&original_tag);
+
+        format!("{name}:{tag}")
+    }
+
+    pub fn ready_conditions(&self) -> Vec<WaitFor> {
+        self.image.ready_conditions()
+    }
+
+    pub fn expose_ports(&self) -> Vec<u16> {
+        self.image.expose_ports()
+    }
+
+    pub fn exec_after_start(&self, cs: ContainerState) -> Vec<ExecCommand> {
+        self.image.exec_after_start(cs)
+    }
+}
+
+impl<I: Image> RunnableImage<I> {
+    /// Returns a new RunnableImage with the specified arguments.
+    ///
+    /// # Examples
+    /// ```
+    /// use testcontainers::{core::RunnableImage, GenericImage};
+    ///
+    /// let image = GenericImage::default();
+    /// let args = vec!["arg1".to_string(), "arg2".to_string()];
+    /// let runnable_image = RunnableImage::from(image.clone()).with_args(args.clone());
+    ///
+    /// assert_eq!(runnable_image.args(), &args);
+    ///
+    /// let another_runnable_image = RunnableImage::from((image, args));
+    ///
+    /// assert_eq!(another_runnable_image.args(), runnable_image.args());
+    /// ```
+    pub fn with_args(self, args: I::Args) -> Self {
+        Self {
+            image_args: args,
+            ..self
+        }
+    }
+
+    /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
+    /// Can be used to specify a custom registry or owner.
+    pub fn with_name(self, name: impl Into<String>) -> Self {
+        Self {
+            image_name: Some(name.into()),
+            ..self
+        }
+    }
+
+    /// Overrides the image tag.
+    ///
+    /// There is no guarantee that the specified tag for an image would result in a
+    /// running container. Users of this API are advised to use this at their own risk.
+    pub fn with_tag(self, tag: impl Into<String>) -> Self {
+        Self {
+            image_tag: Some(tag.into()),
+            ..self
+        }
+    }
+
+    /// Sets the container name.
+    pub fn with_container_name(self, name: impl Into<String>) -> Self {
+        Self {
+            container_name: Some(name.into()),
+            ..self
+        }
+    }
+
+    /// Sets the network the container will be connected to.
+    pub fn with_network(self, network: impl Into<String>) -> Self {
+        Self {
+            network: Some(network.into()),
+            ..self
+        }
+    }
+
+    /// Adds an environment variable to the container.
+    pub fn with_env_var(mut self, (key, value): (impl Into<String>, impl Into<String>)) -> Self {
+        self.env_vars.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds a host to the container.
+    pub fn with_host(mut self, key: impl Into<String>, value: impl Into<Host>) -> Self {
+        self.hosts.insert(key.into(), value.into());
+        self
+    }
+
+    /// Adds a mount to the container.
+    pub fn with_mount(mut self, mount: impl Into<Mount>) -> Self {
+        self.mounts.push(mount.into());
+        self
+    }
+
+    /// Adds a port mapping to the container.
+    pub fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> Self {
+        let mut ports = self.ports.unwrap_or_default();
+        ports.push(port.into());
+
+        Self {
+            ports: Some(ports),
+            ..self
+        }
+    }
+
+    /// Sets the container to run in privileged mode.
+    pub fn with_privileged(self, privileged: bool) -> Self {
+        Self { privileged, ..self }
+    }
+
+    /// Sets the shared memory size in bytes
+    pub fn with_shm_size(self, bytes: u64) -> Self {
+        Self {
+            shm_size: Some(bytes),
+            ..self
+        }
+    }
+}
+
+impl<I> From<I> for RunnableImage<I>
+where
+    I: Image,
+    I::Args: Default,
+{
+    fn from(image: I) -> Self {
+        Self::from((image, I::Args::default()))
+    }
+}
+
+impl<I: Image> From<(I, I::Args)> for RunnableImage<I> {
+    fn from((image, image_args): (I, I::Args)) -> Self {
+        Self {
+            image,
+            image_args,
+            image_name: None,
+            image_tag: None,
+            container_name: None,
+            network: None,
+            env_vars: BTreeMap::default(),
+            hosts: BTreeMap::default(),
+            mounts: Vec::new(),
+            ports: None,
+            privileged: false,
+            shm_size: None,
+        }
+    }
+}
+
+impl From<(u16, u16)> for PortMapping {
+    fn from((local, internal): (u16, u16)) -> Self {
+        PortMapping { local, internal }
+    }
+}

--- a/testcontainers/src/core/image/wait_for.rs
+++ b/testcontainers/src/core/image/wait_for.rs
@@ -1,0 +1,55 @@
+use std::{env::var, time::Duration};
+
+/// Represents a condition that needs to be met before a container is considered ready.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum WaitFor {
+    /// An empty condition. Useful for default cases or fallbacks.
+    Nothing,
+    /// Wait for a message on the stdout stream of the container's logs.
+    StdOutMessage { message: String },
+    /// Wait for a message on the stderr stream of the container's logs.
+    StdErrMessage { message: String },
+    /// Wait for a certain amount of time.
+    Duration { length: Duration },
+    /// Wait for the container's status to become `healthy`.
+    Healthcheck,
+}
+
+impl WaitFor {
+    pub fn message_on_stdout<S: Into<String>>(message: S) -> WaitFor {
+        WaitFor::StdOutMessage {
+            message: message.into(),
+        }
+    }
+
+    pub fn message_on_stderr<S: Into<String>>(message: S) -> WaitFor {
+        WaitFor::StdErrMessage {
+            message: message.into(),
+        }
+    }
+
+    pub fn seconds(length: u64) -> WaitFor {
+        WaitFor::Duration {
+            length: Duration::from_secs(length),
+        }
+    }
+
+    pub fn millis(length: u64) -> WaitFor {
+        WaitFor::Duration {
+            length: Duration::from_millis(length),
+        }
+    }
+
+    pub fn millis_in_env_var(name: &'static str) -> WaitFor {
+        let additional_sleep_period = var(name).map(|value| value.parse());
+
+        (|| {
+            let length = additional_sleep_period.ok()?.ok()?;
+
+            Some(WaitFor::Duration {
+                length: Duration::from_millis(length),
+            })
+        })()
+        .unwrap_or(WaitFor::Nothing)
+    }
+}

--- a/testcontainers/src/core/mounts.rs
+++ b/testcontainers/src/core/mounts.rs
@@ -1,0 +1,95 @@
+/// Represents a filesystem mount.
+/// For more information see [Docker Storage](https://docs.docker.com/storage/) documentation.
+#[derive(Debug, Clone)]
+pub struct Mount {
+    access_mode: AccessMode,
+    mount_type: MountType,
+    source: Option<String>,
+    target: Option<String>,
+}
+
+#[derive(parse_display::Display, Debug, Copy, Clone)]
+#[display(style = "snake_case")]
+pub enum MountType {
+    Bind,
+    Volume,
+    Tmpfs,
+}
+
+#[derive(parse_display::Display, Debug, Copy, Clone)]
+pub enum AccessMode {
+    #[display("ro")]
+    ReadOnly,
+    #[display("rw")]
+    ReadWrite,
+}
+
+impl Mount {
+    /// Creates a `bind-mount`.
+    /// Can be used to mount a file or directory on the host system into a container.
+    ///
+    /// See [bind-mounts documentation](https://docs.docker.com/storage/bind-mounts/) for more information.
+    pub fn bind_mount(host_path: impl Into<String>, container_path: impl Into<String>) -> Self {
+        Self {
+            access_mode: AccessMode::ReadWrite,
+            mount_type: MountType::Bind,
+            source: Some(host_path.into()),
+            target: Some(container_path.into()),
+        }
+    }
+
+    /// Creates a named `volume`.
+    /// Can be used to share data between containers or persist data on the host system.
+    /// The volume isn't removed when the container is removed.
+    ///
+    /// See [volumes documentation](https://docs.docker.com/storage/volumes/) for more information.
+    pub fn volume_mount(name: impl Into<String>, container_path: impl Into<String>) -> Self {
+        Self {
+            access_mode: AccessMode::ReadWrite,
+            mount_type: MountType::Volume,
+            source: Some(name.into()),
+            target: Some(container_path.into()),
+        }
+    }
+
+    /// Creates a `tmpfs` mount.
+    /// Can be used to mount a temporary filesystem in the container's memory.
+    /// `tmpfs` mount is removed when the container is removed.
+    ///
+    /// See [tmpfs documentation](https://docs.docker.com/storage/tmpfs/) for more information.
+    pub fn tmpfs_mount(container_path: impl Into<String>) -> Self {
+        Self {
+            access_mode: AccessMode::ReadWrite,
+            mount_type: MountType::Tmpfs,
+            source: None,
+            target: Some(container_path.into()),
+        }
+    }
+
+    /// Sets the access mode for the mount.
+    /// Default is `AccessMode::ReadWrite`.
+    pub fn with_access_mode(mut self, access_mode: AccessMode) -> Self {
+        self.access_mode = access_mode;
+        self
+    }
+
+    /// Docker mount access mode.
+    pub fn access_mode(&self) -> AccessMode {
+        self.access_mode
+    }
+
+    /// Docker mount type.
+    pub fn mount_type(&self) -> MountType {
+        self.mount_type
+    }
+
+    /// Absolute path of a file, a directory or volume to mount on the host system.
+    pub fn source(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+
+    /// Absolute path of a file or directory to mount in the container.
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_deref()
+    }
+}

--- a/testcontainers/src/images/generic.rs
+++ b/testcontainers/src/images/generic.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use crate::{core::WaitFor, Image, ImageArgs};
+use crate::{
+    core::{mounts::Mount, WaitFor},
+    Image, ImageArgs,
+};
 
 impl ImageArgs for Vec<String> {
     fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
@@ -13,7 +16,7 @@ impl ImageArgs for Vec<String> {
 pub struct GenericImage {
     name: String,
     tag: String,
-    volumes: BTreeMap<String, String>,
+    mounts: Vec<Mount>,
     env_vars: BTreeMap<String, String>,
     wait_for: Vec<WaitFor>,
     entrypoint: Option<String>,
@@ -25,7 +28,7 @@ impl Default for GenericImage {
         Self {
             name: "".to_owned(),
             tag: "".to_owned(),
-            volumes: BTreeMap::new(),
+            mounts: Vec::new(),
             env_vars: BTreeMap::new(),
             wait_for: Vec::new(),
             entrypoint: None,
@@ -43,8 +46,8 @@ impl GenericImage {
         }
     }
 
-    pub fn with_volume<F: Into<String>, D: Into<String>>(mut self, from: F, dest: D) -> Self {
-        self.volumes.insert(from.into(), dest.into());
+    pub fn with_mount(mut self, mount: impl Into<Mount>) -> Self {
+        self.mounts.push(mount.into());
         self
     }
 
@@ -88,8 +91,8 @@ impl Image for GenericImage {
         Box::new(self.env_vars.iter())
     }
 
-    fn volumes(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
-        Box::new(self.volumes.iter())
+    fn mounts(&self) -> Box<dyn Iterator<Item = &Mount> + '_> {
+        Box::new(self.mounts.iter())
     }
 
     fn entrypoint(&self) -> Option<String> {

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -60,7 +60,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{client::Client, WaitFor},
+        core::{client::Client, mounts::Mount, WaitFor},
         images::generic::GenericImage,
     };
 
@@ -89,7 +89,7 @@ mod tests {
 
     #[derive(Default)]
     struct HelloWorld {
-        volumes: BTreeMap<String, String>,
+        mounts: Vec<Mount>,
         env_vars: BTreeMap<String, String>,
     }
 
@@ -112,8 +112,8 @@ mod tests {
             Box::new(self.env_vars.iter())
         }
 
-        fn volumes(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
-            Box::new(self.volumes.iter())
+        fn mounts(&self) -> Box<dyn Iterator<Item = &Mount> + '_> {
+            Box::new(self.mounts.iter())
         }
     }
 
@@ -121,7 +121,6 @@ mod tests {
     fn sync_run_command_should_expose_all_ports_if_no_explicit_mapping_requested() {
         let container = RunnableImage::from(GenericImage::new("hello-world", "latest")).start();
 
-        // inspect volume and env
         let container_details = inspect(container.id());
         let publish_ports = container_details
             .host_config


### PR DESCRIPTION
Closes #582

This is breaking change.

The API was unclear, because `volumes` used to mean `bind-mounts`, which is wrong.

Introduce `Mount` structure with the following mount types:
- bind
- volume
- tmpfs

Also exposes access-mode configuration for mounts: `rw` (read-write) and `ro` (read-only)

*Note*: named volumes not getting removed once container is removed, it's intentional for now. Because named volumes can be used to persist a state. We can review this point later.

## Migration guide

- If your `Image` implements `volumes` method:
  - rename method to `mounts`
  - wrap all existed "volumes" into `Mount::bind_mount(host_path, container_path)`
- If your code uses `RunnableImage::with_volume`
  - replace the call with `RunnableImage::with_mount`
- If your code uses `GenericImage::with_volume`
  - replace the call with `GenericImage::with_mount`