### PR TITLE
feat: add `get_host` to `Container` and deprecate `get_host_ip_address`

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -21,6 +21,7 @@ bollard = { version = "0.16.1", features = ["ssl"] }
 bollard-stubs = "=1.44.0-rc.2"
 conquer-once = { version = "0.4", optional = true }
 dirs = "5.0.1"
+dns-lookup = "2.0.4"
 docker_credential = "1.3.1"
 futures = "0.3"
 log = "0.4"

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -267,7 +267,7 @@ impl Client {
             .expect("Failed to remove network");
     }
 
-    pub(crate) async fn docker_host_name(&self) -> url::Host {
+    pub(crate) async fn docker_hostname(&self) -> url::Host {
         let docker_host = self.config.docker_host();
         let host = match docker_host.scheme() {
             "tcp" | "http" | "https" => docker_host.host().unwrap().to_string(),

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -164,7 +164,7 @@ where
     }
 
     /// Returns the host ip address of docker container
-    #[deprecated(since = "0.16.6", note = "Please use `get_hostname` instead")]
+    #[deprecated(since = "0.16.6", note = "Please use `get_host` instead")]
     pub async fn get_host_ip_address(&self) -> IpAddr {
         let host_name = self.docker_client.docker_hostname().await;
 
@@ -179,8 +179,8 @@ where
         }
     }
 
-    /// the Docker container's hostname, suitable for URL usage.
-    pub async fn get_hostname(&self) -> url::Host {
+    /// Returns the Docker container's host name, suitable for URL usage.
+    pub async fn get_host(&self) -> url::Host {
         self.docker_client.docker_hostname().await
     }
 

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -123,8 +123,15 @@ where
     }
 
     /// Returns the host ip address of docker container
+    #[deprecated(since = "0.16.6", note = "Please use `get_hostname` instead")]
     pub fn get_host_ip_address(&self) -> IpAddr {
+        #[allow(deprecated)]
         self.rt().block_on(self.async_impl().get_host_ip_address())
+    }
+
+    /// Returns the Docker container's hostname, suitable for URL usage.
+    pub fn get_hostname(&self) -> url::Host {
+        self.rt().block_on(self.async_impl().get_hostname())
     }
 
     pub fn exec(&self, cmd: ExecCommand) {

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -158,7 +158,7 @@ where
 
 impl<I: Image> Drop for Container<I> {
     fn drop(&mut self) {
-        if let Some(mut active) = self.inner.take() {
+        if let Some(active) = self.inner.take() {
             active.runtime.block_on(async {
                 match active.async_impl.docker_client.config.command() {
                     env::Command::Remove => active.async_impl.rm().await,

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -123,15 +123,15 @@ where
     }
 
     /// Returns the host ip address of docker container
-    #[deprecated(since = "0.16.6", note = "Please use `get_hostname` instead")]
+    #[deprecated(since = "0.16.6", note = "Please use `get_host` instead")]
     pub fn get_host_ip_address(&self) -> IpAddr {
         #[allow(deprecated)]
         self.rt().block_on(self.async_impl().get_host_ip_address())
     }
 
-    /// Returns the Docker container's hostname, suitable for URL usage.
-    pub fn get_hostname(&self) -> url::Host {
-        self.rt().block_on(self.async_impl().get_hostname())
+    /// Returns the Docker container's host name, suitable for URL usage.
+    pub fn get_host(&self) -> url::Host {
+        self.rt().block_on(self.async_impl().get_host())
     }
 
     pub fn exec(&self, cmd: ExecCommand) {

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -44,7 +44,7 @@ fn generic_image_with_custom_entrypoint() {
     let port = node.get_host_port_ipv4(80);
     assert_eq!(
         "foo",
-        reqwest::blocking::get(format!("http://{}:{port}", node.get_hostname()))
+        reqwest::blocking::get(format!("http://{}:{port}", node.get_host()))
             .unwrap()
             .text()
             .unwrap()
@@ -56,7 +56,7 @@ fn generic_image_with_custom_entrypoint() {
     let port = node.get_host_port_ipv4(80);
     assert_eq!(
         "bar",
-        reqwest::blocking::get(format!("http://{}:{port}", node.get_hostname()))
+        reqwest::blocking::get(format!("http://{}:{port}", node.get_host()))
             .unwrap()
             .text()
             .unwrap()

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -44,7 +44,7 @@ fn generic_image_with_custom_entrypoint() {
     let port = node.get_host_port_ipv4(80);
     assert_eq!(
         "foo",
-        reqwest::blocking::get(format!("http://{}:{port}", node.get_host_ip_address()))
+        reqwest::blocking::get(format!("http://{}:{port}", node.get_hostname()))
             .unwrap()
             .text()
             .unwrap()
@@ -56,7 +56,7 @@ fn generic_image_with_custom_entrypoint() {
     let port = node.get_host_port_ipv4(80);
     assert_eq!(
         "bar",
-        reqwest::blocking::get(format!("http://{}:{port}", node.get_host_ip_address()))
+        reqwest::blocking::get(format!("http://{}:{port}", node.get_hostname()))
             .unwrap()
             .text()
             .unwrap()


### PR DESCRIPTION
Existing logic is incorrect, because we may encounter domain name.
Also, `IpAddr` isn't suitable for URL usage (because of `IpV6`).

`url::Host` is better alternative and supports:
- Domain names
- escapes `IpV6` for `URL`

We preserve `get_host_ip_address` for now, but we have to get rid of this method and extra dependency in the next major release