### PR TITLE
feat: make container and exec logs `Send`able

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -91,12 +91,12 @@ impl Client {
         Ok(Client { config, bollard })
     }
 
-    pub(crate) fn stdout_logs(&self, id: &str) -> LogStreamAsync<'_> {
-        self.logs(id, LogSource::StdOut)
+    pub(crate) fn stdout_logs(&self, id: &str, follow: bool) -> LogStreamAsync {
+        self.logs(id, LogSource::StdOut, follow)
     }
 
-    pub(crate) fn stderr_logs(&self, id: &str) -> LogStreamAsync<'_> {
-        self.logs(id, LogSource::StdErr)
+    pub(crate) fn stderr_logs(&self, id: &str, follow: bool) -> LogStreamAsync {
+        self.logs(id, LogSource::StdErr, follow)
     }
 
     pub(crate) async fn ports(&self, id: &str) -> Result<Ports, ClientError> {
@@ -152,7 +152,7 @@ impl Client {
         &self,
         container_id: &str,
         cmd: Vec<String>,
-    ) -> Result<ExecResult<'_>, ClientError> {
+    ) -> Result<ExecResult, ClientError> {
         let config = CreateExecOptions {
             cmd: Some(cmd),
             attach_stdout: Some(true),
@@ -245,9 +245,9 @@ impl Client {
             .map_err(ClientError::InspectExec)
     }
 
-    fn logs(&self, container_id: &str, log_source: LogSource) -> LogStreamAsync<'_> {
+    fn logs(&self, container_id: &str, log_source: LogSource, follow: bool) -> LogStreamAsync {
         let options = LogsOptions {
-            follow: true,
+            follow,
             stdout: log_source.is_stdout(),
             stderr: log_source.is_stderr(),
             tail: "all".to_owned(),

--- a/testcontainers/src/core/client/exec.rs
+++ b/testcontainers/src/core/client/exec.rs
@@ -1,21 +1,21 @@
 use crate::core::logs::LogStreamAsync;
 
-pub(crate) struct ExecResult<'a> {
+pub(crate) struct ExecResult {
     pub(crate) id: String,
-    pub(crate) stdout: LogStreamAsync<'a>,
-    pub(crate) stderr: LogStreamAsync<'a>,
+    pub(crate) stdout: LogStreamAsync,
+    pub(crate) stderr: LogStreamAsync,
 }
 
-impl<'a> ExecResult<'a> {
+impl ExecResult {
     pub(crate) fn id(&self) -> &str {
         &self.id
     }
 
-    pub(crate) fn stdout(&mut self) -> &mut LogStreamAsync<'a> {
+    pub(crate) fn stdout(&mut self) -> &mut LogStreamAsync {
         &mut self.stdout
     }
 
-    pub(crate) fn stderr(&mut self) -> &mut LogStreamAsync<'a> {
+    pub(crate) fn stderr(&mut self) -> &mut LogStreamAsync {
         &mut self.stderr
     }
 }

--- a/testcontainers/src/core/containers/async_container/exec.rs
+++ b/testcontainers/src/core/containers/async_container/exec.rs
@@ -7,14 +7,14 @@ use tokio::io::{AsyncBufRead, AsyncReadExt};
 use crate::core::{client::Client, error::Result};
 
 /// Represents the result of an executed command in a container.
-pub struct ExecResult<'a> {
+pub struct ExecResult {
     pub(super) client: Arc<Client>,
     pub(crate) id: String,
-    pub(super) stdout: BoxStream<'a, std::result::Result<Bytes, io::Error>>,
-    pub(super) stderr: BoxStream<'a, std::result::Result<Bytes, io::Error>>,
+    pub(super) stdout: BoxStream<'static, std::result::Result<Bytes, io::Error>>,
+    pub(super) stderr: BoxStream<'static, std::result::Result<Bytes, io::Error>>,
 }
 
-impl<'a> ExecResult<'a> {
+impl ExecResult {
     /// Returns the exit code of the executed command.
     /// If the command has not yet exited, this will return `None`.
     pub async fn exit_code(&self) -> Result<Option<i64>> {
@@ -49,7 +49,7 @@ impl<'a> ExecResult<'a> {
     }
 }
 
-impl fmt::Debug for ExecResult<'_> {
+impl fmt::Debug for ExecResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExecResult").field("id", &self.id).finish()
     }

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -32,14 +32,14 @@ impl LogSource {
     }
 }
 
-pub(crate) struct LogStreamAsync<'a> {
-    inner: BoxStream<'a, Result<Bytes, io::Error>>,
+pub(crate) struct LogStreamAsync {
+    inner: BoxStream<'static, Result<Bytes, io::Error>>,
     cache: Vec<Result<Bytes, io::Error>>,
     enable_cache: bool,
 }
 
-impl<'a> LogStreamAsync<'a> {
-    pub fn new(stream: BoxStream<'a, Result<Bytes, io::Error>>) -> Self {
+impl LogStreamAsync {
+    pub fn new(stream: BoxStream<'static, Result<Bytes, io::Error>>) -> Self {
         Self {
             inner: stream,
             cache: vec![],
@@ -78,7 +78,7 @@ impl<'a> LogStreamAsync<'a> {
         Err(WaitLogError::EndOfStream(messages))
     }
 
-    pub(crate) fn into_inner(self) -> BoxStream<'a, Result<Bytes, io::Error>> {
+    pub(crate) fn into_inner(self) -> BoxStream<'static, Result<Bytes, io::Error>> {
         futures::stream::iter(self.cache).chain(self.inner).boxed()
     }
 }
@@ -90,7 +90,7 @@ fn display_bytes(bytes: &[Bytes]) -> Vec<Cow<'_, str>> {
         .collect::<Vec<_>>()
 }
 
-impl<'a> fmt::Debug for LogStreamAsync<'a> {
+impl fmt::Debug for LogStreamAsync {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LogStreamAsync").finish()
     }


### PR DESCRIPTION
There is no need to stick logs to lifetime of container:
- this way logs can't be sent to another thread/task
- logs will stop with EOF if container has been dropped anyway, what's reasonable
- it's step forward log followers (like in [Java implementation](https://java.testcontainers.org/features/container_logs/))