### PR TITLE
feat: introduce `properties-config` cargo feature

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3"
 log = "0.4"
 parse-display = "0.9.0"
 serde = { version = "1", features = ["derive"] }
-serde-java-properties = "0.1.1"
+serde-java-properties = { version = "0.1.1", optional = true }
 serde_json = "1"
 serde_with = "3.7.0"
 signal-hook = { version = "0.3", optional = true }
@@ -37,6 +37,7 @@ url = { version = "2", features = ["serde"] }
 default = []
 blocking = []
 watchdog = ["signal-hook", "conquer-once"]
+properties-config = ["serde-java-properties"]
 
 [dev-dependencies]
 pretty_env_logger = "0.5"

--- a/testcontainers/src/core/env/config.rs
+++ b/testcontainers/src/core/env/config.rs
@@ -3,12 +3,11 @@ use std::{
     str::FromStr,
 };
 
-use serde::Deserialize;
-use serde_with::serde_as;
 use url::Url;
 
 use crate::core::env::GetEnvValue;
 
+#[cfg(feature = "properties-config")]
 const TESTCONTAINERS_PROPERTIES: &str = ".testcontainers.properties";
 
 /// The default `DOCKER_HOST` address that we will try to connect to.
@@ -29,8 +28,8 @@ pub(crate) struct Config {
 }
 
 #[cfg(feature = "properties-config")]
-#[serde_as]
-#[derive(Debug, Default, Deserialize)]
+#[serde_with::serde_as]
+#[derive(Debug, Default, serde::Deserialize)]
 struct TestcontainersProperties {
     #[serde(rename = "tc.host")]
     tc_host: Option<Url>,

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -28,6 +28,19 @@
 //!
 //! See examples in the corresponding runner ([`AsyncRunner`] and [`SyncRunner`])
 //!
+//! ### Docker host resolution
+//!
+//! You can change the configuration of the Docker host used by the client in two ways:
+//! - environment variables
+//! - `~/.testcontainers.properties` file (a Java properties file, enabled by the `properties-config` feature)
+//!
+//! ##### The host is resolved in the following order:
+//!
+//! 1. Docker host from the `tc.host` property in the `~/.testcontainers.properties` file.
+//! 2. `DOCKER_HOST` environment variable.
+//! 3. Docker host from the "docker.host" property in the `~/.testcontainers.properties` file.
+//! 4. Else, the default Docker socket will be returned.
+//!
 //! # Ecosystem
 //!
 //! `testcontainers` is the core crate that provides an API for working with containers in a test environment.


### PR DESCRIPTION
To avoid extra dependencies, expose the logic for reading java-properties file only under the feature

Technically it's breaking change, but we don't expect a lot of usage since this feature was introduced very recently and not that common for rust community