### PR TITLE
fix: expose mount-related types

### DIFF
--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -3,6 +3,7 @@ pub use self::{
     image::{
         ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping, RunnableImage, WaitFor,
     },
+    mounts::{AccessMode, Mount, MountType},
 };
 
 mod image;


### PR DESCRIPTION
They supposed to be public, but module has crate-visibility