### PR TITLE
feat!: extend `exec` interface to return logs and exec code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.7] - 2024-05-01
+### Details
+#### Bug Fixes
+- `get_host` for `unix` and `npipe` docker hosts ([#621](https://github.com/testcontainers/testcontainers-rs/pull/621))
+
+#### Features
+- Extend `WaitFor` for `ExecCommand` ([#622](https://github.com/testcontainers/testcontainers-rs/pull/622))
 ## [0.16.6] - 2024-04-30
 ### Details
 #### Features

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -25,15 +25,17 @@ dirs = "5.0.1"
 docker_credential = "1.3.1"
 futures = "0.3"
 log = "0.4"
+memchr = "2.7.2"
 parse-display = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde-java-properties = { version = "0.2.0", optional = true }
 serde_json = "1"
 serde_with = "3.7.0"
 signal-hook = { version = "0.3", optional = true }
-tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
-tokio-util = "0.7.10"
 thiserror = "1.0.60"
+tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
+tokio-stream = "0.1.15"
+tokio-util = { version = "0.7.10", features = ["io-util"] }
 url = { version = "2", features = ["serde"] }
 
 [features]

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testcontainers"
-version = "0.16.6"
+version = "0.16.7"
 categories = ["development-tools::testing"]
 readme = "README.md"
 authors.workspace = true

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -19,6 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 async-trait = { version = "0.1" }
 bollard = { version = "0.16.1", features = ["ssl"] }
 bollard-stubs = "=1.44.0-rc.2"
+bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
 dirs = "5.0.1"
 dns-lookup = "2.0.4"

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -12,6 +12,7 @@ mod image;
 pub(crate) mod client;
 pub(crate) mod containers;
 pub(crate) mod env;
+pub(crate) mod errors;
 pub(crate) mod logs;
 pub(crate) mod macros;
 pub(crate) mod mounts;

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -7,12 +7,12 @@ pub use self::{
     mounts::{AccessMode, Mount, MountType},
 };
 
+pub mod errors;
 mod image;
 
 pub(crate) mod client;
 pub(crate) mod containers;
 pub(crate) mod env;
-pub(crate) mod errors;
 pub(crate) mod logs;
 pub(crate) mod macros;
 pub(crate) mod mounts;

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -153,8 +153,8 @@ impl Client {
                     let mut output = output;
                     while let Some(chunk) = output.next().await {
                         // don't produce extra messages until the receiver is ready to consume them
-                        sender_backpressure.forget_permits(1);
                         handle_error!(sender_backpressure.acquire().await);
+                        sender_backpressure.forget_permits(1);
                         match chunk {
                             Ok(LogOutput::StdOut { message }) => {
                                 handle_error!(stdout_tx.send(Ok(message)));

--- a/testcontainers/src/core/client/exec.rs
+++ b/testcontainers/src/core/client/exec.rs
@@ -1,0 +1,21 @@
+use crate::core::logs::LogStreamAsync;
+
+pub(crate) struct ExecResult<'a> {
+    pub(crate) id: String,
+    pub(crate) stdout: LogStreamAsync<'a>,
+    pub(crate) stderr: LogStreamAsync<'a>,
+}
+
+impl<'a> ExecResult<'a> {
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn stdout(&mut self) -> &mut LogStreamAsync<'a> {
+        &mut self.stdout
+    }
+
+    pub(crate) fn stderr(&mut self) -> &mut LogStreamAsync<'a> {
+        &mut self.stderr
+    }
+}

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -203,7 +203,7 @@ where
             _ => AttachLog::nothing(),
         };
 
-        let (exec_id, output) = self.docker_client.exec(&self.id, cmd, attach_log).await;
+        let (exec_id, mut output) = self.docker_client.exec(&self.id, cmd, attach_log).await;
         self.docker_client
             .block_until_ready(self.id(), &container_ready_conditions)
             .await;
@@ -212,7 +212,7 @@ where
             CmdWaitFor::StdOutOrErrMessage { message }
             | CmdWaitFor::StdOutMessage { message }
             | CmdWaitFor::StdErrMessage { message } => {
-                output.wait_for_message(&message).await.unwrap();
+                output.wait_for_message(&message, None).await.unwrap();
             }
             CmdWaitFor::ExitCode { code } => loop {
                 let inspect = self

--- a/testcontainers/src/core/containers/async_container/exec.rs
+++ b/testcontainers/src/core/containers/async_container/exec.rs
@@ -1,0 +1,58 @@
+use std::{fmt, io, pin::Pin, sync::Arc};
+
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use crate::core::client::Client;
+
+/// Represents the result of an executed command in a container.
+pub struct ExecResult<'a> {
+    pub(super) client: Arc<Client>,
+    pub(crate) id: String,
+    pub(super) stdout: BoxStream<'a, Result<Bytes, io::Error>>,
+    pub(super) stderr: BoxStream<'a, Result<Bytes, io::Error>>,
+}
+
+impl<'a> ExecResult<'a> {
+    /// Returns the exit code of the executed command.
+    /// If the command has not yet exited, this will return `None`.
+    pub async fn exit_code(&self) -> Result<Option<i64>, bollard::errors::Error> {
+        self.client
+            .inspect_exec(&self.id)
+            .await
+            .map(|exec| exec.exit_code)
+    }
+
+    /// Returns stdout as a vector of bytes.
+    /// If you want to read stdout in asynchronous manner, use `stdout_reader` instead.
+    pub async fn stdout(&mut self) -> Result<Vec<u8>, io::Error> {
+        let mut stdout = Vec::new();
+        self.stdout_reader().read_to_end(&mut stdout).await?;
+        Ok(stdout)
+    }
+
+    /// Returns stderr as a vector of bytes.
+    /// If you want to read stderr in asynchronous manner, use `stderr_reader` instead.
+    pub async fn stderr(&mut self) -> Result<Vec<u8>, io::Error> {
+        let mut stderr = Vec::new();
+        self.stderr_reader().read_to_end(&mut stderr).await?;
+        Ok(stderr)
+    }
+
+    /// Returns an asynchronous reader for stdout.
+    pub fn stdout_reader<'b>(&'b mut self) -> Pin<Box<dyn AsyncRead + 'b>> {
+        Box::pin(tokio_util::io::StreamReader::new(&mut self.stdout))
+    }
+
+    /// Returns an asynchronous reader for stderr.
+    pub fn stderr_reader<'b>(&'b mut self) -> Pin<Box<dyn AsyncRead + 'b>> {
+        Box::pin(tokio_util::io::StreamReader::new(&mut self.stderr))
+    }
+}
+
+impl fmt::Debug for ExecResult<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecResult").field("id", &self.id).finish()
+    }
+}

--- a/testcontainers/src/core/containers/mod.rs
+++ b/testcontainers/src/core/containers/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod async_container;
 #[cfg(feature = "blocking")]
 pub(crate) mod sync_container;
 
-pub use async_container::ContainerAsync;
+pub use async_container::{exec::ExecResult, ContainerAsync};
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
-pub use sync_container::Container;
+pub use sync_container::{exec::SyncExecResult, Container};

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -5,7 +5,7 @@ use crate::{
     ContainerAsync, Image,
 };
 
-mod exec;
+pub(super) mod exec;
 
 /// Represents a running docker container.
 ///
@@ -131,9 +131,9 @@ where
     }
 
     /// Executes a command in the container.
-    pub fn exec(&self, cmd: ExecCommand) -> Result<exec::ExecResult<'_>, ExecError> {
+    pub fn exec(&self, cmd: ExecCommand) -> Result<exec::SyncExecResult<'_>, ExecError> {
         let async_exec = self.rt().block_on(self.async_impl().exec(cmd))?;
-        Ok(exec::ExecResult {
+        Ok(exec::SyncExecResult {
             inner: async_exec,
             runtime: self.rt(),
         })

--- a/testcontainers/src/core/containers/sync_container/exec.rs
+++ b/testcontainers/src/core/containers/sync_container/exec.rs
@@ -3,12 +3,12 @@ use std::{fmt, io, io::Read};
 use tokio_util::io::SyncIoBridge;
 
 /// Represents the result of an executed command in a container.
-pub struct ExecResult<'a> {
+pub struct SyncExecResult<'a> {
     pub(super) inner: crate::core::async_container::exec::ExecResult<'a>,
     pub(super) runtime: &'a tokio::runtime::Runtime,
 }
 
-impl<'a> ExecResult<'a> {
+impl<'a> SyncExecResult<'a> {
     /// Returns the exit code of the executed command.
     /// If the command has not yet exited, this will return `None`.
     pub fn exit_code(&self) -> Result<Option<i64>, bollard::errors::Error> {
@@ -46,7 +46,7 @@ impl<'a> ExecResult<'a> {
     }
 }
 
-impl fmt::Debug for ExecResult<'_> {
+impl fmt::Debug for SyncExecResult<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExecResult")
             .field("id", &self.inner.id)

--- a/testcontainers/src/core/containers/sync_container/exec.rs
+++ b/testcontainers/src/core/containers/sync_container/exec.rs
@@ -1,6 +1,4 @@
-use std::{fmt, io, io::Read};
-
-use tokio_util::io::SyncIoBridge;
+use std::{fmt, io};
 
 /// Represents the result of an executed command in a container.
 pub struct SyncExecResult<'a> {
@@ -16,33 +14,13 @@ impl<'a> SyncExecResult<'a> {
     }
 
     /// Returns stdout as a vector of bytes.
-    /// If you want to read stdout in asynchronous manner, use `stdout_reader` instead.
     pub fn stdout(&mut self) -> Result<Vec<u8>, io::Error> {
         self.runtime.block_on(self.inner.stdout())
     }
 
     /// Returns stderr as a vector of bytes.
-    /// If you want to read stderr in asynchronous manner, use `stderr_reader` instead.
     pub fn stderr(&mut self) -> Result<Vec<u8>, io::Error> {
         self.runtime.block_on(self.inner.stderr())
-    }
-
-    /// Returns an asynchronous reader for stdout.
-    pub fn stdout_reader<'b>(&'b mut self) -> Box<dyn Read + 'b> {
-        let reader = self.inner.stdout_reader();
-        Box::new(SyncIoBridge::new_with_handle(
-            reader,
-            self.runtime.handle().clone(),
-        ))
-    }
-
-    /// Returns an asynchronous reader for stderr.
-    pub fn stderr_reader<'b>(&'b mut self) -> Box<dyn Read + 'b> {
-        let reader = self.inner.stderr_reader();
-        Box::new(SyncIoBridge::new_with_handle(
-            reader,
-            self.runtime.handle().clone(),
-        ))
     }
 }
 

--- a/testcontainers/src/core/containers/sync_container/exec.rs
+++ b/testcontainers/src/core/containers/sync_container/exec.rs
@@ -1,0 +1,55 @@
+use std::{fmt, io, io::Read};
+
+use tokio_util::io::SyncIoBridge;
+
+/// Represents the result of an executed command in a container.
+pub struct ExecResult<'a> {
+    pub(super) inner: crate::core::async_container::exec::ExecResult<'a>,
+    pub(super) runtime: &'a tokio::runtime::Runtime,
+}
+
+impl<'a> ExecResult<'a> {
+    /// Returns the exit code of the executed command.
+    /// If the command has not yet exited, this will return `None`.
+    pub fn exit_code(&self) -> Result<Option<i64>, bollard::errors::Error> {
+        self.runtime.block_on(self.inner.exit_code())
+    }
+
+    /// Returns stdout as a vector of bytes.
+    /// If you want to read stdout in asynchronous manner, use `stdout_reader` instead.
+    pub fn stdout(&mut self) -> Result<Vec<u8>, io::Error> {
+        self.runtime.block_on(self.inner.stdout())
+    }
+
+    /// Returns stderr as a vector of bytes.
+    /// If you want to read stderr in asynchronous manner, use `stderr_reader` instead.
+    pub fn stderr(&mut self) -> Result<Vec<u8>, io::Error> {
+        self.runtime.block_on(self.inner.stderr())
+    }
+
+    /// Returns an asynchronous reader for stdout.
+    pub fn stdout_reader<'b>(&'b mut self) -> Box<dyn Read + 'b> {
+        let reader = self.inner.stdout_reader();
+        Box::new(SyncIoBridge::new_with_handle(
+            reader,
+            self.runtime.handle().clone(),
+        ))
+    }
+
+    /// Returns an asynchronous reader for stderr.
+    pub fn stderr_reader<'b>(&'b mut self) -> Box<dyn Read + 'b> {
+        let reader = self.inner.stderr_reader();
+        Box::new(SyncIoBridge::new_with_handle(
+            reader,
+            self.runtime.handle().clone(),
+        ))
+    }
+}
+
+impl fmt::Debug for ExecResult<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExecResult")
+            .field("id", &self.inner.id)
+            .finish()
+    }
+}

--- a/testcontainers/src/core/errors.rs
+++ b/testcontainers/src/core/errors.rs
@@ -1,5 +1,6 @@
 use crate::core::logs::WaitLogError;
 
+/// Error type for exec operation.
 #[derive(Debug, thiserror::Error)]
 pub enum ExecError {
     #[error("failed to start exec process: {0}")]
@@ -12,6 +13,7 @@ pub enum ExecError {
     WaitContainer(#[from] WaitContainerError),
 }
 
+/// Error type for waiting for container readiness based on [`crate::core::WaitFor`] conditions.
 #[derive(Debug, thiserror::Error)]
 pub enum WaitContainerError {
     #[error("failed to wait for container log: {0}")]

--- a/testcontainers/src/core/errors.rs
+++ b/testcontainers/src/core/errors.rs
@@ -1,0 +1,27 @@
+use crate::core::logs::WaitLogError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExecError {
+    #[error("failed to start exec process: {0}")]
+    Init(#[from] bollard::errors::Error),
+    #[error("exec process exited with code {actual}, expected {expected}")]
+    ExitCodeMismatch { expected: i64, actual: i64 },
+    #[error("failed to wait for exec log: {0}")]
+    WaitLog(#[from] WaitLogError),
+    #[error("container's wait conditions are not met: {0}")]
+    WaitContainer(#[from] WaitContainerError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WaitContainerError {
+    #[error("failed to wait for container log: {0}")]
+    WaitLog(#[from] WaitLogError),
+    #[error("failed to inspect container: {0}")]
+    Inspect(bollard::errors::Error),
+    #[error("container state is unavailable")]
+    StateUnavailable,
+    #[error("healthcheck is not configured for container: {0}")]
+    HealthCheckNotConfigured(String),
+    #[error("container is unhealthy")]
+    Unhealthy,
+}

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,13 +1,13 @@
 use std::fmt::Debug;
 
-pub use exec_command::{CmdWaitFor, ExecCommand};
+pub use exec::{CmdWaitFor, ExecCommand};
 pub use runnable_image::{CgroupnsMode, Host, PortMapping, RunnableImage};
 pub use wait_for::WaitFor;
 
 use super::ports::Ports;
 use crate::core::mounts::Mount;
 
-mod exec_command;
+mod exec;
 mod runnable_image;
 mod wait_for;
 

--- a/testcontainers/src/core/image/exec.rs
+++ b/testcontainers/src/core/image/exec.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use bytes::Bytes;
+
 use crate::core::WaitFor;
 
 #[derive(Debug)]
@@ -43,9 +45,9 @@ pub enum CmdWaitFor {
     /// An empty condition. Useful for default cases or fallbacks.
     Nothing,
     /// Wait for a message on the stdout stream of the command's output.
-    StdOutMessage { message: String },
+    StdOutMessage { message: Bytes },
     /// Wait for a message on the stderr stream of the command's output.
-    StdErrMessage { message: String },
+    StdErrMessage { message: Bytes },
     /// Wait for a certain amount of time.
     Duration { length: Duration },
     /// Wait for the command's exit code to be equal to the provided one.
@@ -53,15 +55,15 @@ pub enum CmdWaitFor {
 }
 
 impl CmdWaitFor {
-    pub fn message_on_stdout<S: Into<String>>(message: S) -> Self {
+    pub fn message_on_stdout(message: impl AsRef<[u8]>) -> Self {
         Self::StdOutMessage {
-            message: message.into(),
+            message: Bytes::from(message.as_ref().to_vec()),
         }
     }
 
-    pub fn message_on_stderr<S: Into<String>>(message: S) -> Self {
+    pub fn message_on_stderr(message: impl AsRef<[u8]>) -> Self {
         Self::StdErrMessage {
-            message: message.into(),
+            message: Bytes::from(message.as_ref().to_vec()),
         }
     }
 

--- a/testcontainers/src/core/image/exec.rs
+++ b/testcontainers/src/core/image/exec.rs
@@ -46,8 +46,6 @@ pub enum CmdWaitFor {
     StdOutMessage { message: String },
     /// Wait for a message on the stderr stream of the command's output.
     StdErrMessage { message: String },
-    /// Wait for a message on the stdout or stderr stream of the command's output.
-    StdOutOrErrMessage { message: String },
     /// Wait for a certain amount of time.
     Duration { length: Duration },
     /// Wait for the command's exit code to be equal to the provided one.
@@ -63,12 +61,6 @@ impl CmdWaitFor {
 
     pub fn message_on_stderr<S: Into<String>>(message: S) -> Self {
         Self::StdErrMessage {
-            message: message.into(),
-        }
-    }
-
-    pub fn message_on_stdout_or_stderr<S: Into<String>>(message: S) -> Self {
-        Self::StdOutOrErrMessage {
             message: message.into(),
         }
     }

--- a/testcontainers/src/core/image/wait_for.rs
+++ b/testcontainers/src/core/image/wait_for.rs
@@ -1,14 +1,16 @@
 use std::{env::var, time::Duration};
 
+use bytes::Bytes;
+
 /// Represents a condition that needs to be met before a container is considered ready.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum WaitFor {
     /// An empty condition. Useful for default cases or fallbacks.
     Nothing,
     /// Wait for a message on the stdout stream of the container's logs.
-    StdOutMessage { message: String },
+    StdOutMessage { message: Bytes },
     /// Wait for a message on the stderr stream of the container's logs.
-    StdErrMessage { message: String },
+    StdErrMessage { message: Bytes },
     /// Wait for a certain amount of time.
     Duration { length: Duration },
     /// Wait for the container's status to become `healthy`.
@@ -16,15 +18,15 @@ pub enum WaitFor {
 }
 
 impl WaitFor {
-    pub fn message_on_stdout<S: Into<String>>(message: S) -> WaitFor {
+    pub fn message_on_stdout(message: impl AsRef<[u8]>) -> WaitFor {
         WaitFor::StdOutMessage {
-            message: message.into(),
+            message: Bytes::from(message.as_ref().to_vec()),
         }
     }
 
-    pub fn message_on_stderr<S: Into<String>>(message: S) -> WaitFor {
+    pub fn message_on_stderr(message: impl AsRef<[u8]>) -> WaitFor {
         WaitFor::StdErrMessage {
-            message: message.into(),
+            message: Bytes::from(message.as_ref().to_vec()),
         }
     }
 

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -70,7 +70,10 @@
 //! [`testcontainers-modules`]: https://crates.io/crates/testcontainers-modules
 
 pub mod core;
-pub use crate::core::{containers::*, Image, ImageArgs, RunnableImage};
+#[cfg(feature = "blocking")]
+#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+pub use crate::core::Container;
+pub use crate::core::{errors, ContainerAsync, Image, ImageArgs, RunnableImage};
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -223,7 +223,7 @@ where
             .image()
             .exec_after_start(ContainerState::new(container.ports().await))
         {
-            container.exec(cmd).await;
+            container.exec(cmd).await.unwrap();
         }
 
         container
@@ -279,7 +279,7 @@ mod tests {
             .start()
             .await;
 
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
         let publish_ports = container_details
             .host_config
             .unwrap()
@@ -308,7 +308,7 @@ mod tests {
             .start()
             .await;
 
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
 
         let port_bindings = container_details
             .host_config
@@ -328,7 +328,7 @@ mod tests {
             .start()
             .await;
 
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
         let networks = container_details
             .network_settings
             .unwrap()
@@ -350,7 +350,7 @@ mod tests {
             .start()
             .await;
 
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
         let container_name = container_details.name.unwrap();
         assert!(container_name.ends_with("async_hello_container"));
     }
@@ -427,7 +427,7 @@ mod tests {
             .start()
             .await;
 
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
         let shm_size = container_details.host_config.unwrap().shm_size.unwrap();
 
         assert_eq!(shm_size, 1_000_000);
@@ -442,7 +442,7 @@ mod tests {
             .await;
 
         let client = Client::lazy_client().await;
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
 
         let privileged = container_details.host_config.unwrap().privileged.unwrap();
         assert!(privileged, "privileged must be `true`");
@@ -457,7 +457,7 @@ mod tests {
             .await;
 
         let client = Client::lazy_client().await;
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
 
         let cgroupns_mode = container_details
             .host_config
@@ -481,7 +481,7 @@ mod tests {
             .await;
 
         let client = Client::lazy_client().await;
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
 
         let cgroupns_mode = container_details
             .host_config
@@ -505,7 +505,7 @@ mod tests {
             .await;
 
         let client = Client::lazy_client().await;
-        let container_details = client.inspect(container.id()).await;
+        let container_details = client.inspect(container.id()).await.unwrap();
 
         let userns_mode = container_details.host_config.unwrap().userns_mode.unwrap();
         assert_eq!("host", userns_mode, "userns mode must be `host`");

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -80,7 +80,7 @@ mod tests {
     }
 
     fn inspect(id: &str) -> ContainerInspectResponse {
-        runtime().block_on(docker_client().inspect(id))
+        runtime().block_on(docker_client().inspect(id)).unwrap()
     }
 
     fn network_exists(client: &Arc<Client>, name: &str) -> bool {

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -114,7 +114,6 @@ async fn async_run_exec() {
         .await
         .unwrap();
 
-    assert_eq!(res.exit_code().await.unwrap(), Some(0));
     let stdout = String::from_utf8(res.stdout().await.unwrap()).unwrap();
     assert!(stdout.contains("foo"), "stdout must contain 'foo'");
 

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -154,7 +154,6 @@ fn sync_run_exec() {
                 .with_cmd_ready_condition(CmdWaitFor::message_on_stdout("foo")),
         )
         .unwrap();
-    assert_eq!(res.exit_code().unwrap(), Some(0));
     let stdout = String::from_utf8(res.stdout().unwrap()).unwrap();
     assert!(stdout.contains("foo"), "stdout must contain 'foo'");
 

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -167,11 +167,9 @@ fn sync_run_exec() {
         ]))
         .unwrap();
 
-    let mut stdout = String::new();
-    res.stdout_reader().read_to_string(&mut stdout).unwrap();
+    let stdout = String::from_utf8(res.stdout().unwrap()).unwrap();
     assert_eq!(stdout, "stdout 1\nstdout 2\n");
 
-    let mut stderr = String::new();
-    res.stderr_reader().read_to_string(&mut stderr).unwrap();
+    let stderr = String::from_utf8(res.stderr().unwrap()).unwrap();
     assert_eq!(stderr, "stderr 1\nstderr 2\n");
 }


### PR DESCRIPTION
Closes #617
Step towards #502 and #606

Additionally:

- Support non-utf8 logs.