### PR TITLE
chore!: bump MSRV to `1.75` to allow `RPIT` & `AFIT`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["docker", "testcontainers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/testcontainers/testcontainers-rs"
-rust-version = "1.70"
+rust-version = "1.75"
 
 [workspace.dependencies]
 testimages = { path = "testimages" }


### PR DESCRIPTION
It's really helpful and allows some further refactoring for better API.

In most of the cases, it should not be a problem (and even pretty common) to run test against fresher versions of Rust.

PR is needed for https://github.com/testcontainers/testcontainers-rs/pull/649 and couple of follow-up PRs