### PR TITLE
refactor!: drop re-export of `CgroupnsMode` accessible through `core`

### DIFF
--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -70,7 +70,7 @@
 //! [`testcontainers-modules`]: https://crates.io/crates/testcontainers-modules
 
 pub mod core;
-pub use crate::core::{containers::*, CgroupnsMode, Image, ImageArgs, RunnableImage};
+pub use crate::core::{containers::*, Image, ImageArgs, RunnableImage};
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -12,9 +12,9 @@ use crate::{
         client::Client,
         mounts::{AccessMode, Mount, MountType},
         network::Network,
-        ContainerState,
+        CgroupnsMode, ContainerState,
     },
-    CgroupnsMode, ContainerAsync, Image, ImageArgs, RunnableImage,
+    ContainerAsync, Image, ImageArgs, RunnableImage,
 };
 
 #[async_trait]


### PR DESCRIPTION
`CgroupnsMode` is accessible through `testcontainers::core::CgroupnsMode`, there is no need to re-export it on crate-level, it's not that common config and there is no high-demand on this.

Usually, only high-level structures are re-exported.

But I would like to consider improving the structure of our modules in the future.