### PR TITLE
feat: extend `WaitFor` for `ExecCommand`

### DIFF
--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,7 +1,7 @@
 pub use self::{
     containers::*,
     image::{
-        CgroupnsMode, ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping,
+        CgroupnsMode, CmdWaitFor, ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping,
         RunnableImage, WaitFor,
     },
     mounts::{AccessMode, Mount, MountType},

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -4,11 +4,13 @@ use tokio::runtime::RuntimeFlavor;
 
 use crate::{
     core::{
-        client::{Client, DesiredLogStream},
-        env, macros,
+        client::{AttachLog, Client},
+        env,
+        image::CmdWaitFor,
+        macros,
         network::Network,
         ports::Ports,
-        ContainerState, ExecCommand, WaitFor,
+        ContainerState, ExecCommand,
     },
     Image, RunnableImage,
 };
@@ -193,22 +195,44 @@ where
 
         log::debug!("Executing command {:?}", cmd);
 
-        let desired_log = if let WaitFor::StdErrMessage { .. } = &cmd_ready_condition {
-            DesiredLogStream::Stderr
-        } else {
-            DesiredLogStream::Stdout
+        let attach_log = match cmd_ready_condition {
+            CmdWaitFor::StdOutMessage { .. } => AttachLog::stdout(),
+            CmdWaitFor::StdErrMessage { .. } => AttachLog::stderr(),
+            CmdWaitFor::StdOutOrErrMessage { .. } => AttachLog::stdout_and_stderr(),
+            _ => AttachLog::nothing(),
         };
 
-        let output = self.docker_client.exec(&self.id, cmd, desired_log).await;
+        let (exec_id, output) = self.docker_client.exec(&self.id, cmd, attach_log).await;
         self.docker_client
             .block_until_ready(self.id(), &container_ready_conditions)
             .await;
 
         match cmd_ready_condition {
-            WaitFor::StdOutMessage { message } | WaitFor::StdErrMessage { message } => {
+            CmdWaitFor::StdOutOrErrMessage { message }
+            | CmdWaitFor::StdOutMessage { message }
+            | CmdWaitFor::StdErrMessage { message } => {
                 output.wait_for_message(&message).await.unwrap();
             }
-            WaitFor::Duration { length } => {
+            CmdWaitFor::ExitCode { code } => loop {
+                let inspect = self
+                    .docker_client
+                    .bollard
+                    .inspect_exec(&exec_id)
+                    .await
+                    .unwrap();
+
+                if let Some(exit_code) = inspect.exit_code {
+                    assert_eq!(
+                        exit_code, code,
+                        "expected exit code {} but got {:?}",
+                        code, inspect.exit_code
+                    );
+                    break;
+                } else {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                }
+            },
+            CmdWaitFor::Duration { length } => {
                 tokio::time::sleep(length).await;
             }
             _ => {}

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-pub use exec_command::ExecCommand;
+pub use exec_command::{CmdWaitFor, ExecCommand};
 pub use runnable_image::{CgroupnsMode, Host, PortMapping, RunnableImage};
 pub use wait_for::WaitFor;
 

--- a/testcontainers/src/core/image/exec_command.rs
+++ b/testcontainers/src/core/image/exec_command.rs
@@ -1,9 +1,11 @@
+use std::time::Duration;
+
 use crate::core::WaitFor;
 
 #[derive(Debug)]
 pub struct ExecCommand {
     pub(crate) cmd: Vec<String>,
-    pub(crate) cmd_ready_condition: WaitFor,
+    pub(crate) cmd_ready_condition: CmdWaitFor,
     pub(crate) container_ready_conditions: Vec<WaitFor>,
 }
 
@@ -12,7 +14,7 @@ impl ExecCommand {
     pub fn new(cmd: Vec<String>) -> Self {
         Self {
             cmd,
-            cmd_ready_condition: WaitFor::Nothing,
+            cmd_ready_condition: CmdWaitFor::Nothing,
             container_ready_conditions: vec![],
         }
     }
@@ -24,8 +26,8 @@ impl ExecCommand {
     }
 
     /// Conditions to be checked on executed command output
-    pub fn with_cmd_ready_condition(mut self, ready_conditions: WaitFor) -> Self {
-        self.cmd_ready_condition = ready_conditions;
+    pub fn with_cmd_ready_condition(mut self, ready_conditions: impl Into<CmdWaitFor>) -> Self {
+        self.cmd_ready_condition = ready_conditions.into();
         self
     }
 }
@@ -33,5 +35,69 @@ impl ExecCommand {
 impl Default for ExecCommand {
     fn default() -> Self {
         Self::new(vec![])
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum CmdWaitFor {
+    /// An empty condition. Useful for default cases or fallbacks.
+    Nothing,
+    /// Wait for a message on the stdout stream of the command's output.
+    StdOutMessage { message: String },
+    /// Wait for a message on the stderr stream of the command's output.
+    StdErrMessage { message: String },
+    /// Wait for a message on the stdout or stderr stream of the command's output.
+    StdOutOrErrMessage { message: String },
+    /// Wait for a certain amount of time.
+    Duration { length: Duration },
+    /// Wait for the command's exit code to be equal to the provided one.
+    ExitCode { code: i64 },
+}
+
+impl CmdWaitFor {
+    pub fn message_on_stdout<S: Into<String>>(message: S) -> Self {
+        Self::StdOutMessage {
+            message: message.into(),
+        }
+    }
+
+    pub fn message_on_stderr<S: Into<String>>(message: S) -> Self {
+        Self::StdErrMessage {
+            message: message.into(),
+        }
+    }
+
+    pub fn message_on_stdout_or_stderr<S: Into<String>>(message: S) -> Self {
+        Self::StdOutOrErrMessage {
+            message: message.into(),
+        }
+    }
+
+    pub fn exit_code(code: i64) -> Self {
+        Self::ExitCode { code }
+    }
+
+    pub fn seconds(length: u64) -> Self {
+        Self::Duration {
+            length: Duration::from_secs(length),
+        }
+    }
+
+    pub fn millis(length: u64) -> Self {
+        Self::Duration {
+            length: Duration::from_millis(length),
+        }
+    }
+}
+
+impl From<WaitFor> for CmdWaitFor {
+    fn from(wait_for: WaitFor) -> Self {
+        match wait_for {
+            WaitFor::Nothing => Self::Nothing,
+            WaitFor::StdOutMessage { message } => Self::StdOutMessage { message },
+            WaitFor::StdErrMessage { message } => Self::StdErrMessage { message },
+            WaitFor::Duration { length } => Self::Duration { length },
+            WaitFor::Healthcheck => Self::ExitCode { code: 0 },
+        }
     }
 }

--- a/testcontainers/src/core/image/exec_command.rs
+++ b/testcontainers/src/core/image/exec_command.rs
@@ -11,7 +11,7 @@ pub struct ExecCommand {
 
 impl ExecCommand {
     /// Command to be executed
-    pub fn new(cmd: Vec<impl Into<String>>) -> Self {
+    pub fn new(cmd: impl IntoIterator<Item = impl Into<String>>) -> Self {
         Self {
             cmd: cmd.into_iter().map(Into::into).collect(),
             cmd_ready_condition: CmdWaitFor::Nothing,

--- a/testcontainers/src/core/image/exec_command.rs
+++ b/testcontainers/src/core/image/exec_command.rs
@@ -11,9 +11,9 @@ pub struct ExecCommand {
 
 impl ExecCommand {
     /// Command to be executed
-    pub fn new(cmd: Vec<String>) -> Self {
+    pub fn new(cmd: Vec<impl Into<String>>) -> Self {
         Self {
-            cmd,
+            cmd: cmd.into_iter().map(Into::into).collect(),
             cmd_ready_condition: CmdWaitFor::Nothing,
             container_ready_conditions: vec![],
         }
@@ -34,7 +34,7 @@ impl ExecCommand {
 
 impl Default for ExecCommand {
     fn default() -> Self {
-        Self::new(vec![])
+        Self::new(Vec::<String>::new())
     }
 }
 

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -26,7 +26,7 @@ impl<'d> LogStreamAsync<'d> {
             }
         }
 
-        Err(end_of_stream(lines))
+        Err(end_of_stream(message, lines))
     }
 }
 
@@ -42,9 +42,9 @@ fn handle_line(line: String, message: &str, lines: &mut Vec<String>) -> bool {
     false
 }
 
-fn end_of_stream(lines: Vec<String>) -> WaitError {
+fn end_of_stream(expected_msg: &str, lines: Vec<String>) -> WaitError {
     log::error!(
-        "Failed to find message in stream after comparing {} lines.",
+        "Failed to find message '{expected_msg}' in stream after comparing {} lines.",
         lines.len()
     );
 

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -100,23 +100,20 @@ async fn async_run_exec() {
 
     // exit code, it waits for result
     container
-        .exec(
-            ExecCommand::new(vec!["sleep", "3"]).with_cmd_ready_condition(CmdWaitFor::exit_code(0)),
-        )
+        .exec(ExecCommand::new(["sleep", "3"]).with_cmd_ready_condition(CmdWaitFor::exit_code(0)))
         .await;
 
     // stdout
     container
         .exec(
-            ExecCommand::new(vec!["ls"])
-                .with_cmd_ready_condition(CmdWaitFor::message_on_stdout("foo")),
+            ExecCommand::new(["ls"]).with_cmd_ready_condition(CmdWaitFor::message_on_stdout("foo")),
         )
         .await;
 
     // stdout or stderr
     container
         .exec(
-            ExecCommand::new(vec!["ls"])
+            ExecCommand::new(["ls"])
                 .with_cmd_ready_condition(CmdWaitFor::message_on_stdout_or_stderr("foo")),
         )
         .await;

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -101,15 +101,14 @@ async fn async_run_exec() {
     // exit code, it waits for result
     container
         .exec(
-            ExecCommand::new(vec!["sleep".to_string(), "3".to_string()])
-                .with_cmd_ready_condition(CmdWaitFor::exit_code(0)),
+            ExecCommand::new(vec!["sleep", "3"]).with_cmd_ready_condition(CmdWaitFor::exit_code(0)),
         )
         .await;
 
     // stdout
     container
         .exec(
-            ExecCommand::new(vec!["ls".to_string()])
+            ExecCommand::new(vec!["ls"])
                 .with_cmd_ready_condition(CmdWaitFor::message_on_stdout("foo")),
         )
         .await;
@@ -117,7 +116,7 @@ async fn async_run_exec() {
     // stdout or stderr
     container
         .exec(
-            ExecCommand::new(vec!["ls".to_string()])
+            ExecCommand::new(vec!["ls"])
                 .with_cmd_ready_condition(CmdWaitFor::message_on_stdout_or_stderr("foo")),
         )
         .await;


### PR DESCRIPTION
- support check of exit code
- allow check the message against both `stderr` and `stdout`
- extend `new` to accept `impl IntoIterator<Item = impl Into<String>>` (e.g to accept `["cmd", "arg1", "arg2"]` as is)

Closes #617