### PR TITLE
fix: correct drop of a network for sync container

### DIFF
--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -33,8 +33,7 @@ pub struct ContainerAsync<I: Image> {
     id: String,
     image: RunnableImage<I>,
     pub(super) docker_client: Arc<Client>,
-    #[cfg_attr(not(feature = "blocking"), allow(dead_code))]
-    pub(super) network: Option<Arc<Network>>,
+    network: Option<Arc<Network>>,
     dropped: bool,
 }
 

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -160,7 +160,6 @@ impl<I: Image> Drop for Container<I> {
     fn drop(&mut self) {
         if let Some(mut active) = self.inner.take() {
             active.runtime.block_on(async {
-                drop(active.async_impl.network.take());
                 match active.async_impl.docker_client.config.command() {
                     env::Command::Remove => active.async_impl.rm().await,
                     env::Command::Keep => {}


### PR DESCRIPTION
Network must be dropped only after container, not before