### PR TITLE
feat: expose follow flag for `stdout` and `stderr`

### DIFF
--- a/testcontainers/src/core/containers/async_container/exec.rs
+++ b/testcontainers/src/core/containers/async_container/exec.rs
@@ -22,12 +22,12 @@ impl ExecResult {
         Ok(res.exit_code)
     }
 
-    /// Returns an asynchronous reader for stdout.
+    /// Returns an asynchronous reader for stdout. It follows log stream until the command exits.
     pub fn stdout<'b>(&'b mut self) -> Pin<Box<dyn AsyncBufRead + 'b>> {
         Box::pin(tokio_util::io::StreamReader::new(&mut self.stdout))
     }
 
-    /// Returns an asynchronous reader for stderr.
+    /// Returns an asynchronous reader for stderr. It follows log stream until the command exits.
     pub fn stderr<'b>(&'b mut self) -> Pin<Box<dyn AsyncBufRead + 'b>> {
         Box::pin(tokio_util::io::StreamReader::new(&mut self.stderr))
     }

--- a/testcontainers/src/core/containers/sync_container/exec.rs
+++ b/testcontainers/src/core/containers/sync_container/exec.rs
@@ -1,10 +1,13 @@
 use std::{fmt, io::BufRead, sync::Arc};
 
-use crate::{core::sync_container::sync_reader, TestcontainersError};
+use crate::{
+    core::{async_container, sync_container::sync_reader},
+    TestcontainersError,
+};
 
 /// Represents the result of an executed command in a container.
 pub struct SyncExecResult {
-    pub(super) inner: crate::core::async_container::exec::ExecResult,
+    pub(super) inner: async_container::exec::ExecResult,
     pub(super) runtime: Arc<tokio::runtime::Runtime>,
 }
 
@@ -32,11 +35,17 @@ impl SyncExecResult {
     }
 
     /// Returns stdout as a vector of bytes.
+    /// Keep in mind that this will block until the command exits.
+    ///
+    /// If you want to read stderr in chunks, use [`SyncExecResult::stdout`] instead.
     pub fn stdout_to_vec(&mut self) -> Result<Vec<u8>, TestcontainersError> {
         self.runtime.block_on(self.inner.stdout_to_vec())
     }
 
     /// Returns stderr as a vector of bytes.
+    /// Keep in mind that this will block until the command exits.
+    ///
+    /// If you want to read stderr in chunks, use [`SyncExecResult::stderr`] instead.
     pub fn stderr_to_vec(&mut self) -> Result<Vec<u8>, TestcontainersError> {
         self.runtime.block_on(self.inner.stderr_to_vec())
     }


### PR DESCRIPTION
It allows to read logs only until the moment of the call (i.e read all currently accessible logs)