### PR TITLE
refactor!: get rid of associated type `ImageArgs` and rename to `cmd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Testcontainers-rs
 
-![Continuous Integration](https://github.com/testcontainers/testcontainers-rs/workflows/Continuous%20Integration/badge.svg?branch=main)
+![Continuous Integration](https://github.com/testcontainers/testcontainers-rs/actions/workflows/ci.yml/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/testcontainers.svg)](https://crates.io/crates/testcontainers)
 [![Docs.rs](https://docs.rs/testcontainers/badge.svg)](https://docs.rs/testcontainers)
 [![Slack](https://img.shields.io/badge/Slack-join-orange?style=flat&logo=slack&)](https://join.slack.com/t/testcontainers/shared_invite/zt-2gra37tid-n9xDJGjjVb7hMRanGjowkw)
@@ -29,7 +29,8 @@ fn test_redis() {
     let container = GenericImage::new("redis", "7.2.4")
         .with_exposed_port(6379)
         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
-        .start();
+        .start()
+        .expect("Redis started");
 }
 ```
 
@@ -44,7 +45,8 @@ async fn test_redis() {
         .with_exposed_port(6379)
         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
         .start()
-        .await;
+        .await
+        .expect("Redis started");
 }
 ```
 

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,7 +1,7 @@
 pub use self::{
     containers::*,
     image::{
-        CgroupnsMode, CmdWaitFor, ContainerState, ExecCommand, Host, Image, ImageArgs, PortMapping,
+        CgroupnsMode, CmdWaitFor, ContainerState, ExecCommand, Host, Image, PortMapping,
         RunnableImage, WaitFor,
     },
     mounts::{AccessMode, Mount, MountType},

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -83,16 +83,6 @@ where
         self.image.image()
     }
 
-    /// Returns a reference to the [`arguments`] of the [`Image`] of this container.
-    ///
-    /// Access to this is useful to retrieve relevant information which had been passed as [`arguments`]
-    ///
-    /// [`Image`]: trait.Image.html
-    /// [`arguments`]: trait.Image.html#associatedtype.Args
-    pub fn image_args(&self) -> &I::Args {
-        self.image.args()
-    }
-
     pub async fn ports(&self) -> Result<Ports> {
         self.docker_client.ports(&self.id).await.map_err(Into::into)
     }

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -73,16 +73,6 @@ where
         self.async_impl().image()
     }
 
-    /// Returns a reference to the [`arguments`] of the [`Image`] of this container.
-    ///
-    /// Access to this is useful to retrieve relevant information which had been passed as [`arguments`]
-    ///
-    /// [`Image`]: trait.Image.html
-    /// [`arguments`]: trait.Image.html#associatedtype.Args
-    pub fn image_args(&self) -> &I::Args {
-        self.async_impl().image_args()
-    }
-
     pub fn ports(&self) -> Result<Ports> {
         self.rt().block_on(self.async_impl().ports())
     }
@@ -225,8 +215,6 @@ mod test {
     pub struct HelloWorld;
 
     impl Image for HelloWorld {
-        type Args = ();
-
         fn name(&self) -> String {
             "hello-world".to_owned()
         }

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -22,20 +22,7 @@ mod wait_for;
 pub trait Image
 where
     Self: Sized + Sync + Send,
-    Self::Args: ImageArgs + Clone + Debug + Sync + Send,
 {
-    /// A type representing the arguments for an Image.
-    ///
-    /// There are a couple of things regarding the arguments of images:
-    ///
-    /// 1. Similar to the Default implementation of an Image, the Default instance
-    /// of its arguments should be meaningful!
-    /// 2. Implementations should be conservative about which arguments they expose. Many times,
-    /// users will either go with the default arguments or just override one or two. When defining
-    /// the arguments of your image, consider that the whole purpose is to facilitate integration
-    /// testing. Only expose those that actually make sense for this case.
-    type Args;
-
     /// The name of the docker image to pull from the Docker Hub registry.
     fn name(&self) -> String;
 
@@ -80,9 +67,14 @@ where
         Box::new(std::iter::empty())
     }
 
-    /// Returns the entrypoint this instance was created with.
+    /// Returns the [entrypoint](`https://docs.docker.com/reference/dockerfile/#entrypoint`) this image needs to be created with.
     fn entrypoint(&self) -> Option<String> {
         None
+    }
+
+    /// Returns the [`CMD`](https://docs.docker.com/reference/dockerfile/#cmd) this image needs to be created with.
+    fn cmd(&self) -> impl IntoIterator<Item = impl Into<String>> {
+        std::iter::empty::<String>()
     }
 
     /// Returns the ports that needs to be exposed when a container is created.
@@ -146,15 +138,5 @@ impl ContainerState {
                 id: self.id.clone(),
                 port: internal_port,
             })
-    }
-}
-
-pub trait ImageArgs {
-    fn into_iterator(self) -> Box<dyn Iterator<Item = String>>;
-}
-
-impl ImageArgs for () {
-    fn into_iterator(self) -> Box<dyn Iterator<Item = String>> {
-        Box::new(vec![].into_iter())
     }
 }

--- a/testcontainers/src/core/image/runnable_image.rs
+++ b/testcontainers/src/core/image/runnable_image.rs
@@ -149,7 +149,7 @@ impl<I: Image> RunnableImage<I> {
     ///
     /// assert_eq!(runnable_image.cmd(), &cmd);
     ///
-    /// let another_runnable_image = RunnableImage::from((image, cmd));
+    /// let another_runnable_image = RunnableImage::from(image).with_cmd(cmd);
     ///
     /// assert_eq!(another_runnable_image.cmd(), runnable_image.cmd());
     /// ```

--- a/testcontainers/src/core/image/runnable_image.rs
+++ b/testcontainers/src/core/image/runnable_image.rs
@@ -145,7 +145,7 @@ impl<I: Image> RunnableImage<I> {
     ///
     /// let image = GenericImage::default();
     /// let cmd = ["arg1", "arg2"];
-    /// let runnable_image = RunnableImage::from(image.clone()).with_cmd(&cmd);
+    /// let runnable_image = RunnableImage::from(image.clone()).with_cmd(cmd);
     ///
     /// assert_eq!(runnable_image.cmd(), &cmd);
     ///

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -72,9 +72,7 @@ pub mod core;
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub use crate::core::Container;
-pub use crate::core::{
-    error::TestcontainersError, ContainerAsync, Image, ImageArgs, RunnableImage,
-};
+pub use crate::core::{error::TestcontainersError, ContainerAsync, Image, RunnableImage};
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -15,7 +15,7 @@ use crate::{
         network::Network,
         CgroupnsMode, ContainerState,
     },
-    ContainerAsync, Image, ImageArgs, RunnableImage,
+    ContainerAsync, Image, RunnableImage,
 };
 
 const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
@@ -182,13 +182,9 @@ where
                 });
             }
 
-            let args = runnable_image
-                .args()
-                .clone()
-                .into_iterator()
-                .collect::<Vec<String>>();
-            if !args.is_empty() {
-                config.cmd = Some(args);
+            let cmd = runnable_image.cmd();
+            if !cmd.is_empty() {
+                config.cmd = Some(cmd);
             }
 
             // create the container with options

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -94,8 +94,6 @@ mod tests {
     }
 
     impl Image for HelloWorld {
-        type Args = ();
-
         fn name(&self) -> String {
             "hello-world".to_owned()
         }

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -12,8 +12,6 @@ use tokio::io::AsyncReadExt;
 pub struct HelloWorld;
 
 impl Image for HelloWorld {
-    type Args = ();
-
     fn name(&self) -> String {
         "hello-world".to_owned()
     }

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -15,8 +15,6 @@ fn get_server_container(msg: Option<WaitFor>) -> GenericImage {
 pub struct HelloWorld;
 
 impl Image for HelloWorld {
-    type Args = ();
-
     fn name(&self) -> String {
         "hello-world".to_owned()
     }
@@ -92,7 +90,8 @@ fn generic_image_running_with_extra_hosts_added() -> anyhow::Result<()> {
 
     // Override hosts for server_2 adding
     // custom-host as an alias for localhost
-    let server_2 = RunnableImage::from((server_2, vec![format!("http://custom-host:{port}")]))
+    let server_2 = RunnableImage::from(server_2)
+        .with_cmd([format!("http://custom-host:{port}")])
         .with_host("custom-host", Host::HostGateway);
 
     server_2.start()?;


### PR DESCRIPTION
- really common pattern is to use `Vec<String>`
- `args` isn't the best term, because in fact it's Docker's [CMD](https://docs.docker.com/reference/dockerfile/#cmd)
- it was not aligned with existing `ExecCommand`
- current interface is confusing and users struggle with it
- essentially it should be closer to the current representation of environment variables and other parameters
- new implementation allows to override args regardless of underlying type
- it's still will be possible to use custom strict arguments type for particular image which can be converted to list of strings if users want

Dependent PR to modules: https://github.com/testcontainers/testcontainers-rs-modules-community/pull/143

Also, I'm preparing 2 follow-up PRs which will improve the user experience.