### PR TITLE
fix: collect bridge IP address correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.ref }}

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -5,10 +5,12 @@ use bollard::{
     container::{Config, CreateContainerOptions, LogsOptions, RemoveContainerOptions},
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
     image::CreateImageOptions,
-    network::CreateNetworkOptions,
+    network::{CreateNetworkOptions, InspectNetworkOptions},
     Docker,
 };
-use bollard_stubs::models::{ContainerCreateResponse, ContainerInspectResponse, HealthStatusEnum};
+use bollard_stubs::models::{
+    ContainerCreateResponse, ContainerInspectResponse, HealthStatusEnum, Network,
+};
 use futures::{StreamExt, TryStreamExt};
 use tokio::sync::OnceCell;
 
@@ -230,6 +232,16 @@ impl Client {
             .unwrap();
 
         network.id
+    }
+
+    /// Inspects a network
+    pub(crate) async fn inspect_network(
+        &self,
+        name: &str,
+    ) -> Result<Network, bollard::errors::Error> {
+        self.bollard
+            .inspect_network(name, Some(InspectNetworkOptions::<String>::default()))
+            .await
     }
 
     pub(crate) async fn create_container(

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -166,12 +166,8 @@ where
             .image
             .network()
             .clone()
-            .or_else(|| {
-                network_settings
-                    .bridge
-                    .and_then(|b| if !b.is_empty() { Some(b) } else { None })
-            })
-            .or(Some("bridge".to_owned()))
+            .or_else(|| network_settings.bridge.filter(|b| !b.is_empty()))
+            .or_else(|| Some("bridge".to_owned()))
             .unwrap_or_else(|| panic!("container {} has missing bridge name", self.id));
 
         let ip = networks

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -385,22 +385,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn async_should_rely_on_network_mode_when_no_network_provided_and_settings_bridge_empty()
-    {
-        let web_server = GenericImage::new("simple_web_server", "latest")
-            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
-            .with_wait_for(WaitFor::seconds(1));
-
-        let container = RunnableImage::from(web_server.clone()).start().await;
-
-        assert!(!container
-            .get_bridge_ip_address()
-            .await
-            .to_string()
-            .is_empty())
-    }
-
-    #[tokio::test]
     async fn async_should_rely_on_network_mode_when_network_is_provided_and_settings_bridge_empty()
     {
         let web_server = GenericImage::new("simple_web_server", "latest")

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -385,19 +385,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn async_should_rely_on_default_bridge_network_when_no_network_provided_and_settings_bridge_empty(
-    ) {
-        let hello_world = GenericImage::new("simple_web_server", "latest")
+    async fn async_should_rely_on_network_mode_when_no_network_provided_and_settings_bridge_empty()
+    {
+        let web_server = GenericImage::new("simple_web_server", "latest")
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
 
-        let container = RunnableImage::from(hello_world.clone()).start().await;
+        let container = RunnableImage::from(web_server.clone()).start().await;
 
         assert!(!container
             .get_bridge_ip_address()
             .await
             .to_string()
             .is_empty())
+    }
+
+    #[tokio::test]
+    async fn async_should_rely_on_network_mode_when_network_is_provided_and_settings_bridge_empty()
+    {
+        let web_server = GenericImage::new("simple_web_server", "latest")
+            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+            .with_wait_for(WaitFor::seconds(1));
+
+        let container = RunnableImage::from(web_server.clone())
+            .with_network("bridge")
+            .start()
+            .await;
+
+        assert!(!container
+            .get_bridge_ip_address()
+            .await
+            .to_string()
+            .is_empty())
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn async_should_panic_when_non_bridged_network_selected() {
+        let web_server = GenericImage::new("simple_web_server", "latest")
+            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+            .with_wait_for(WaitFor::seconds(1));
+
+        let container = RunnableImage::from(web_server.clone())
+            .with_network("host")
+            .start()
+            .await;
+
+        container.get_bridge_ip_address().await;
     }
 
     #[tokio::test]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -385,6 +385,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn async_should_rely_on_default_bridge_network_when_no_network_provided_and_settings_bridge_empty(
+    ) {
+        let hello_world = GenericImage::new("simple_web_server", "latest")
+            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+            .with_wait_for(WaitFor::seconds(1));
+
+        let container = RunnableImage::from(hello_world.clone()).start().await;
+
+        assert!(!container
+            .get_bridge_ip_address()
+            .await
+            .to_string()
+            .is_empty())
+    }
+
+    #[tokio::test]
     async fn async_run_command_should_set_shared_memory_size() {
         let client = Client::lazy_client().await;
         let image = GenericImage::new("hello-world", "latest");

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -189,19 +189,6 @@ mod tests {
     }
 
     #[test]
-    fn sync_should_rely_on_network_mode_when_no_network_provided_and_settings_bridge_empty() {
-        let web_server = GenericImage::new("simple_web_server", "latest")
-            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
-            .with_wait_for(WaitFor::seconds(1));
-
-        let container = RunnableImage::from(web_server.clone())
-            .with_network("test")
-            .start();
-
-        assert!(!container.get_bridge_ip_address().to_string().is_empty())
-    }
-
-    #[test]
     fn sync_should_rely_on_network_mode_when_network_is_provided_and_settings_bridge_empty() {
         let web_server = GenericImage::new("simple_web_server", "latest")
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -189,17 +189,44 @@ mod tests {
     }
 
     #[test]
-    fn async_should_rely_on_default_bridge_network_when_no_network_provided_and_settings_bridge_empty(
-    ) {
-        let hello_world = GenericImage::new("simple_web_server", "latest")
+    fn sync_should_rely_on_network_mode_when_no_network_provided_and_settings_bridge_empty() {
+        let web_server = GenericImage::new("simple_web_server", "latest")
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
 
-        let container = RunnableImage::from(hello_world.clone()).start();
+        let container = RunnableImage::from(web_server.clone())
+            .with_network("test")
+            .start();
 
         assert!(!container.get_bridge_ip_address().to_string().is_empty())
     }
 
+    #[test]
+    fn sync_should_rely_on_network_mode_when_network_is_provided_and_settings_bridge_empty() {
+        let web_server = GenericImage::new("simple_web_server", "latest")
+            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+            .with_wait_for(WaitFor::seconds(1));
+
+        let container = RunnableImage::from(web_server.clone())
+            .with_network("bridge")
+            .start();
+
+        assert!(!container.get_bridge_ip_address().to_string().is_empty())
+    }
+
+    #[test]
+    #[should_panic]
+    fn sync_should_panic_when_non_bridged_network_selected() {
+        let web_server = GenericImage::new("simple_web_server", "latest")
+            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+            .with_wait_for(WaitFor::seconds(1));
+
+        let container = RunnableImage::from(web_server.clone())
+            .with_network("host")
+            .start();
+
+        container.get_bridge_ip_address();
+    }
     #[test]
     fn sync_run_command_should_include_name() {
         let image = GenericImage::new("hello-world", "latest");

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -189,6 +189,18 @@ mod tests {
     }
 
     #[test]
+    fn async_should_rely_on_default_bridge_network_when_no_network_provided_and_settings_bridge_empty(
+    ) {
+        let hello_world = GenericImage::new("simple_web_server", "latest")
+            .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+            .with_wait_for(WaitFor::seconds(1));
+
+        let container = RunnableImage::from(hello_world.clone()).start();
+
+        assert!(!container.get_bridge_ip_address().to_string().is_empty())
+    }
+
+    #[test]
     fn sync_run_command_should_include_name() {
         let image = GenericImage::new("hello-world", "latest");
         let container = RunnableImage::from(image)


### PR DESCRIPTION
I bumped into this issue while using https://github.com/testcontainers/testcontainers-rs-modules-community/tree/main/src/mysql 
and the latest version of testcontainers-rs.

`get_bridge_ip_address` was not returning the correct IP address value. When running a container on GNU/Linux systems
`NetworkSettings.bridge` might be an empty string therefore it is not useful as a default value.

This PR tries to provide a default value for such scenarios where:

- No `--bridge` flag has been explicitly provided when starting the container
- `NetworkSettings.bridge` is an empty string
- Container has not been launched with a specific network and therefore defaults to whatever is configured on the docker daemon

Thanks for all the efforts in this project!
