### PR TITLE
feat: ability to access container logs

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -35,7 +35,7 @@ signal-hook = { version = "0.3", optional = true }
 thiserror = "1.0.60"
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
-tokio-util = { version = "0.7.10", features = ["io-util"] }
+tokio-util = { version = "0.7.10", features = ["io"] }
 url = { version = "2", features = ["serde"] }
 
 [features]

--- a/testcontainers/src/core/containers/sync_container/exec.rs
+++ b/testcontainers/src/core/containers/sync_container/exec.rs
@@ -1,4 +1,6 @@
-use std::{fmt, io};
+use std::{fmt, io, io::BufRead};
+
+use crate::core::sync_container::sync_reader;
 
 /// Represents the result of an executed command in a container.
 pub struct SyncExecResult<'a> {
@@ -13,14 +15,30 @@ impl<'a> SyncExecResult<'a> {
         self.runtime.block_on(self.inner.exit_code())
     }
 
+    /// Returns an asynchronous reader for stdout.
+    pub fn stdout<'b>(&'b mut self) -> Box<dyn BufRead + 'b> {
+        Box::new(sync_reader::SyncReadBridge::new(
+            self.inner.stdout(),
+            self.runtime,
+        ))
+    }
+
+    /// Returns an asynchronous reader for stderr.
+    pub fn stderr<'b>(&'b mut self) -> Box<dyn BufRead + 'b> {
+        Box::new(sync_reader::SyncReadBridge::new(
+            self.inner.stderr(),
+            self.runtime,
+        ))
+    }
+
     /// Returns stdout as a vector of bytes.
-    pub fn stdout(&mut self) -> Result<Vec<u8>, io::Error> {
-        self.runtime.block_on(self.inner.stdout())
+    pub fn stdout_to_vec(&mut self) -> Result<Vec<u8>, io::Error> {
+        self.runtime.block_on(self.inner.stdout_to_vec())
     }
 
     /// Returns stderr as a vector of bytes.
-    pub fn stderr(&mut self) -> Result<Vec<u8>, io::Error> {
-        self.runtime.block_on(self.inner.stderr())
+    pub fn stderr_to_vec(&mut self) -> Result<Vec<u8>, io::Error> {
+        self.runtime.block_on(self.inner.stderr_to_vec())
     }
 }
 

--- a/testcontainers/src/core/containers/sync_container/sync_reader.rs
+++ b/testcontainers/src/core/containers/sync_container/sync_reader.rs
@@ -1,0 +1,64 @@
+use std::io::{BufRead, Read};
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt};
+
+/// Allows to use [`tokio::io::AsyncRead`] synchronously as [`std::io::Read`].
+/// In fact, it's almost the same as [`tokio_util::io::SyncIoBridge`], but utilizes [`tokio::runtime::Runtime`] instead of [`tokio::runtime::Handle`].
+/// This is needed because [`tokio::runtime::Handle::block_on`] can't drive the IO on `current_thread` runtime.
+pub(super) struct SyncReadBridge<'a, T> {
+    inner: T,
+    runtime: &'a tokio::runtime::Runtime,
+}
+
+impl<'a, T: Unpin> SyncReadBridge<'a, T> {
+    pub fn new(inner: T, runtime: &'a tokio::runtime::Runtime) -> Self {
+        Self { inner, runtime }
+    }
+}
+
+impl<T: AsyncBufRead + Unpin> BufRead for SyncReadBridge<'_, T> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        let inner = &mut self.inner;
+        self.runtime.block_on(AsyncBufReadExt::fill_buf(inner))
+    }
+
+    fn consume(&mut self, amt: usize) {
+        let inner = &mut self.inner;
+        AsyncBufReadExt::consume(inner, amt)
+    }
+
+    fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> std::io::Result<usize> {
+        let inner = &mut self.inner;
+        self.runtime
+            .block_on(AsyncBufReadExt::read_until(inner, byte, buf))
+    }
+    fn read_line(&mut self, buf: &mut String) -> std::io::Result<usize> {
+        let inner = &mut self.inner;
+        self.runtime
+            .block_on(AsyncBufReadExt::read_line(inner, buf))
+    }
+}
+
+impl<T: AsyncRead + Unpin> Read for SyncReadBridge<'_, T> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let inner = &mut self.inner;
+        self.runtime.block_on(AsyncReadExt::read(inner, buf))
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> std::io::Result<usize> {
+        let inner = &mut self.inner;
+        self.runtime.block_on(inner.read_to_end(buf))
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> std::io::Result<usize> {
+        let inner = &mut self.inner;
+        self.runtime.block_on(inner.read_to_string(buf))
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        let inner = &mut self.inner;
+        // The AsyncRead trait returns the count, synchronous doesn't.
+        let _n = self.runtime.block_on(inner.read_exact(buf))?;
+        Ok(())
+    }
+}

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -114,7 +114,7 @@ async fn async_run_exec() {
         .await
         .unwrap();
 
-    let stdout = String::from_utf8(res.stdout().await.unwrap()).unwrap();
+    let stdout = String::from_utf8(res.stdout_to_vec().await.unwrap()).unwrap();
     assert!(stdout.contains("foo"), "stdout must contain 'foo'");
 
     // stdout and stderr readers
@@ -129,17 +129,11 @@ async fn async_run_exec() {
         .unwrap();
 
     let mut stdout = String::new();
-    res.stdout_reader()
-        .read_to_string(&mut stdout)
-        .await
-        .unwrap();
+    res.stdout().read_to_string(&mut stdout).await.unwrap();
     assert_eq!(stdout, "stdout 1\nstdout 2\n");
 
     let mut stderr = String::new();
-    res.stderr_reader()
-        .read_to_string(&mut stderr)
-        .await
-        .unwrap();
+    res.stderr().read_to_string(&mut stderr).await.unwrap();
     assert_eq!(stderr, "stderr 1\nstderr 2\n");
 }
 


### PR DESCRIPTION
Closes #502

Exposes `stdout` and `stderr` methods, which returns:
- `tokio::io::AsyncBufRead` impl for async container
- `std::io::BufRead` impl for sync container (under `blocking` feature)

Also, small alignment is performed (related to #617):
- rename the `ExecResult` `stdout`/`stderr` methods to match the container methods