### PR TITLE
fix!: make `DOCKER_CONFIG` usage consistent with Docker CLI

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -29,6 +29,5 @@ For that reason, Testcontainers for Rust gives you the ability to read the Docke
 Configuration is fetched in the following order:
 
 1. `DOCKER_AUTH_CONFIG` environment variable, unmarshalling the string value from its JSON representation and using it as the Docker config.
-2. `DOCKER_CONFIG` environment variable, as an alternative path to the Docker config file.
+2. `DOCKER_CONFIG` environment variable, as an alternative path to the directory containing Docker `config.json` file.
 3. else it will load the default Docker config file, which lives in the user's home, e.g. `~/.docker/config.json`.
-

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -48,7 +48,7 @@
 //! Configuration is fetched in the following order:
 //!
 //! 1. `DOCKER_AUTH_CONFIG` environment variable, unmarshalling the string value from its JSON representation and using it as the Docker config.
-//! 2. `DOCKER_CONFIG` environment variable, as an alternative path to the Docker config file.
+//! 2. `DOCKER_CONFIG` environment variable, as an alternative path to the directory containing Docker `config.json` file.
 //! 3. else it will load the default Docker config file, which lives in the user's home, e.g. `~/.docker/config.json`.
 //!
 //! # Ecosystem


### PR DESCRIPTION
`DOCKER_CONFIG` typically points to the directory with config files, and the actual configuration file is usually expected at `${DOCKER_CONFIG}/config.json`:
- Docker CLI https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
- testcontainers-java https://github.com/testcontainers/testcontainers-java/blob/6658a2c0a880d01c6d402ea9a4cb5f72eb15083c/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java#L78-L81

testcontainers-rs treats this variable differently as a path to the configuration file (it does not append `/config.json`), so when the environment is configured to be used by other docker-related tools, testcontainers-rs fails to read the configuration, thus failing to access private registries.

This pull request makes `DOCKER_CONFIG` variable usage consistent with other tools. This is in a way a breaking change, so maybe a version bump will be needed.