### PR TITLE
refactor!: add `ImageExt` trait to avoid explicit conversion to `RunnableImage`

### DIFF
--- a/docs/quickstart/community_modules.md
+++ b/docs/quickstart/community_modules.md
@@ -42,18 +42,19 @@ for more details.
 ## 2. How to override module defaults
 
 Sometimes it's necessary to override default settings of the module (e.g `tag`, `name`, environment variables etc.)
-In order to do that, just use [RunnableImage](https://docs.rs/testcontainers/latest/testcontainers/core/struct.RunnableImage.html):
+In order to do that, just use extension trait [ImageExt](https://docs.rs/testcontainers/latest/testcontainers/core/trait.ImageExt.html)
+that returns customized [RunnableImage](https://docs.rs/testcontainers/latest/testcontainers/core/struct.RunnableImage.html):
 
 ```rust
 use testcontainers_modules::{
     redis::Redis,
-    testcontainers::RunnableImage
+    testcontainers::{RunnableImage, ImageExt},
 };
 
 
 /// Create a Redis module with `6.2-alpine` tag and custom password
 fn create_redis() -> RunnableImage<Redis> {
-    RunnableImage::from(Redis::default())
+    Redis::default()
         .with_tag("6.2-alpine")
         .with_env_var(("REDIS_PASSWORD", "my_secret_password"))
 }

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,7 +1,7 @@
 pub use self::{
     containers::*,
     image::{
-        CgroupnsMode, CmdWaitFor, ContainerState, ExecCommand, Host, Image, PortMapping,
+        CgroupnsMode, CmdWaitFor, ContainerState, ExecCommand, Host, Image, ImageExt, PortMapping,
         RunnableImage, WaitFor,
     },
     mounts::{AccessMode, Mount, MountType},

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -392,13 +392,12 @@ mod tests {
 
     use tokio::io::AsyncBufReadExt;
 
-    use super::*;
     use crate::{images::generic::GenericImage, runners::AsyncRunner};
 
     #[tokio::test]
     async fn async_logs_are_accessible() -> anyhow::Result<()> {
         let image = GenericImage::new("testcontainers/helloworld", "1.1.0");
-        let container = RunnableImage::from(image).start().await?;
+        let container = image.start().await?;
 
         let stderr = container.stderr(true);
 

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -209,7 +209,7 @@ impl<I: Image> Drop for Container<I> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{core::WaitFor, runners::SyncRunner, GenericImage, RunnableImage};
+    use crate::{core::WaitFor, runners::SyncRunner, GenericImage};
 
     #[derive(Debug, Default)]
     pub struct HelloWorld;
@@ -238,7 +238,7 @@ mod test {
     #[test]
     fn sync_logs_are_accessible() -> anyhow::Result<()> {
         let image = GenericImage::new("testcontainers/helloworld", "1.1.0");
-        let container = RunnableImage::from(image).start()?;
+        let container = image.start()?;
 
         let stderr = container.stderr(true);
 

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, fmt::Debug};
 
 pub use exec::{CmdWaitFor, ExecCommand};
+pub use image_ext::ImageExt;
 pub use runnable_image::{CgroupnsMode, Host, PortMapping, RunnableImage};
 pub use wait_for::WaitFor;
 
@@ -8,6 +9,7 @@ use super::ports::Ports;
 use crate::{core::mounts::Mount, TestcontainersError};
 
 mod exec;
+mod image_ext;
 mod runnable_image;
 mod wait_for;
 

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -1,0 +1,171 @@
+use std::time::Duration;
+
+use crate::{
+    core::{CgroupnsMode, Host, Mount, PortMapping},
+    Image, RunnableImage,
+};
+
+pub trait ImageExt<I: Image> {
+    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I>;
+    fn with_name(self, name: impl Into<String>) -> RunnableImage<I>;
+    fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I>;
+    fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I>;
+    fn with_network(self, network: impl Into<String>) -> RunnableImage<I>;
+    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I>;
+    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I>;
+    fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I>;
+    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I>;
+    fn with_privileged(self, privileged: bool) -> RunnableImage<I>;
+    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I>;
+    fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I>;
+    fn with_shm_size(self, bytes: u64) -> RunnableImage<I>;
+    fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I>;
+}
+
+impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
+    /// Returns a new RunnableImage with the specified (overridden) `CMD` ([`Image::cmd`]).
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// use testcontainers::{GenericImage, ImageExt};
+    ///
+    /// let image = GenericImage::new("image", "tag");
+    /// let cmd = ["arg1", "arg2"];
+    /// let overridden_cmd = image.clone().with_cmd(cmd);
+    ///
+    /// assert!(overridden_cmd.cmd().eq(cmd));
+    ///
+    /// let another_runnable_image = image.with_cmd(cmd);
+    ///
+    /// assert!(another_runnable_image.cmd().eq(overridden_cmd.cmd()));
+    /// ```
+    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            overridden_cmd: cmd.into_iter().map(Into::into).collect(),
+            ..runnable
+        }
+    }
+
+    /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
+    /// Can be used to specify a custom registry or owner.
+    fn with_name(self, name: impl Into<String>) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            image_name: Some(name.into()),
+            ..runnable
+        }
+    }
+
+    /// Overrides the image tag.
+    ///
+    /// There is no guarantee that the specified tag for an image would result in a
+    /// running container. Users of this API are advised to use this at their own risk.
+    fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            image_tag: Some(tag.into()),
+            ..runnable
+        }
+    }
+
+    /// Sets the container name.
+    fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I> {
+        let runnable = self.into();
+
+        RunnableImage {
+            container_name: Some(name.into()),
+            ..runnable
+        }
+    }
+
+    /// Sets the network the container will be connected to.
+    fn with_network(self, network: impl Into<String>) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            network: Some(network.into()),
+            ..runnable
+        }
+    }
+
+    /// Adds an environment variable to the container.
+    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I> {
+        let mut runnable = self.into();
+        runnable.env_vars.insert(name.into(), value.into());
+        runnable
+    }
+
+    /// Adds a host to the container.
+    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I> {
+        let mut runnable = self.into();
+        runnable.hosts.insert(key.into(), value.into());
+        runnable
+    }
+
+    /// Adds a mount to the container.
+    fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I> {
+        let mut runnable = self.into();
+        runnable.mounts.push(mount.into());
+        runnable
+    }
+
+    /// Adds a port mapping to the container.
+    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I> {
+        let runnable = self.into();
+        let mut ports = runnable.ports.unwrap_or_default();
+        ports.push(port.into());
+
+        RunnableImage {
+            ports: Some(ports),
+            ..runnable
+        }
+    }
+
+    /// Sets the container to run in privileged mode.
+    fn with_privileged(self, privileged: bool) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            privileged,
+            ..runnable
+        }
+    }
+
+    /// cgroup namespace mode for the container. Possible values are:
+    /// - `\"private\"`: the container runs in its own private cgroup namespace
+    /// - `\"host\"`: use the host system's cgroup namespace
+    /// If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration.
+    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            cgroupns_mode: Some(cgroupns_mode),
+            ..runnable
+        }
+    }
+
+    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
+    fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            userns_mode: Some(String::from(userns_mode)),
+            ..runnable
+        }
+    }
+
+    /// Sets the shared memory size in bytes
+    fn with_shm_size(self, bytes: u64) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            shm_size: Some(bytes),
+            ..runnable
+        }
+    }
+
+    /// Sets the startup timeout for the container. The default is 60 seconds.
+    fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I> {
+        let runnable = self.into();
+        RunnableImage {
+            startup_timeout: Some(timeout),
+            ..runnable
+        }
+    }
+}

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -6,23 +6,6 @@ use crate::{
 };
 
 pub trait ImageExt<I: Image> {
-    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I>;
-    fn with_name(self, name: impl Into<String>) -> RunnableImage<I>;
-    fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I>;
-    fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I>;
-    fn with_network(self, network: impl Into<String>) -> RunnableImage<I>;
-    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I>;
-    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I>;
-    fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I>;
-    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I>;
-    fn with_privileged(self, privileged: bool) -> RunnableImage<I>;
-    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I>;
-    fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I>;
-    fn with_shm_size(self, bytes: u64) -> RunnableImage<I>;
-    fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I>;
-}
-
-impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
     /// Returns a new RunnableImage with the specified (overridden) `CMD` ([`Image::cmd`]).
     ///
     /// # Examples
@@ -39,6 +22,56 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
     ///
     /// assert!(another_runnable_image.cmd().eq(overridden_cmd.cmd()));
     /// ```
+    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I>;
+
+    /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
+    /// Can be used to specify a custom registry or owner.
+    fn with_name(self, name: impl Into<String>) -> RunnableImage<I>;
+
+    /// Overrides the image tag.
+    ///
+    /// There is no guarantee that the specified tag for an image would result in a
+    /// running container. Users of this API are advised to use this at their own risk.
+    fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I>;
+
+    /// Sets the container name.
+    fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I>;
+
+    /// Sets the network the container will be connected to.
+    fn with_network(self, network: impl Into<String>) -> RunnableImage<I>;
+
+    /// Adds an environment variable to the container.
+    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I>;
+
+    /// Adds a host to the container.
+    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I>;
+
+    /// Adds a mount to the container.
+    fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I>;
+
+    /// Adds a port mapping to the container.
+    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I>;
+
+    /// Sets the container to run in privileged mode.
+    fn with_privileged(self, privileged: bool) -> RunnableImage<I>;
+
+    /// cgroup namespace mode for the container. Possible values are:
+    /// - [`CgroupnsMode::Private`]: the container runs in its own private cgroup namespace
+    /// - [`CgroupnsMode::Host`]: use the host system's cgroup namespace
+    /// If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration.
+    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I>;
+
+    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
+    fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I>;
+
+    /// Sets the shared memory size in bytes
+    fn with_shm_size(self, bytes: u64) -> RunnableImage<I>;
+
+    /// Sets the startup timeout for the container. The default is 60 seconds.
+    fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I>;
+}
+
+impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
     fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -47,8 +80,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
-    /// Can be used to specify a custom registry or owner.
     fn with_name(self, name: impl Into<String>) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -57,10 +88,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Overrides the image tag.
-    ///
-    /// There is no guarantee that the specified tag for an image would result in a
-    /// running container. Users of this API are advised to use this at their own risk.
     fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -69,7 +96,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Sets the container name.
     fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I> {
         let runnable = self.into();
 
@@ -79,7 +105,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Sets the network the container will be connected to.
     fn with_network(self, network: impl Into<String>) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -88,28 +113,24 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Adds an environment variable to the container.
     fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I> {
         let mut runnable = self.into();
         runnable.env_vars.insert(name.into(), value.into());
         runnable
     }
 
-    /// Adds a host to the container.
     fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I> {
         let mut runnable = self.into();
         runnable.hosts.insert(key.into(), value.into());
         runnable
     }
 
-    /// Adds a mount to the container.
     fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I> {
         let mut runnable = self.into();
         runnable.mounts.push(mount.into());
         runnable
     }
 
-    /// Adds a port mapping to the container.
     fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I> {
         let runnable = self.into();
         let mut ports = runnable.ports.unwrap_or_default();
@@ -121,7 +142,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Sets the container to run in privileged mode.
     fn with_privileged(self, privileged: bool) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -130,10 +150,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// cgroup namespace mode for the container. Possible values are:
-    /// - `\"private\"`: the container runs in its own private cgroup namespace
-    /// - `\"host\"`: use the host system's cgroup namespace
-    /// If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration.
     fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -142,7 +158,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
     fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -151,7 +166,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Sets the shared memory size in bytes
     fn with_shm_size(self, bytes: u64) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {
@@ -160,7 +174,6 @@ impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    /// Sets the startup timeout for the container. The default is 60 seconds.
     fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I> {
         let runnable = self.into();
         RunnableImage {

--- a/testcontainers/src/core/image/runnable_image.rs
+++ b/testcontainers/src/core/image/runnable_image.rs
@@ -43,7 +43,9 @@ pub enum Host {
 
 #[derive(Debug, Clone, Copy)]
 pub enum CgroupnsMode {
+    /// Use the host system's cgroup namespace
     Host,
+    /// Private cgroup namespace
     Private,
 }
 

--- a/testcontainers/src/core/image/runnable_image.rs
+++ b/testcontainers/src/core/image/runnable_image.rs
@@ -9,21 +9,21 @@ use crate::{
 #[must_use]
 #[derive(Debug, Clone)]
 pub struct RunnableImage<I: Image> {
-    image: I,
-    overridden_cmd: Vec<String>,
-    image_name: Option<String>,
-    image_tag: Option<String>,
-    container_name: Option<String>,
-    network: Option<String>,
-    env_vars: BTreeMap<String, String>,
-    hosts: BTreeMap<String, Host>,
-    mounts: Vec<Mount>,
-    ports: Option<Vec<PortMapping>>,
-    privileged: bool,
-    shm_size: Option<u64>,
-    cgroupns_mode: Option<CgroupnsMode>,
-    userns_mode: Option<String>,
-    startup_timeout: Option<Duration>,
+    pub(super) image: I,
+    pub(super) overridden_cmd: Vec<String>,
+    pub(super) image_name: Option<String>,
+    pub(super) image_tag: Option<String>,
+    pub(super) container_name: Option<String>,
+    pub(super) network: Option<String>,
+    pub(super) env_vars: BTreeMap<String, String>,
+    pub(super) hosts: BTreeMap<String, Host>,
+    pub(super) mounts: Vec<Mount>,
+    pub(super) ports: Option<Vec<PortMapping>>,
+    pub(super) privileged: bool,
+    pub(super) shm_size: Option<u64>,
+    pub(super) cgroupns_mode: Option<CgroupnsMode>,
+    pub(super) userns_mode: Option<String>,
+    pub(super) startup_timeout: Option<Duration>,
 }
 
 /// Represents a port mapping between a local port and the internal port of a container.
@@ -141,136 +141,6 @@ impl<I: Image> RunnableImage<I> {
     /// Returns the startup timeout for the container.
     pub fn startup_timeout(&self) -> Option<Duration> {
         self.startup_timeout
-    }
-}
-
-impl<I: Image> RunnableImage<I> {
-    /// Returns a new RunnableImage with the specified (overridden) `CMD` ([`Image::cmd`]).
-    ///
-    /// # Examples
-    /// ```rust,no_run
-    /// use testcontainers::{core::RunnableImage, GenericImage};
-    ///
-    /// let image = GenericImage::default();
-    /// let cmd = ["arg1", "arg2"];
-    /// let runnable_image = RunnableImage::from(image.clone()).with_cmd(cmd);
-    ///
-    /// assert!(runnable_image.cmd().eq(cmd));
-    ///
-    /// let another_runnable_image = RunnableImage::from(image).with_cmd(cmd);
-    ///
-    /// assert!(another_runnable_image.cmd().eq(runnable_image.cmd()));
-    /// ```
-    pub fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> Self {
-        Self {
-            overridden_cmd: cmd.into_iter().map(Into::into).collect(),
-            ..self
-        }
-    }
-
-    /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
-    /// Can be used to specify a custom registry or owner.
-    pub fn with_name(self, name: impl Into<String>) -> Self {
-        Self {
-            image_name: Some(name.into()),
-            ..self
-        }
-    }
-
-    /// Overrides the image tag.
-    ///
-    /// There is no guarantee that the specified tag for an image would result in a
-    /// running container. Users of this API are advised to use this at their own risk.
-    pub fn with_tag(self, tag: impl Into<String>) -> Self {
-        Self {
-            image_tag: Some(tag.into()),
-            ..self
-        }
-    }
-
-    /// Sets the container name.
-    pub fn with_container_name(self, name: impl Into<String>) -> Self {
-        Self {
-            container_name: Some(name.into()),
-            ..self
-        }
-    }
-
-    /// Sets the network the container will be connected to.
-    pub fn with_network(self, network: impl Into<String>) -> Self {
-        Self {
-            network: Some(network.into()),
-            ..self
-        }
-    }
-
-    /// Adds an environment variable to the container.
-    pub fn with_env_var(mut self, (key, value): (impl Into<String>, impl Into<String>)) -> Self {
-        self.env_vars.insert(key.into(), value.into());
-        self
-    }
-
-    /// Adds a host to the container.
-    pub fn with_host(mut self, key: impl Into<String>, value: impl Into<Host>) -> Self {
-        self.hosts.insert(key.into(), value.into());
-        self
-    }
-
-    /// Adds a mount to the container.
-    pub fn with_mount(mut self, mount: impl Into<Mount>) -> Self {
-        self.mounts.push(mount.into());
-        self
-    }
-
-    /// Adds a port mapping to the container.
-    pub fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> Self {
-        let mut ports = self.ports.unwrap_or_default();
-        ports.push(port.into());
-
-        Self {
-            ports: Some(ports),
-            ..self
-        }
-    }
-
-    /// Sets the container to run in privileged mode.
-    pub fn with_privileged(self, privileged: bool) -> Self {
-        Self { privileged, ..self }
-    }
-
-    /// cgroup namespace mode for the container. Possible values are:
-    /// - `\"private\"`: the container runs in its own private cgroup namespace
-    /// - `\"host\"`: use the host system's cgroup namespace
-    /// If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration.
-    pub fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> Self {
-        Self {
-            cgroupns_mode: Some(cgroupns_mode),
-            ..self
-        }
-    }
-
-    /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
-    pub fn with_userns_mode(self, userns_mode: &str) -> Self {
-        Self {
-            userns_mode: Some(String::from(userns_mode)),
-            ..self
-        }
-    }
-
-    /// Sets the shared memory size in bytes
-    pub fn with_shm_size(self, bytes: u64) -> Self {
-        Self {
-            shm_size: Some(bytes),
-            ..self
-        }
-    }
-
-    /// Sets the startup timeout for the container. The default is 60 seconds.
-    pub fn with_startup_timeout(self, timeout: Duration) -> Self {
-        Self {
-            startup_timeout: Some(timeout),
-            ..self
-        }
     }
 }
 

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -72,7 +72,7 @@ pub mod core;
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub use crate::core::Container;
-pub use crate::core::{error::TestcontainersError, ContainerAsync, Image, RunnableImage};
+pub use crate::core::{error::TestcontainersError, ContainerAsync, Image, ImageExt, RunnableImage};
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -260,15 +260,13 @@ impl From<CgroupnsMode> for HostConfigCgroupnsModeEnum {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{core::WaitFor, images::generic::GenericImage};
+    use crate::{core::WaitFor, images::generic::GenericImage, ImageExt};
 
     #[tokio::test]
     async fn async_run_command_should_expose_all_ports_if_no_explicit_mapping_requested(
     ) -> anyhow::Result<()> {
         let client = Client::lazy_client().await?;
-        let container = RunnableImage::from(GenericImage::new("hello-world", "latest"))
-            .start()
-            .await?;
+        let container = GenericImage::new("hello-world", "latest").start().await?;
 
         let container_details = client.inspect(container.id()).await?;
         let publish_ports = container_details
@@ -298,7 +296,7 @@ mod tests {
     async fn async_run_command_should_expose_only_requested_ports() -> anyhow::Result<()> {
         let client = Client::lazy_client().await?;
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
+        let container = image
             .with_mapped_port((123, 456))
             .with_mapped_port((555, 888))
             .start()
@@ -326,10 +324,7 @@ mod tests {
     async fn async_run_command_should_include_network() -> anyhow::Result<()> {
         let client = Client::lazy_client().await?;
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_network("awesome-net-1")
-            .start()
-            .await?;
+        let container = image.with_network("awesome-net-1").start().await?;
 
         let container_details = client.inspect(container.id()).await?;
         let networks = container_details
@@ -349,7 +344,7 @@ mod tests {
     async fn async_run_command_should_include_name() -> anyhow::Result<()> {
         let client = Client::lazy_client().await?;
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
+        let container = image
             .with_container_name("async_hello_container")
             .start()
             .await?;
@@ -370,16 +365,14 @@ mod tests {
             assert!(!client.network_exists("awesome-net-2").await?);
 
             // creating the first container creates the network
-            let _container1 = RunnableImage::from(hello_world.clone())
+            let _container1 = hello_world
+                .clone()
                 .with_network("awesome-net-2")
                 .start()
                 .await;
 
             // creating a 2nd container doesn't fail because check if the network exists already
-            let _container2 = RunnableImage::from(hello_world)
-                .with_network("awesome-net-2")
-                .start()
-                .await;
+            let _container2 = hello_world.with_network("awesome-net-2").start().await;
 
             assert!(client.network_exists("awesome-net-2").await?);
         }
@@ -398,10 +391,7 @@ mod tests {
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
 
-        let container = RunnableImage::from(web_server.clone())
-            .with_network("bridge")
-            .start()
-            .await?;
+        let container = web_server.clone().with_network("bridge").start().await?;
 
         assert!(
             !container
@@ -420,10 +410,7 @@ mod tests {
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
 
-        let container = RunnableImage::from(web_server.clone())
-            .with_network("host")
-            .start()
-            .await?;
+        let container = web_server.clone().with_network("host").start().await?;
 
         let res = container.get_bridge_ip_address().await;
         assert!(
@@ -437,10 +424,7 @@ mod tests {
     async fn async_run_command_should_set_shared_memory_size() -> anyhow::Result<()> {
         let client = Client::lazy_client().await?;
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_shm_size(1_000_000)
-            .start()
-            .await?;
+        let container = image.with_shm_size(1_000_000).start().await?;
 
         let container_details = client.inspect(container.id()).await?;
         let shm_size = container_details
@@ -456,10 +440,7 @@ mod tests {
     #[tokio::test]
     async fn async_run_command_should_include_privileged() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_privileged(true)
-            .start()
-            .await?;
+        let container = image.with_privileged(true).start().await?;
 
         let client = Client::lazy_client().await?;
         let container_details = client.inspect(container.id()).await?;
@@ -476,10 +457,7 @@ mod tests {
     #[tokio::test]
     async fn async_run_command_should_have_host_cgroupns_mode() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_cgroupns_mode(CgroupnsMode::Host)
-            .start()
-            .await?;
+        let container = image.with_cgroupns_mode(CgroupnsMode::Host).start().await?;
 
         let client = Client::lazy_client().await?;
         let container_details = client.inspect(container.id()).await?;
@@ -501,7 +479,7 @@ mod tests {
     #[tokio::test]
     async fn async_run_command_should_have_private_cgroupns_mode() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
+        let container = image
             .with_cgroupns_mode(CgroupnsMode::Private)
             .start()
             .await?;
@@ -526,10 +504,7 @@ mod tests {
     #[tokio::test]
     async fn async_run_command_should_have_host_userns_mode() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_userns_mode("host")
-            .start()
-            .await?;
+        let container = image.with_userns_mode("host").start().await?;
 
         let client = Client::lazy_client().await?;
         let container_details = client.inspect(container.id()).await?;

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -62,6 +62,7 @@ mod tests {
     use crate::{
         core::{client::Client, mounts::Mount, WaitFor},
         images::generic::GenericImage,
+        ImageExt,
     };
 
     static RUNTIME: OnceLock<Runtime> = OnceLock::new();
@@ -118,7 +119,7 @@ mod tests {
     #[test]
     fn sync_run_command_should_expose_all_ports_if_no_explicit_mapping_requested(
     ) -> anyhow::Result<()> {
-        let container = RunnableImage::from(GenericImage::new("hello-world", "latest")).start()?;
+        let container = GenericImage::new("hello-world", "latest").start()?;
 
         let container_details = inspect(container.id());
         let publish_ports = container_details
@@ -145,7 +146,7 @@ mod tests {
     #[test]
     fn sync_run_command_should_expose_only_requested_ports() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
+        let container = image
             .with_mapped_port((124, 456))
             .with_mapped_port((556, 888))
             .start()?;
@@ -174,9 +175,7 @@ mod tests {
     #[test]
     fn sync_run_command_should_include_network() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_network("sync-awesome-net-1")
-            .start()?;
+        let container = image.with_network("sync-awesome-net-1").start()?;
 
         let container_details = inspect(container.id());
         let networks = container_details
@@ -199,9 +198,7 @@ mod tests {
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
 
-        let container = RunnableImage::from(web_server.clone())
-            .with_network("bridge")
-            .start()?;
+        let container = web_server.clone().with_network("bridge").start()?;
 
         assert!(!container.get_bridge_ip_address()?.to_string().is_empty());
         Ok(())
@@ -213,9 +210,7 @@ mod tests {
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
 
-        let container = RunnableImage::from(web_server.clone())
-            .with_network("host")
-            .start()?;
+        let container = web_server.clone().with_network("host").start()?;
 
         let res = container.get_bridge_ip_address();
         assert!(res.is_err());
@@ -224,9 +219,7 @@ mod tests {
     #[test]
     fn sync_run_command_should_include_name() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_container_name("sync_hello_container")
-            .start()?;
+        let container = image.with_container_name("sync_hello_container").start()?;
 
         let container_details = inspect(container.id());
         let container_name = container_details.name.expect("Name");
@@ -236,22 +229,19 @@ mod tests {
 
     #[test]
     fn sync_run_command_with_container_network_should_not_expose_ports() -> anyhow::Result<()> {
-        let _first_container =
-            RunnableImage::from(GenericImage::new("simple_web_server", "latest"))
-                .with_container_name("the_first_one")
-                .start()?;
+        let _first_container = GenericImage::new("simple_web_server", "latest")
+            .with_container_name("the_first_one")
+            .start()?;
 
         let image = GenericImage::new("hello-world", "latest");
-        RunnableImage::from(image)
-            .with_network("container:the_first_one")
-            .start()?;
+        image.with_network("container:the_first_one").start()?;
         Ok(())
     }
 
     #[test]
     fn sync_run_command_should_include_privileged() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image).with_privileged(true).start()?;
+        let container = image.with_privileged(true).start()?;
         let container_details = inspect(container.id());
 
         let privileged = container_details
@@ -266,9 +256,7 @@ mod tests {
     #[test]
     fn sync_run_command_should_set_shared_memory_size() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = RunnableImage::from(image)
-            .with_shm_size(1_000_000)
-            .start()?;
+        let container = image.with_shm_size(1_000_000).start()?;
 
         let container_details = inspect(container.id());
         let shm_size = container_details
@@ -289,11 +277,11 @@ mod tests {
             assert!(!network_exists(&client, "sync-awesome-net"));
 
             // creating the first container creates the network
-            let _container1: Container<HelloWorld> = RunnableImage::from(HelloWorld::default())
+            let _container1: Container<HelloWorld> = HelloWorld::default()
                 .with_network("sync-awesome-net")
                 .start()?;
             // creating a 2nd container doesn't fail because check if the network exists already
-            let _container2 = RunnableImage::from(HelloWorld::default())
+            let _container2 = HelloWorld::default()
                 .with_network("sync-awesome-net")
                 .start()?;
 

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -55,7 +55,7 @@ async fn cleanup_hello_world_image() -> anyhow::Result<()> {
 async fn bollard_pull_missing_image_hello_world() -> anyhow::Result<()> {
     let _ = pretty_env_logger::try_init();
     cleanup_hello_world_image().await?;
-    let _container = RunnableImage::from(HelloWorld).start().await?;
+    let _container = HelloWorld.start().await?;
     Ok(())
 }
 
@@ -63,11 +63,7 @@ async fn bollard_pull_missing_image_hello_world() -> anyhow::Result<()> {
 async fn explicit_call_to_pull_missing_image_hello_world() -> anyhow::Result<()> {
     let _ = pretty_env_logger::try_init();
     cleanup_hello_world_image().await?;
-    let _container = RunnableImage::from(HelloWorld)
-        .pull_image()
-        .await?
-        .start()
-        .await?;
+    let _container = HelloWorld.pull_image().await?.start().await?;
     Ok(())
 }
 

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -90,7 +90,7 @@ fn generic_image_running_with_extra_hosts_added() -> anyhow::Result<()> {
 
     // Override hosts for server_2 adding
     // custom-host as an alias for localhost
-    let server_2 = RunnableImage::from(server_2)
+    let server_2 = server_2
         .with_cmd([format!("http://custom-host:{port}")])
         .with_host("custom-host", Host::HostGateway);
 


### PR DESCRIPTION
This PR allows to override some image values without explicit conversion to `RunnableImage`.

For example:

```rs
// Instead of this:
use testcontainers::RunnableImage;
RunnableImage::from(image).with_tag("x").with_network("a").start();

// It can be done directly on image:
use testcontainers::ImageExt;
image.with_tag("x").with_network("a").start();
```

Also, it allows to simplify `GenericImage`. Because it was kinda duplicative code.