### PR TITLE
fix: correct default for `get_host_ip_address` in case of `unix` or `npipe`

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -282,7 +282,7 @@ impl Client {
                 .into_iter()
                 .filter_map(|ipam_cfg| ipam_cfg.gateway)
                 .next()
-                .unwrap_or_else(|| "localhost".to_string()),
+                .unwrap_or_else(|| "127.0.0.1".to_string()),
             _ => unreachable!("docker host is already validated in the config"),
         }
     }

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -168,7 +168,7 @@ where
 
         host_ip
             .parse()
-            .expect(format!("invalid host ip: '{host_ip}'"))
+            .unwrap_or_else(|e| panic!("invalid host ip: '{host_ip}', error: {e}"))
     }
 
     pub async fn exec(&self, cmd: ExecCommand) {

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -164,11 +164,11 @@ where
 
     /// Returns the host ip address of docker container
     pub async fn get_host_ip_address(&self) -> IpAddr {
-        self.docker_client
-            .docker_host_ip_address()
-            .await
+        let host_ip = self.docker_client.docker_host_ip_address().await;
+
+        host_ip
             .parse()
-            .expect("invalid host IP")
+            .expect(format!("invalid host ip: '{host_ip}'"))
     }
 
     pub async fn exec(&self, cmd: ExecCommand) {

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -144,8 +144,8 @@ mod tests {
     fn sync_run_command_should_expose_only_requested_ports() {
         let image = GenericImage::new("hello-world", "latest");
         let container = RunnableImage::from(image)
-            .with_mapped_port((123, 456))
-            .with_mapped_port((555, 888))
+            .with_mapped_port((124, 456))
+            .with_mapped_port((556, 888))
             .start();
 
         let container_details = inspect(container.id());


### PR DESCRIPTION
`IpAddr` can't be parsed from `localhost`, it expects domain.

We could use `url::Host`, but it would be a breaking change and method must be renamed in that case