### PR TITLE
Add exec_with

### DIFF
--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,7 +1,8 @@
 pub use self::{
     containers::*,
     image::{
-        ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping, RunnableImage, WaitFor,
+        ContainerState, ExecCommand, ExecWithCommand, Host, Image, ImageArgs, PortMapping,
+        RunnableImage, WaitFor,
     },
     mounts::{AccessMode, Mount, MountType},
 };

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -87,17 +87,13 @@ impl Client {
         &self,
         container_id: &str,
         cmd: Vec<String>,
-        desired_log: DesiredLogStream,
+        attach_stdout: Option<bool>,
+        attach_stderr: Option<bool>,
     ) -> LogStreamAsync<'_> {
-        let (stdout, stderr) = match desired_log {
-            DesiredLogStream::Stdout => (true, false),
-            DesiredLogStream::Stderr => (false, true),
-        };
-
         let config = CreateExecOptions {
             cmd: Some(cmd),
-            attach_stdout: Some(stdout),
-            attach_stderr: Some(stderr),
+            attach_stdout,
+            attach_stderr,
             ..Default::default()
         };
 

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-pub use exec_command::ExecCommand;
+pub use exec_command::{ExecCommand, ExecWithCommand};
 pub use runnable_image::{Host, PortMapping, RunnableImage};
 pub use wait_for::WaitFor;
 

--- a/testcontainers/src/core/image/exec_command.rs
+++ b/testcontainers/src/core/image/exec_command.rs
@@ -35,3 +35,40 @@ impl Default for ExecCommand {
         Self::new(vec![])
     }
 }
+
+#[derive(Debug, Default)]
+pub struct ExecWithCommand {
+    pub(crate) cmd: Vec<String>,
+    pub(crate) attach_stdout: Option<bool>,
+    pub(crate) attach_stderr: Option<bool>,
+    pub(crate) container_ready_conditions: Vec<WaitFor>,
+}
+impl ExecWithCommand {
+    /// Command to be executed
+    pub fn new(cmd: Vec<String>) -> Self {
+        Self {
+            cmd,
+            attach_stdout: None,
+            attach_stderr: None,
+            container_ready_conditions: vec![],
+        }
+    }
+
+    /// Whether to attach stdout of a running container
+    pub fn with_attach_stdout(mut self, attach_stdout: Option<bool>) -> Self {
+        self.attach_stdout = attach_stdout;
+        self
+    }
+
+    /// Whether to attach stderr of a running container
+    pub fn with_attach_stderr(mut self, attach_stderr: Option<bool>) -> Self {
+        self.attach_stderr = attach_stderr;
+        self
+    }
+
+    /// Conditions to be checked on related container
+    pub fn with_container_ready_conditions(mut self, ready_conditions: Vec<WaitFor>) -> Self {
+        self.container_ready_conditions = ready_conditions;
+        self
+    }
+}


### PR DESCRIPTION
Closes #617 - `exec_with` returns AsyncLogStream, which can be used by users to parse output stdout, stderr, or both (at once).