### PR TITLE
fix: `get_host` for `unix` and `npipe` docker hosts

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -10,11 +10,22 @@ use bollard::{
 };
 use bollard_stubs::models::{ContainerCreateResponse, ContainerInspectResponse, HealthStatusEnum};
 use futures::{StreamExt, TryStreamExt};
+use tokio::sync::OnceCell;
 
 use crate::core::{env, logs::LogStreamAsync, ports::Ports, WaitFor};
 
 mod bollard_client;
 mod factory;
+
+static IN_A_CONTAINER: OnceCell<bool> = OnceCell::const_new();
+
+// See https://github.com/docker/docker/blob/a9fa38b1edf30b23cae3eade0be48b3d4b1de14b/daemon/initlayer/setup_unix.go#L25
+// and Java impl: https://github.com/testcontainers/testcontainers-java/blob/994b385761dde7d832ab7b6c10bc62747fe4b340/core/src/main/java/org/testcontainers/dockerclient/DockerClientConfigUtils.java#L16C5-L17
+async fn is_in_container() -> bool {
+    *IN_A_CONTAINER
+        .get_or_init(|| async { tokio::fs::metadata("/.dockerenv").await.is_ok() })
+        .await
+}
 
 /// The desired log stream.
 pub(crate) enum DesiredLogStream {
@@ -269,24 +280,32 @@ impl Client {
 
     pub(crate) async fn docker_hostname(&self) -> url::Host {
         let docker_host = self.config.docker_host();
-        let host = match docker_host.scheme() {
-            "tcp" | "http" | "https" => docker_host.host().unwrap().to_string(),
-            "unix" | "npipe" => self
-                .bollard
-                .inspect_network::<String>("bridge", None)
-                .await
-                .ok()
-                .and_then(|net| net.ipam)
-                .and_then(|ipam| ipam.config)
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|ipam_cfg| ipam_cfg.gateway)
-                .next()
-                .unwrap_or_else(|| "localhost".to_string()),
-            _ => unreachable!("docker host is already validated in the config"),
-        };
+        match docker_host.scheme() {
+            "tcp" | "http" | "https" => docker_host.host().unwrap().to_owned(),
+            "unix" | "npipe" => {
+                if is_in_container().await {
+                    let host = self
+                        .bollard
+                        .inspect_network::<String>("bridge", None)
+                        .await
+                        .ok()
+                        .and_then(|net| net.ipam)
+                        .and_then(|ipam| ipam.config)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|ipam_cfg| ipam_cfg.gateway)
+                        .next()
+                        .filter(|gateway| !gateway.trim().is_empty())
+                        .unwrap_or_else(|| "localhost".to_string());
 
-        url::Host::parse(&host).unwrap_or_else(|e| panic!("invalid host: '{host}', error: {e}"))
+                    url::Host::parse(&host)
+                        .unwrap_or_else(|e| panic!("invalid host: '{host}', error: {e}"))
+                } else {
+                    url::Host::Domain("localhost".to_string())
+                }
+            }
+            _ => unreachable!("docker host is already validated in the config"),
+        }
     }
 
     async fn credentials_for_image(&self, descriptor: &str) -> Option<DockerCredentials> {

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -179,7 +179,8 @@ where
         }
     }
 
-    /// Returns the Docker container's host name, suitable for URL usage.
+    /// Returns the host that this container may be reached on (may not be the local machine)
+    /// Suitable for use in URL
     pub async fn get_host(&self) -> url::Host {
         self.docker_client.docker_hostname().await
     }

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -129,7 +129,8 @@ where
         self.rt().block_on(self.async_impl().get_host_ip_address())
     }
 
-    /// Returns the Docker container's host name, suitable for URL usage.
+    /// Returns the host that this container may be reached on (may not be the local machine)
+    /// Suitable for use in URL
     pub fn get_host(&self) -> url::Host {
         self.rt().block_on(self.async_impl().get_host())
     }


### PR DESCRIPTION
The implementation should be aligned with this impl: https://github.com/testcontainers/testcontainers-java/blob/994b385761dde7d832ab7b6c10bc62747fe4b340/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java#L451-L467

 I.e. we should return `Gateway` only if client running in a container.
Otherwise, it's `localhost` for `unix` and `pipe`