### PR TITLE
refactor!: rename `RunnableImage` to `ContainerRequest`

### DIFF
--- a/docs/features/wait_strategies.md
+++ b/docs/features/wait_strategies.md
@@ -23,4 +23,4 @@ you can use the `with_wait_for` method to specify the wait strategy.
 
 Ordinarily Testcontainers will wait for up to 60 seconds for containers to start.
 If the default 60s timeout is not sufficient, it can be updated with the
-[`RunnableImage::with_startup_timeout(duration)`](https://docs.rs/testcontainers/latest/testcontainers/core/struct.RunnableImage.html#method.with_startup_timeout) method.
+[`ImageExt::with_startup_timeout(duration)`](https://docs.rs/testcontainers/latest/testcontainers/core/trait.ImageExt.html#method.with_startup_timeout) method.

--- a/docs/quickstart/community_modules.md
+++ b/docs/quickstart/community_modules.md
@@ -33,7 +33,7 @@ fn test_with_postgres() {
 > For example:
 >
 >```rust
->use testcontainers_modules::testcontainers::RunnableImage;
+>use testcontainers_modules::testcontainers::ImageExt;
 >```
 
 You can also see [examples](https://github.com/testcontainers/testcontainers-rs-modules-community/tree/main/examples)
@@ -43,17 +43,17 @@ for more details.
 
 Sometimes it's necessary to override default settings of the module (e.g `tag`, `name`, environment variables etc.)
 In order to do that, just use extension trait [ImageExt](https://docs.rs/testcontainers/latest/testcontainers/core/trait.ImageExt.html)
-that returns customized [RunnableImage](https://docs.rs/testcontainers/latest/testcontainers/core/struct.RunnableImage.html):
+that returns a customized [ContainerRequest](https://docs.rs/testcontainers/latest/testcontainers/core/struct.ContainerRequest.html):
 
 ```rust
 use testcontainers_modules::{
     redis::Redis,
-    testcontainers::{RunnableImage, ImageExt},
+    testcontainers::{ContainerRequest, ImageExt},
 };
 
 
 /// Create a Redis module with `6.2-alpine` tag and custom password
-fn create_redis() -> RunnableImage<Redis> {
+fn create_redis() -> ContainerRequest<Redis> {
     Redis::default()
         .with_tag("6.2-alpine")
         .with_env_var(("REDIS_PASSWORD", "my_secret_password"))

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,9 +1,6 @@
 pub use self::{
     containers::*,
-    image::{
-        CgroupnsMode, CmdWaitFor, ContainerState, ExecCommand, Host, Image, ImageExt, PortMapping,
-        RunnableImage, WaitFor,
-    },
+    image::{CmdWaitFor, ContainerState, ExecCommand, Image, ImageExt, WaitFor},
     mounts::{AccessMode, Mount, MountType},
 };
 

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -16,7 +16,7 @@ use crate::{
         ports::Ports,
         ContainerState, ExecCommand, WaitFor,
     },
-    Image, RunnableImage,
+    ContainerRequest, Image,
 };
 
 pub(super) mod exec;
@@ -39,7 +39,7 @@ pub(super) mod exec;
 /// [drop_impl]: struct.ContainerAsync.html#impl-Drop
 pub struct ContainerAsync<I: Image> {
     id: String,
-    image: RunnableImage<I>,
+    image: ContainerRequest<I>,
     pub(super) docker_client: Arc<Client>,
     #[allow(dead_code)]
     network: Option<Arc<Network>>,
@@ -55,7 +55,7 @@ where
     pub(crate) async fn new(
         id: String,
         docker_client: Arc<Client>,
-        image: RunnableImage<I>,
+        image: ContainerRequest<I>,
         network: Option<Arc<Network>>,
     ) -> Result<ContainerAsync<I>> {
         let container = ContainerAsync {

--- a/testcontainers/src/core/containers/mod.rs
+++ b/testcontainers/src/core/containers/mod.rs
@@ -1,8 +1,10 @@
 pub(crate) mod async_container;
+pub(crate) mod request;
 #[cfg(feature = "blocking")]
 pub(crate) mod sync_container;
 
 pub use async_container::{exec::ExecResult, ContainerAsync};
+pub use request::{CgroupnsMode, ContainerRequest, Host, PortMapping};
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub use sync_container::{exec::SyncExecResult, Container};

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -5,25 +5,25 @@ use crate::{
     Image, TestcontainersError,
 };
 
-/// Image wrapper that allows to override some of the image properties.
+/// Represents a request to start a container, allowing customization of the container.
 #[must_use]
 #[derive(Debug, Clone)]
-pub struct RunnableImage<I: Image> {
-    pub(super) image: I,
-    pub(super) overridden_cmd: Vec<String>,
-    pub(super) image_name: Option<String>,
-    pub(super) image_tag: Option<String>,
-    pub(super) container_name: Option<String>,
-    pub(super) network: Option<String>,
-    pub(super) env_vars: BTreeMap<String, String>,
-    pub(super) hosts: BTreeMap<String, Host>,
-    pub(super) mounts: Vec<Mount>,
-    pub(super) ports: Option<Vec<PortMapping>>,
-    pub(super) privileged: bool,
-    pub(super) shm_size: Option<u64>,
-    pub(super) cgroupns_mode: Option<CgroupnsMode>,
-    pub(super) userns_mode: Option<String>,
-    pub(super) startup_timeout: Option<Duration>,
+pub struct ContainerRequest<I: Image> {
+    pub(crate) image: I,
+    pub(crate) overridden_cmd: Vec<String>,
+    pub(crate) image_name: Option<String>,
+    pub(crate) image_tag: Option<String>,
+    pub(crate) container_name: Option<String>,
+    pub(crate) network: Option<String>,
+    pub(crate) env_vars: BTreeMap<String, String>,
+    pub(crate) hosts: BTreeMap<String, Host>,
+    pub(crate) mounts: Vec<Mount>,
+    pub(crate) ports: Option<Vec<PortMapping>>,
+    pub(crate) privileged: bool,
+    pub(crate) shm_size: Option<u64>,
+    pub(crate) cgroupns_mode: Option<CgroupnsMode>,
+    pub(crate) userns_mode: Option<String>,
+    pub(crate) startup_timeout: Option<Duration>,
 }
 
 /// Represents a port mapping between a local port and the internal port of a container.
@@ -49,7 +49,7 @@ pub enum CgroupnsMode {
     Private,
 }
 
-impl<I: Image> RunnableImage<I> {
+impl<I: Image> ContainerRequest<I> {
     pub fn image(&self) -> &I {
         &self.image
     }
@@ -146,7 +146,7 @@ impl<I: Image> RunnableImage<I> {
     }
 }
 
-impl<I: Image> From<I> for RunnableImage<I> {
+impl<I: Image> From<I> for ContainerRequest<I> {
     fn from(image: I) -> Self {
         Self {
             image,

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, fmt::Debug};
 
 pub use exec::{CmdWaitFor, ExecCommand};
 pub use image_ext::ImageExt;
-pub use runnable_image::{CgroupnsMode, Host, PortMapping, RunnableImage};
 pub use wait_for::WaitFor;
 
 use super::ports::Ports;
@@ -10,7 +9,6 @@ use crate::{core::mounts::Mount, TestcontainersError};
 
 mod exec;
 mod image_ext;
-mod runnable_image;
 mod wait_for;
 
 /// Represents a docker image.

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -2,11 +2,13 @@ use std::time::Duration;
 
 use crate::{
     core::{CgroupnsMode, Host, Mount, PortMapping},
-    Image, RunnableImage,
+    ContainerRequest, Image,
 };
 
+/// Represents an extension for the [`Image`] trait.
+/// Allows to override image defaults and container configuration.
 pub trait ImageExt<I: Image> {
-    /// Returns a new RunnableImage with the specified (overridden) `CMD` ([`Image::cmd`]).
+    /// Returns a new [`ContainerRequest`] with the specified (overridden) `CMD` ([`Image::cmd`]).
     ///
     /// # Examples
     /// ```rust,no_run
@@ -22,161 +24,167 @@ pub trait ImageExt<I: Image> {
     ///
     /// assert!(another_runnable_image.cmd().eq(overridden_cmd.cmd()));
     /// ```
-    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I>;
+    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> ContainerRequest<I>;
 
     /// Overrides the fully qualified image name (consists of `{domain}/{owner}/{image}`).
     /// Can be used to specify a custom registry or owner.
-    fn with_name(self, name: impl Into<String>) -> RunnableImage<I>;
+    fn with_name(self, name: impl Into<String>) -> ContainerRequest<I>;
 
     /// Overrides the image tag.
     ///
     /// There is no guarantee that the specified tag for an image would result in a
     /// running container. Users of this API are advised to use this at their own risk.
-    fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I>;
+    fn with_tag(self, tag: impl Into<String>) -> ContainerRequest<I>;
 
     /// Sets the container name.
-    fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I>;
+    fn with_container_name(self, name: impl Into<String>) -> ContainerRequest<I>;
 
     /// Sets the network the container will be connected to.
-    fn with_network(self, network: impl Into<String>) -> RunnableImage<I>;
+    fn with_network(self, network: impl Into<String>) -> ContainerRequest<I>;
 
     /// Adds an environment variable to the container.
-    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I>;
+    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>)
+        -> ContainerRequest<I>;
 
     /// Adds a host to the container.
-    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I>;
+    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> ContainerRequest<I>;
 
     /// Adds a mount to the container.
-    fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I>;
+    fn with_mount(self, mount: impl Into<Mount>) -> ContainerRequest<I>;
 
     /// Adds a port mapping to the container.
-    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I>;
+    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> ContainerRequest<I>;
 
     /// Sets the container to run in privileged mode.
-    fn with_privileged(self, privileged: bool) -> RunnableImage<I>;
+    fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
 
     /// cgroup namespace mode for the container. Possible values are:
     /// - [`CgroupnsMode::Private`]: the container runs in its own private cgroup namespace
     /// - [`CgroupnsMode::Host`]: use the host system's cgroup namespace
     /// If not specified, the daemon default is used, which can either be `\"private\"` or `\"host\"`, depending on daemon version, kernel support and configuration.
-    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I>;
+    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> ContainerRequest<I>;
 
     /// Sets the usernamespace mode for the container when usernamespace remapping option is enabled.
-    fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I>;
+    fn with_userns_mode(self, userns_mode: &str) -> ContainerRequest<I>;
 
     /// Sets the shared memory size in bytes
-    fn with_shm_size(self, bytes: u64) -> RunnableImage<I>;
+    fn with_shm_size(self, bytes: u64) -> ContainerRequest<I>;
 
     /// Sets the startup timeout for the container. The default is 60 seconds.
-    fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I>;
+    fn with_startup_timeout(self, timeout: Duration) -> ContainerRequest<I>;
 }
 
-impl<RI: Into<RunnableImage<I>>, I: Image> ImageExt<I> for RI {
-    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> RunnableImage<I> {
+/// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
+impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
+    fn with_cmd(self, cmd: impl IntoIterator<Item = impl Into<String>>) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             overridden_cmd: cmd.into_iter().map(Into::into).collect(),
             ..runnable
         }
     }
 
-    fn with_name(self, name: impl Into<String>) -> RunnableImage<I> {
+    fn with_name(self, name: impl Into<String>) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             image_name: Some(name.into()),
             ..runnable
         }
     }
 
-    fn with_tag(self, tag: impl Into<String>) -> RunnableImage<I> {
+    fn with_tag(self, tag: impl Into<String>) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             image_tag: Some(tag.into()),
             ..runnable
         }
     }
 
-    fn with_container_name(self, name: impl Into<String>) -> RunnableImage<I> {
+    fn with_container_name(self, name: impl Into<String>) -> ContainerRequest<I> {
         let runnable = self.into();
 
-        RunnableImage {
+        ContainerRequest {
             container_name: Some(name.into()),
             ..runnable
         }
     }
 
-    fn with_network(self, network: impl Into<String>) -> RunnableImage<I> {
+    fn with_network(self, network: impl Into<String>) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             network: Some(network.into()),
             ..runnable
         }
     }
 
-    fn with_env_var(self, name: impl Into<String>, value: impl Into<String>) -> RunnableImage<I> {
+    fn with_env_var(
+        self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> ContainerRequest<I> {
         let mut runnable = self.into();
         runnable.env_vars.insert(name.into(), value.into());
         runnable
     }
 
-    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> RunnableImage<I> {
+    fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> ContainerRequest<I> {
         let mut runnable = self.into();
         runnable.hosts.insert(key.into(), value.into());
         runnable
     }
 
-    fn with_mount(self, mount: impl Into<Mount>) -> RunnableImage<I> {
+    fn with_mount(self, mount: impl Into<Mount>) -> ContainerRequest<I> {
         let mut runnable = self.into();
         runnable.mounts.push(mount.into());
         runnable
     }
 
-    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> RunnableImage<I> {
+    fn with_mapped_port<P: Into<PortMapping>>(self, port: P) -> ContainerRequest<I> {
         let runnable = self.into();
         let mut ports = runnable.ports.unwrap_or_default();
         ports.push(port.into());
 
-        RunnableImage {
+        ContainerRequest {
             ports: Some(ports),
             ..runnable
         }
     }
 
-    fn with_privileged(self, privileged: bool) -> RunnableImage<I> {
+    fn with_privileged(self, privileged: bool) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             privileged,
             ..runnable
         }
     }
 
-    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> RunnableImage<I> {
+    fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             cgroupns_mode: Some(cgroupns_mode),
             ..runnable
         }
     }
 
-    fn with_userns_mode(self, userns_mode: &str) -> RunnableImage<I> {
+    fn with_userns_mode(self, userns_mode: &str) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             userns_mode: Some(String::from(userns_mode)),
             ..runnable
         }
     }
 
-    fn with_shm_size(self, bytes: u64) -> RunnableImage<I> {
+    fn with_shm_size(self, bytes: u64) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             shm_size: Some(bytes),
             ..runnable
         }
     }
 
-    fn with_startup_timeout(self, timeout: Duration) -> RunnableImage<I> {
+    fn with_startup_timeout(self, timeout: Duration) -> ContainerRequest<I> {
         let runnable = self.into();
-        RunnableImage {
+        ContainerRequest {
             startup_timeout: Some(timeout),
             ..runnable
         }

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -72,7 +72,9 @@ pub mod core;
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub use crate::core::Container;
-pub use crate::core::{error::TestcontainersError, ContainerAsync, Image, ImageExt, RunnableImage};
+pub use crate::core::{
+    error::TestcontainersError, ContainerAsync, ContainerRequest, Image, ImageExt,
+};
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -15,7 +15,7 @@ use crate::{
         network::Network,
         CgroupnsMode, ContainerState,
     },
-    ContainerAsync, Image, RunnableImage,
+    ContainerAsync, ContainerRequest, Image,
 };
 
 const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
@@ -42,13 +42,13 @@ pub trait AsyncRunner<I: Image> {
 
     /// Pulls the image from the registry.
     /// Useful if you want to pull the image before starting the container.
-    async fn pull_image(self) -> Result<RunnableImage<I>>;
+    async fn pull_image(self) -> Result<ContainerRequest<I>>;
 }
 
 #[async_trait]
 impl<T, I> AsyncRunner<I> for T
 where
-    T: Into<RunnableImage<I>> + Send,
+    T: Into<ContainerRequest<I>> + Send,
     I: Image,
 {
     async fn start(self) -> Result<ContainerAsync<I>> {
@@ -219,7 +219,7 @@ where
         .map_err(|_| WaitContainerError::StartupTimeout)?
     }
 
-    async fn pull_image(self) -> Result<RunnableImage<I>> {
+    async fn pull_image(self) -> Result<ContainerRequest<I>> {
         let runnable_image = self.into();
         let client = Client::lazy_client().await?;
         client.pull_image(&runnable_image.descriptor()).await?;

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -1,4 +1,4 @@
-use crate::{core::error::Result, Container, Image, RunnableImage};
+use crate::{core::error::Result, Container, ContainerRequest, Image};
 
 /// Helper trait to start containers synchronously.
 ///
@@ -21,12 +21,12 @@ pub trait SyncRunner<I: Image> {
 
     /// Pulls the image from the registry.
     /// Useful if you want to pull the image before starting the container.
-    fn pull_image(self) -> Result<RunnableImage<I>>;
+    fn pull_image(self) -> Result<ContainerRequest<I>>;
 }
 
 impl<T, I> SyncRunner<I> for T
 where
-    T: Into<RunnableImage<I>> + Send,
+    T: Into<ContainerRequest<I>> + Send,
     I: Image,
 {
     fn start(self) -> Result<Container<I>> {
@@ -36,7 +36,7 @@ where
         Ok(Container::new(runtime, async_container))
     }
 
-    fn pull_image(self) -> Result<RunnableImage<I>> {
+    fn pull_image(self) -> Result<ContainerRequest<I>> {
         let runtime = build_sync_runner()?;
         runtime.block_on(super::AsyncRunner::pull_image(self))
     }


### PR DESCRIPTION
I decided to go with renaming because it's a good moment: we've provided `ImageExt` trait in order to avoid direct usage of `RunnableImage` when possible. Renaming seems to be minor issue in contrast of other changes.

This is semantically more correct, it allows to customize some parameters of a container to create, but not the image itself (`network`, `shm_size`, `cgroupns` etc.). Subjectively, it's more obvious to see  `ContainerRequest<Redis>` instead of `RunnableImage<Redis>`. Also, it's similar to Testcontainers for Go.