### PR TITLE
feat: impl `Error` for `WaitError`

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -33,6 +33,7 @@ serde_with = "3.7.0"
 signal-hook = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-util = "0.7.10"
+thiserror = "1.0.60"
 url = { version = "2", features = ["serde"] }
 
 [features]

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -56,8 +56,8 @@ fn end_of_stream(expected_msg: &str, lines: Vec<String>) -> WaitError {
 pub enum WaitError {
     /// Indicates the stream ended before finding the log line you were looking for.
     /// Contains all the lines that were read for debugging purposes.
-    EndOfStream(#[allow(dead_code)] Vec<String>), // todo: tuple is used by Debug impl, remove once nightly clippy is fixed
-    Io(#[allow(dead_code)] io::Error),
+    EndOfStream(Vec<String>),
+    Io(io::Error),
 }
 
 impl From<io::Error> for WaitError {

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -52,11 +52,13 @@ fn end_of_stream(expected_msg: &str, lines: Vec<String>) -> WaitError {
 }
 
 /// Defines error cases when waiting for a message in a stream.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WaitError {
     /// Indicates the stream ended before finding the log line you were looking for.
     /// Contains all the lines that were read for debugging purposes.
+    #[error("End of stream reached: {0:?}")]
     EndOfStream(Vec<String>),
+    #[error(transparent)]
     Io(io::Error),
 }
 


### PR DESCRIPTION
- improves error/panic message
- we're going to introduce fallible API gradually, so we can consider this as a first step 
- it solves the issue of unused fields, because debug impl is intentionally ignored by the dead_code lint