### PR TITLE
feat: add ability to read container logs into `Vec`

### DIFF
--- a/testcontainers/src/core/containers/async_container/exec.rs
+++ b/testcontainers/src/core/containers/async_container/exec.rs
@@ -33,7 +33,9 @@ impl ExecResult {
     }
 
     /// Returns stdout as a vector of bytes.
-    /// If you want to read stdout in asynchronous manner, use `stdout_reader` instead.
+    /// Keep in mind that this will block until the command exits.
+    ///
+    /// If you want to read stdout in asynchronous manner, use [`ExecResult::stdout`] instead.
     pub async fn stdout_to_vec(&mut self) -> Result<Vec<u8>> {
         let mut stdout = Vec::new();
         self.stdout().read_to_end(&mut stdout).await?;
@@ -41,7 +43,9 @@ impl ExecResult {
     }
 
     /// Returns stderr as a vector of bytes.
-    /// If you want to read stderr in asynchronous manner, use `stderr_reader` instead.
+    /// Keep in mind that this will block until the command exits.
+    ///
+    /// If you want to read stderr in asynchronous manner, use [`ExecResult::stderr`] instead.
     pub async fn stderr_to_vec(&mut self) -> Result<Vec<u8>> {
         let mut stderr = Vec::new();
         self.stderr().read_to_end(&mut stderr).await?;

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -170,6 +170,24 @@ where
         ))
     }
 
+    /// Returns stdout as a vector of bytes available at the moment of call (from container startup to present).
+    ///
+    /// If you want to read stdout in chunks, use [`Container::stdout`] instead.
+    pub fn stdout_to_vec(&self) -> Result<Vec<u8>> {
+        let mut stdout = Vec::new();
+        self.stdout(false).read_to_end(&mut stdout)?;
+        Ok(stdout)
+    }
+
+    /// Returns stderr as a vector of bytes available at the moment of call (from container startup to present).
+    ///
+    /// If you want to read stderr in chunks, use [`Container::stderr`] instead.
+    pub fn stderr_to_vec(&self) -> Result<Vec<u8>> {
+        let mut stderr = Vec::new();
+        self.stderr(false).read_to_end(&mut stderr)?;
+        Ok(stderr)
+    }
+
     /// Returns reference to inner `Runtime`. It's safe to unwrap because it's `Some` until `Container` is dropped.
     fn rt(&self) -> &Arc<tokio::runtime::Runtime> {
         &self.inner.as_ref().unwrap().runtime
@@ -267,12 +285,10 @@ mod test {
         container.stop()?;
 
         // stdout is empty
-        let mut stdout = String::new();
-        container.stdout(true).read_to_string(&mut stdout)?;
+        let stdout = String::from_utf8(container.stdout_to_vec()?)?;
         assert_eq!(stdout, "");
         // stderr contains 6 lines
-        let mut stderr = String::new();
-        container.stderr(true).read_to_string(&mut stderr)?;
+        let stderr = String::from_utf8(container.stderr_to_vec()?)?;
         assert_eq!(
             stderr.lines().count(),
             6,


### PR DESCRIPTION
We already have these methods for `exec`, they are good shortcuts, and I added them to `Container` as well to make the interfaces consistent.