### PR TITLE
docs: add quickstarts and replicate docs.rs info to website

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -7,7 +7,7 @@ You can override some default properties if your environment requires that.
 The configuration may be loaded from multiple locations. Properties are considered in the following order:
 
 1. Environment variables
-3. `~/.testcontainers.properties` file (a Java properties file, enabled by the `properties-config` feature)
+2. `~/.testcontainers.properties` file (a Java properties file, enabled by the `properties-config` feature)
    Example locations:  
    **Linux:** `/home/myuser/.testcontainers.properties`  
    **Windows:** `C:/Users/myuser/.testcontainers.properties`  

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -1,0 +1,34 @@
+# Custom configuration
+
+You can override some default properties if your environment requires that.
+
+## Configuration locations
+
+The configuration may be loaded from multiple locations. Properties are considered in the following order:
+
+1. Environment variables
+3. `~/.testcontainers.properties` file (a Java properties file, enabled by the `properties-config` feature)
+   Example locations:  
+   **Linux:** `/home/myuser/.testcontainers.properties`  
+   **Windows:** `C:/Users/myuser/.testcontainers.properties`  
+   **macOS:** `/Users/myuser/.testcontainers.properties`
+
+## Docker host resolution
+
+The host is resolved in the following order:
+
+1. Docker host from the `tc.host` property in the `~/.testcontainers.properties` file.
+2. `DOCKER_HOST` environment variable.
+3. Docker host from the "docker.host" property in the `~/.testcontainers.properties` file.
+4. Else, the default Docker socket will be returned.
+
+## Docker authentication
+
+Sometimes the Docker images you use live in a private Docker registry.
+For that reason, Testcontainers for Rust gives you the ability to read the Docker configuration and retrieve the authentication for a given registry.
+Configuration is fetched in the following order:
+
+1. `DOCKER_AUTH_CONFIG` environment variable, unmarshalling the string value from its JSON representation and using it as the Docker config.
+2. `DOCKER_CONFIG` environment variable, as an alternative path to the Docker config file.
+3. else it will load the default Docker config file, which lives in the user's home, e.g. `~/.docker/config.json`.
+

--- a/docs/features/wait/introduction.md
+++ b/docs/features/wait/introduction.md
@@ -1,9 +1,0 @@
-# Wait Strategies
-
-There are scenarios where your tests need the external services they rely on to reach a specific state that is particularly useful for testing. This is generally approximated as 'Can we talk to this container over the network?' or 'Let's wait until the container is running an reaches certain state'.
-
-_Testcontainers for Rust_ comes with the concept of `wait strategy`, which allows your tests to actually wait for the most useful conditions to be met, before continuing with their execution.
-
-## Startup timeout and Poll interval
-
-When defining a wait strategy, it should define a way to set the startup timeout to avoid waiting infinitely.

--- a/docs/features/wait_strategies.md
+++ b/docs/features/wait_strategies.md
@@ -6,27 +6,21 @@ _Testcontainers for
 Rust_ comes with the concept of `wait strategy`, which allows your tests to actually wait for
 the most useful conditions to be met, before continuing with their execution.
 
-The strategy is defined by the [`WaitFor`] enum with the following variants:
+The strategy is defined by the [`WaitFor`](https://docs.rs/testcontainers/0.17.0/testcontainers/core/enum.WaitFor.html)
+enum with the following variants:
 
 * `StdOutMessage` - wait for a specific message to appear on the container's stdout
 * `StdErrMessage` - wait for a specific message to appear on the container's stderr
 * `Healthcheck` - wait for the container to be healthy
 * `Duration` - wait for a specific duration. Usually less preferable and better to combine with other strategies.
 
-[`Image`] implementation is responsible for returning the appropriate `WaitFor` strategies.
-For [`GenericImage`] you can use the `with_wait_for` method to specify the wait strategy.
+[`Image`](https://docs.rs/testcontainers/0.17.0/testcontainers/core/trait.Image.html) implementation
+is responsible for returning the appropriate `WaitFor` strategies.
+For [`GenericImage`](https://docs.rs/testcontainers/0.17.0/testcontainers/struct.GenericImage.html)
+you can use the `with_wait_for` method to specify the wait strategy.
 
 ## Startup timeout and Poll interval
 
 Ordinarily Testcontainers will wait for up to 60 seconds for containers to start.
 If the default 60s timeout is not sufficient, it can be updated with the
-[`RunnableImage::with_startup_timeout(duration)`] method.
-
-
-[`RunnableImage::with_startup_timeout(duration)`]: https://docs.rs/testcontainers/0.17.0/testcontainers/core/struct.RunnableImage.html#method.with_startup_timeout
-
-[`Image`]: https://docs.rs/testcontainers/0.17.0/testcontainers/core/trait.Image.html
-
-[`WaitFor`]: https://docs.rs/testcontainers/0.17.0/testcontainers/core/enum.WaitFor.html
-
-[`GenericImage`]: https://docs.rs/testcontainers/0.17.0/testcontainers/struct.GenericImage.html
+[`RunnableImage::with_startup_timeout(duration)`](https://docs.rs/testcontainers/0.17.0/testcontainers/core/struct.RunnableImage.html#method.with_startup_timeout) method.

--- a/docs/features/wait_strategies.md
+++ b/docs/features/wait_strategies.md
@@ -6,7 +6,7 @@ _Testcontainers for
 Rust_ comes with the concept of `wait strategy`, which allows your tests to actually wait for
 the most useful conditions to be met, before continuing with their execution.
 
-The strategy is defined by the [`WaitFor`](https://docs.rs/testcontainers/0.17.0/testcontainers/core/enum.WaitFor.html)
+The strategy is defined by the [`WaitFor`](https://docs.rs/testcontainers/latest/testcontainers/core/enum.WaitFor.html)
 enum with the following variants:
 
 * `StdOutMessage` - wait for a specific message to appear on the container's stdout
@@ -14,13 +14,13 @@ enum with the following variants:
 * `Healthcheck` - wait for the container to be healthy
 * `Duration` - wait for a specific duration. Usually less preferable and better to combine with other strategies.
 
-[`Image`](https://docs.rs/testcontainers/0.17.0/testcontainers/core/trait.Image.html) implementation
+[`Image`](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html) implementation
 is responsible for returning the appropriate `WaitFor` strategies.
-For [`GenericImage`](https://docs.rs/testcontainers/0.17.0/testcontainers/struct.GenericImage.html)
+For [`GenericImage`](https://docs.rs/testcontainers/latest/testcontainers/struct.GenericImage.html)
 you can use the `with_wait_for` method to specify the wait strategy.
 
 ## Startup timeout and Poll interval
 
 Ordinarily Testcontainers will wait for up to 60 seconds for containers to start.
 If the default 60s timeout is not sufficient, it can be updated with the
-[`RunnableImage::with_startup_timeout(duration)`](https://docs.rs/testcontainers/0.17.0/testcontainers/core/struct.RunnableImage.html#method.with_startup_timeout) method.
+[`RunnableImage::with_startup_timeout(duration)`](https://docs.rs/testcontainers/latest/testcontainers/core/struct.RunnableImage.html#method.with_startup_timeout) method.

--- a/docs/features/wait_strategies.md
+++ b/docs/features/wait_strategies.md
@@ -8,10 +8,10 @@ the most useful conditions to be met, before continuing with their execution.
 
 The strategy is defined by the [`WaitFor`] enum with the following variants:
 
-- `StdOutMessage` - wait for a specific message to appear on the container's stdout
-- `StdErrMessage` - wait for a specific message to appear on the container's stderr
-- `Healthcheck` - wait for the container to be healthy
-- `Duration` - wait for a specific duration. Usually less preferable and better to combine with other strategies.
+* `StdOutMessage` - wait for a specific message to appear on the container's stdout
+* `StdErrMessage` - wait for a specific message to appear on the container's stderr
+* `Healthcheck` - wait for the container to be healthy
+* `Duration` - wait for a specific duration. Usually less preferable and better to combine with other strategies.
 
 [`Image`] implementation is responsible for returning the appropriate `WaitFor` strategies.
 For [`GenericImage`] you can use the `with_wait_for` method to specify the wait strategy.

--- a/docs/features/wait_strategies.md
+++ b/docs/features/wait_strategies.md
@@ -1,0 +1,32 @@
+# Waiting for containers to start or be ready
+
+There are scenarios where your tests need the external services they rely on to reach a specific state that is particularly useful for testing. This is generally approximated as 'Can we talk to this container over the network?' or 'Let's wait until the container is running an reaches certain state'.
+
+_Testcontainers for
+Rust_ comes with the concept of `wait strategy`, which allows your tests to actually wait for
+the most useful conditions to be met, before continuing with their execution.
+
+The strategy is defined by the [`WaitFor`] enum with the following variants:
+
+- `StdOutMessage` - wait for a specific message to appear on the container's stdout
+- `StdErrMessage` - wait for a specific message to appear on the container's stderr
+- `Healthcheck` - wait for the container to be healthy
+- `Duration` - wait for a specific duration. Usually less preferable and better to combine with other strategies.
+
+[`Image`] implementation is responsible for returning the appropriate `WaitFor` strategies.
+For [`GenericImage`] you can use the `with_wait_for` method to specify the wait strategy.
+
+## Startup timeout and Poll interval
+
+Ordinarily Testcontainers will wait for up to 60 seconds for containers to start.
+If the default 60s timeout is not sufficient, it can be updated with the
+[`RunnableImage::with_startup_timeout(duration)`] method.
+
+
+[`RunnableImage::with_startup_timeout(duration)`]: https://docs.rs/testcontainers/0.17.0/testcontainers/core/struct.RunnableImage.html#method.with_startup_timeout
+
+[`Image`]: https://docs.rs/testcontainers/0.17.0/testcontainers/core/trait.Image.html
+
+[`WaitFor`]: https://docs.rs/testcontainers/0.17.0/testcontainers/core/enum.WaitFor.html
+
+[`GenericImage`]: https://docs.rs/testcontainers/0.17.0/testcontainers/struct.GenericImage.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,8 @@ automated integration/smoke tests. The clean, easy-to-use API enables developers
 that should be run as part of a test and clean up those resources when the test is done.
 
 To start using _Testcontainers for Rust_ please read our quickstart guide for:
-- [Ready-to-use `testcontainers-modules` crate](quickstart/community_modules.md)
-- [Core `testcontainers` crate](quickstart/testcontainers.md)
+* [Ready-to-use `testcontainers-modules` crate](quickstart/community_modules.md)
+* [Core `testcontainers` crate](quickstart/testcontainers.md)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,9 @@ _Testcontainers for Rust_ is a Rust library that makes it simple to create and c
 automated integration/smoke tests. The clean, easy-to-use API enables developers to programmatically define containers
 that should be run as part of a test and clean up those resources when the test is done.
 
-To start using _Testcontainers for Rust_ please read our [quickstart guide](./quickstart.md).
-
+To start using _Testcontainers for Rust_ please read our quickstart guide for:
+- [Ready-to-use `testcontainers-modules` crate](quickstart/community_modules.md)
+- [Core `testcontainers` crate](quickstart/testcontainers.md)
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ automated integration/smoke tests. The clean, easy-to-use API enables developers
 that should be run as part of a test and clean up those resources when the test is done.
 
 To start using _Testcontainers for Rust_ please read our quickstart guide for:
+
 * [Ready-to-use `testcontainers-modules` crate](quickstart/community_modules.md)
 * [Core `testcontainers` crate](quickstart/testcontainers.md)
 

--- a/docs/quickstart/community_modules.md
+++ b/docs/quickstart/community_modules.md
@@ -1,0 +1,60 @@
+_Testcontainers for Rust_ are provided as two separate crates: `testcontainers` and `testcontainers-modules`.
+
+While `testcontainers` is the core crate that provides an API for working with containers in a test environment,
+`testcontainers-modules` is a community-maintained crate that provides ready-to-use images (aka modules).
+
+Usually, it's easier to depend on ready-to-use images, as it saves time and effort.
+This guide will show you how to use it.
+
+## 1. Usage
+
+1. Depend on [testcontainers-modules] with necessary features (e.g `postgres`, `minio` etc.)
+    - Enable `blocking` feature if you want to use modules
+      within synchronous tests (feature-gate for `SyncRunner`)
+2. Then start using the modules inside your tests with either `AsyncRunner` or `SyncRunner`
+
+Simple example of using `postgres` module with `SyncRunner` (`blocking` and `posrges` features enabled):
+
+```rust
+use testcontainers_modules::{postgres, testcontainers::runners::SyncRunner};
+
+#[test]
+fn test_with_postgres() {
+    let container = postgres::Postgres::default().start().unwrap();
+    let host_port = container.get_host_port_ipv4(5432).unwrap();
+    let connection_string = &format!(
+        "postgres://postgres:postgres@127.0.0.1:{host_port}/postgres",
+    );
+}
+```
+
+> You don't need to explicitly depend on `testcontainers` as it's re-exported dependency
+> of `testcontainers-modules` with aligned version between these crates.
+> For example:
+>
+>```rust
+>use testcontainers_modules::testcontainers::RunnableImage;
+>```
+
+You can also see [examples](https://github.com/testcontainers/testcontainers-rs-modules-community/tree/main/examples)
+for more details.
+
+## 2. How to override module defaults
+
+Sometimes it's necessary to override default settings of the module (e.g `tag`, `name`, environment variables etc.)
+In order to do that, just use [RunnableImage](https://docs.rs/testcontainers/latest/testcontainers/core/struct.RunnableImage.html):
+
+```rust
+use testcontainers_modules::{
+    redis::Redis,
+    testcontainers::RunnableImage
+};
+
+
+/// Create a Redis module with `6.2-alpine` tag and custom password
+fn create_redis() -> RunnableImage<Redis> {
+    RunnableImage::from(Redis::default())
+        .with_tag("6.2-alpine")
+        .with_env_var(("REDIS_PASSWORD", "my_secret_password"))
+}
+```

--- a/docs/quickstart/testcontainers.md
+++ b/docs/quickstart/testcontainers.md
@@ -1,0 +1,96 @@
+_Testcontainers for Rust_ plays well with the native `cargo test`.
+
+The ideal use case is for integration or end to end tests. It helps you to spin
+up and manage the dependencies life cycle via Docker.
+
+## 1. System requirements
+
+Please read the [system requirements](../system_requirements/) page before you start.
+
+## 2. Install _Testcontainers for Rust_
+
+- If your tests are async:
+```sh
+cargo add testcontainers
+```
+- If you don't use async and want to use the blocking API:
+```sh
+cargo add testcontainers --features blocking
+```
+
+## 3. Spin up Redis
+
+```rust
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage};
+
+#[tokio::test]
+async fn test_redis() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let container = GenericImage::new("redis", "7.2.4")
+        .with_exposed_port(6379)
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()?
+        .await;
+}
+```
+
+Here we use the `GenericImage` struct to create a Redis container.
+
+* `GenericImage::new` accepts the image name and tag.
+* `with_exposed_port` adds a port to be exposed from the container (can be called multiple times).
+* `with_wait_for` allows to pass conditions (`WaitFor`) of container rediness. It
+  is important to get this set because it helps to know when the container is
+  ready to receive any traffic. In this case, we check for the logs we know come
+  from Redis, telling us that it is ready to accept requests.
+* `start` is a function of the `AsyncRunner` trait that starts the container.
+  The same logic is applicable for `SyncRunner` if you are using `blocking` feature.
+
+When you use `with_exposed_port` you have to imagine yourself using `docker run -p
+<port>`. When you do so, `dockerd` maps the selected `<port>` from inside the
+container to a random one available on your host.
+
+In the previous example, we expose `6379` for `tcp` traffic to the outside. This
+allows Redis to be reachable from your code that runs outside the container, but
+it also makes parallelization possible. When you run multiple cargo tests in parallel,
+each test starts a Redis container, and each of them is exposed on a different random port.
+
+All the containers must be removed at some point, otherwise they will run until
+the host is overloaded. In order to provide a clean environment, we rely on `RAII` semantic
+of containers (`Drop` trait). Thus, when the container goes out of scope, it is removed by default.
+However, you can change this behavior by setting the `TESTCONTAINERS_COMMAND` environment
+variable to `keep`.
+
+## 4. Make your code to talk with the container
+
+We will use [redis](https://github.com/redis-rs/redis-rs) as a client in this example.
+This code gets the endpoint from the container we just started, and it configures the client.
+
+> This is just an example, you can choose any client you want (e.g [`fred`](https://github.com/aembke/fred.rs))
+
+```rust
+use redis::Client;
+use testcontainers::{core::WaitFor, runners::AsyncRunner, GenericImage};
+
+#[tokio::test]
+async fn test_redis() -> Result<(), Box<dyn std::error::Error + 'static>> {
+    let container = GenericImage::new("redis", "7.2.4")
+        .with_exposed_port(6379)
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()?
+        .await;
+    let host = container.get_host()?;
+    let host_port = container.get_host_port_ipv4(REDIS_PORT)?;
+
+    let url = format!("redis://{host}:{host_port}");
+    let client = redis::Client::open(url.as_ref())?;
+    // do something with the client
+}
+```
+
+* `get_host` returns the host that this container may be reached on (may not be the local machine).
+  In most of the cases it will be `localhost`.
+* `get_host_port_ipv4` returns the mapped host port for an internal port of this docker container.
+  In this case it returns the port that was exposed by the container.
+
+## 5. Run the test
+
+You can run the test via `cargo test`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,49 +2,52 @@
 site_name: Testcontainers for Rust
 site_url: https://rust.testcontainers.org
 plugins:
-    - search
-    - codeinclude
-    - include-markdown
-    - markdownextradata
+  - search
+  - codeinclude
+  - include-markdown
+  - markdownextradata
 theme:
-    name: material
-    custom_dir: docs/theme
-    palette:
-        scheme: testcontainers
-    font:
-        text: Roboto
-        code: Roboto Mono
-    logo: logo.svg
-    favicon: favicon.ico
+  name: material
+  custom_dir: docs/theme
+  palette:
+    scheme: testcontainers
+  font:
+    text: Roboto
+    code: Roboto Mono
+  logo: logo.svg
+  favicon: favicon.ico
 extra_css:
-    - css/extra.css
-    - css/tc-header.css
+  - css/extra.css
+  - css/tc-header.css
 repo_name: testcontainers-rs
 repo_url: https://github.com/testcontainers/testcontainers-rs
 markdown_extensions:
-    - admonition
-    - codehilite:
-        linenums: false
-    - pymdownx.superfences
-    - pymdownx.tabbed:
-        alternate_style: true
-    - pymdownx.snippets
-    - toc:
-        permalink: true
-    - attr_list
-    - pymdownx.emoji:
-        emoji_generator: !!python/name:material.extensions.emoji.to_svg
-        emoji_index: !!python/name:material.extensions.emoji.twemoji
+  - admonition
+  - codehilite:
+      linenums: false
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+  - toc:
+      permalink: true
+  - attr_list
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
 nav:
-    - Home: index.md
-    - Features:
-        - Wait Strategies:
-            - Introduction: features/wait/introduction.md
-    - System Requirements:
-        - system_requirements/docker.md
-    - Contributing:
-        - contributing_docs.md
-    - Getting help: getting_help.md
+  - Home: index.md
+  - Quickstart:
+      - quickstart/testcontainers.md
+      - quickstart/community_modules.md
+  - Features:
+      - features/configuration.md
+      - features/wait_strategies.md
+  - System Requirements:
+      - system_requirements/docker.md
+  - Contributing:
+      - contributing_docs.md
+  - Getting help: getting_help.md
 edit_uri: edit/main/docs/
 extra:
-    latest_version: 0.16.7
+  latest_version: 0.16.7


### PR DESCRIPTION
Add quick-start guides and some basic documentation from `docs.rs` (e.g configuration, wait strategies).

We still need to cover a lot of topics to make it more visible, but let's do it iteratively!