### PR TITLE
refactor(image): avoid unnecessary owned structs and boxing

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
 dirs = "5.0.1"
 docker_credential = "1.3.1"
+either = "1.12.0"
 futures = "0.3"
 log = "0.4"
 memchr = "2.7.2"

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -215,12 +215,12 @@ mod test {
     pub struct HelloWorld;
 
     impl Image for HelloWorld {
-        fn name(&self) -> String {
-            "hello-world".to_owned()
+        fn name(&self) -> &str {
+            "hello-world"
         }
 
-        fn tag(&self) -> String {
-            "latest".to_owned()
+        fn tag(&self) -> &str {
+            "latest"
         }
 
         fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -94,12 +94,12 @@ mod tests {
     }
 
     impl Image for HelloWorld {
-        fn name(&self) -> String {
-            "hello-world".to_owned()
+        fn name(&self) -> &str {
+            "hello-world"
         }
 
-        fn tag(&self) -> String {
-            "latest".to_owned()
+        fn tag(&self) -> &str {
+            "latest"
         }
 
         fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -12,12 +12,12 @@ use tokio::io::AsyncReadExt;
 pub struct HelloWorld;
 
 impl Image for HelloWorld {
-    fn name(&self) -> String {
-        "hello-world".to_owned()
+    fn name(&self) -> &str {
+        "hello-world"
     }
 
-    fn tag(&self) -> String {
-        "latest".to_owned()
+    fn tag(&self) -> &str {
+        "latest"
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -15,12 +15,12 @@ fn get_server_container(msg: Option<WaitFor>) -> GenericImage {
 pub struct HelloWorld;
 
 impl Image for HelloWorld {
-    fn name(&self) -> String {
-        "hello-world".to_owned()
+    fn name(&self) -> &str {
+        "hello-world"
     }
 
-    fn tag(&self) -> String {
-        "latest".to_owned()
+    fn tag(&self) -> &str {
+        "latest"
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {


### PR DESCRIPTION
It's quite big incompatible change, but in general it doesn't require a lot of work to switch to new API.
And it will be mostly transparent for users of [ready-to-use modules](https://github.com/testcontainers/testcontainers-rs-modules-community/pull/144)

- get rid of `Box<dyn Iterator<..>`, use RPIT instead
- use `Into<Cow<'_, str>` instead of `&String`
- use `&str` instead of `String`

In fact, we don't need owned structs from image methods, and even if we need - it's better to cast implicitly under the hood, avoiding extra cloning in every image implementation.

Also, a new API relaxes requirements of returned type and makes some use-cases simpler.