### PR TITLE
feat: allow cgroupns-mode and userns-mode to be configured 

### DIFF
--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,7 +1,8 @@
 pub use self::{
     containers::*,
     image::{
-        ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping, RunnableImage, WaitFor,
+        CgroupnsMode, ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping,
+        RunnableImage, WaitFor,
     },
     mounts::{AccessMode, Mount, MountType},
 };

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 pub use exec_command::ExecCommand;
-pub use runnable_image::{Host, PortMapping, RunnableImage};
+pub use runnable_image::{CgroupnsMode, Host, PortMapping, RunnableImage};
 pub use wait_for::WaitFor;
 
 use super::ports::Ports;

--- a/testcontainers/src/core/image/runnable_image.rs
+++ b/testcontainers/src/core/image/runnable_image.rs
@@ -22,6 +22,7 @@ pub struct RunnableImage<I: Image> {
     privileged: bool,
     shm_size: Option<u64>,
     cgroupns_mode: Option<CgroupnsMode>,
+    userns_mode: Option<String>,
 }
 
 /// Represents a port mapping between a local port and the internal port of a container.
@@ -84,6 +85,10 @@ impl<I: Image> RunnableImage<I> {
 
     pub fn cgroupns_mode(&self) -> Option<CgroupnsMode> {
         self.cgroupns_mode
+    }
+
+    pub fn userns_mode(&self) -> Option<String> {
+        self.userns_mode.clone()
     }
 
     /// Shared memory size in bytes
@@ -223,6 +228,14 @@ impl<I: Image> RunnableImage<I> {
         }
     }
 
+    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
+    pub fn with_userns_mode(self, userns_mode: &str) -> Self {
+        Self {
+            userns_mode: Some(String::from(userns_mode)),
+            ..self
+        }
+    }
+
     /// Sets the shared memory size in bytes
     pub fn with_shm_size(self, bytes: u64) -> Self {
         Self {
@@ -258,6 +271,7 @@ impl<I: Image> From<(I, I::Args)> for RunnableImage<I> {
             privileged: false,
             shm_size: None,
             cgroupns_mode: None,
+            userns_mode: None,
         }
     }
 }

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -70,7 +70,7 @@
 //! [`testcontainers-modules`]: https://crates.io/crates/testcontainers-modules
 
 pub mod core;
-pub use crate::core::{containers::*, Image, ImageArgs, RunnableImage};
+pub use crate::core::{containers::*, CgroupnsMode, Image, ImageArgs, RunnableImage};
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]


### PR DESCRIPTION
Allow cgroupns and userns to be defined when building RunnableImage