### PR TITLE
refactor!: exposed and mapped ports api

### DIFF
--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -2,7 +2,7 @@ pub use self::{
     containers::*,
     image::{CmdWaitFor, ContainerState, ExecCommand, Image, ImageExt, WaitFor},
     mounts::{AccessMode, Mount, MountType},
-    ports::ExposedPort,
+    ports::ContainerPort,
 };
 
 mod image;

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -2,7 +2,7 @@ pub use self::{
     containers::*,
     image::{CmdWaitFor, ContainerState, ExecCommand, Image, ImageExt, WaitFor},
     mounts::{AccessMode, Mount, MountType},
-    ports::ContainerPort,
+    ports::{ContainerPort, IntoContainerPort},
 };
 
 mod image;

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -14,7 +14,7 @@ use crate::{
         macros,
         network::Network,
         ports::Ports,
-        ContainerState, ExecCommand, ExposedPort, WaitFor,
+        ContainerPort, ContainerState, ExecCommand, WaitFor,
     },
     ContainerRequest, Image,
 };
@@ -92,7 +92,7 @@ where
     ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method will return an error.
-    pub async fn get_host_port_ipv4(&self, internal_port: ExposedPort) -> Result<u16> {
+    pub async fn get_host_port_ipv4(&self, internal_port: ContainerPort) -> Result<u16> {
         self.ports()
             .await?
             .map_to_host_port_ipv4(internal_port)
@@ -107,7 +107,7 @@ where
     ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method will return an error.
-    pub async fn get_host_port_ipv6(&self, internal_port: ExposedPort) -> Result<u16> {
+    pub async fn get_host_port_ipv6(&self, internal_port: ContainerPort) -> Result<u16> {
         self.ports()
             .await?
             .map_to_host_port_ipv6(internal_port)

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -1,7 +1,7 @@
 use std::{fmt, io::BufRead, net::IpAddr, sync::Arc};
 
 use crate::{
-    core::{env, error::Result, ports::Ports, ExecCommand, ExposedPort},
+    core::{env, error::Result, ports::Ports, ContainerPort, ExecCommand},
     ContainerAsync, Image,
 };
 
@@ -82,7 +82,7 @@ where
     ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method returns an error.
-    pub fn get_host_port_ipv4(&self, internal_port: ExposedPort) -> Result<u16> {
+    pub fn get_host_port_ipv4(&self, internal_port: ContainerPort) -> Result<u16> {
         self.rt()
             .block_on(self.async_impl().get_host_port_ipv4(internal_port))
     }
@@ -92,7 +92,7 @@ where
     ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method returns an error.
-    pub fn get_host_port_ipv6(&self, internal_port: ExposedPort) -> Result<u16> {
+    pub fn get_host_port_ipv6(&self, internal_port: ContainerPort) -> Result<u16> {
         self.rt()
             .block_on(self.async_impl().get_host_port_ipv6(internal_port))
     }

--- a/testcontainers/src/core/error.rs
+++ b/testcontainers/src/core/error.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use crate::core::logs::WaitLogError;
-pub use crate::core::{client::ClientError, env::ConfigurationError, ExposedPort};
+pub use crate::core::{client::ClientError, env::ConfigurationError, ContainerPort};
 
 pub type Result<T> = std::result::Result<T, TestcontainersError>;
 
@@ -15,7 +15,7 @@ pub enum TestcontainersError {
     WaitContainer(#[from] WaitContainerError),
     /// Represents an error when a container does not expose a specified port
     #[error("container '{id}' does not expose port {port}")]
-    PortNotExposed { id: String, port: ExposedPort },
+    PortNotExposed { id: String, port: ContainerPort },
     /// Represents an error when a container is missing some information
     #[error(transparent)]
     MissingInfo(#[from] ContainerMissingInfo),

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -4,7 +4,7 @@ pub use exec::{CmdWaitFor, ExecCommand};
 pub use image_ext::ImageExt;
 pub use wait_for::WaitFor;
 
-use super::ports::{ExposedPort, Ports};
+use super::ports::{ContainerPort, Ports};
 use crate::{core::mounts::Mount, TestcontainersError};
 
 mod exec;
@@ -69,7 +69,7 @@ where
     ///
     /// This method is useful when there is a need to expose some ports, but there is
     /// no `EXPOSE` instruction in the Dockerfile of an image.
-    fn expose_ports(&self) -> &[ExposedPort] {
+    fn expose_ports(&self) -> &[ContainerPort] {
         &[]
     }
 
@@ -104,10 +104,10 @@ impl ContainerState {
         }
     }
 
-    /// Returns the host port for the given internal port (`IPv4`).
+    /// Returns the host port for the given internal container's port (`IPv4`).
     ///
     /// Results in an error ([`TestcontainersError::PortNotExposed`]) if the port is not exposed.
-    pub fn host_port_ipv4(&self, internal_port: ExposedPort) -> Result<u16, TestcontainersError> {
+    pub fn host_port_ipv4(&self, internal_port: ContainerPort) -> Result<u16, TestcontainersError> {
         self.ports
             .map_to_host_port_ipv4(internal_port)
             .ok_or_else(|| TestcontainersError::PortNotExposed {
@@ -116,10 +116,10 @@ impl ContainerState {
             })
     }
 
-    /// Returns the host port for the given internal port (`IPv6`).
+    /// Returns the host port for the given internal container's port (`IPv6`).
     ///
     /// Results in an error ([`TestcontainersError::PortNotExposed`]) if the port is not exposed.
-    pub fn host_port_ipv6(&self, internal_port: ExposedPort) -> Result<u16, TestcontainersError> {
+    pub fn host_port_ipv6(&self, internal_port: ContainerPort) -> Result<u16, TestcontainersError> {
         self.ports
             .map_to_host_port_ipv6(internal_port)
             .ok_or_else(|| TestcontainersError::PortNotExposed {

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -61,7 +61,8 @@ pub trait ImageExt<I: Image> {
     ///
     /// let image = GenericImage::new("image", "tag").with_mapped_port(8080, 80.tcp());
     /// ```
-    fn with_mapped_port(self, host_port: u16, container_port: ContainerPort) -> ContainerRequest<I>;
+    fn with_mapped_port(self, host_port: u16, container_port: ContainerPort)
+        -> ContainerRequest<I>;
 
     /// Sets the container to run in privileged mode.
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
@@ -147,7 +148,11 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         runnable
     }
 
-    fn with_mapped_port(self, host_port: u16, container_port: ContainerPort) -> ContainerRequest<I> {
+    fn with_mapped_port(
+        self,
+        host_port: u16,
+        container_port: ContainerPort,
+    ) -> ContainerRequest<I> {
         let runnable = self.into();
         let mut ports = runnable.ports.unwrap_or_default();
         ports.push(PortMapping::new(host_port, container_port.into()));

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -53,11 +53,15 @@ pub trait ImageExt<I: Image> {
     fn with_mount(self, mount: impl Into<Mount>) -> ContainerRequest<I>;
 
     /// Adds a port mapping to the container, mapping the host port to the container's internal port.
-    fn with_mapped_port<EP: Into<ContainerPort>>(
-        self,
-        host_port: u16,
-        exposed_port: EP,
-    ) -> ContainerRequest<I>;
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// use testcontainers::{GenericImage, ImageExt};
+    /// use testcontainers::core::IntoContainerPort;
+    ///
+    /// let image = GenericImage::new("image", "tag").with_mapped_port(8080, 80.tcp());
+    /// ```
+    fn with_mapped_port(self, host_port: u16, container_port: ContainerPort) -> ContainerRequest<I>;
 
     /// Sets the container to run in privileged mode.
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
@@ -143,11 +147,7 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         runnable
     }
 
-    fn with_mapped_port<EP: Into<ContainerPort>>(
-        self,
-        host_port: u16,
-        container_port: EP,
-    ) -> ContainerRequest<I> {
+    fn with_mapped_port(self, host_port: u16, container_port: ContainerPort) -> ContainerRequest<I> {
         let runnable = self.into();
         let mut ports = runnable.ports.unwrap_or_default();
         ports.push(PortMapping::new(host_port, container_port.into()));

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -155,7 +155,7 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     ) -> ContainerRequest<I> {
         let runnable = self.into();
         let mut ports = runnable.ports.unwrap_or_default();
-        ports.push(PortMapping::new(host_port, container_port.into()));
+        ports.push(PortMapping::new(host_port, container_port));
 
         ContainerRequest {
             ports: Some(ports),

--- a/testcontainers/src/images/generic.rs
+++ b/testcontainers/src/images/generic.rs
@@ -1,5 +1,7 @@
-use crate::core::ports::ExposedPort;
-use crate::{core::WaitFor, Image};
+use crate::{
+    core::{ports::ContainerPort, WaitFor},
+    Image,
+};
 
 #[must_use]
 #[derive(Debug, Clone)]
@@ -8,7 +10,7 @@ pub struct GenericImage {
     tag: String,
     wait_for: Vec<WaitFor>,
     entrypoint: Option<String>,
-    exposed_ports: Vec<ExposedPort>,
+    exposed_ports: Vec<ContainerPort>,
 }
 
 impl GenericImage {
@@ -32,7 +34,7 @@ impl GenericImage {
         self
     }
 
-    pub fn with_exposed_port(mut self, port: ExposedPort) -> Self {
+    pub fn with_exposed_port(mut self, port: ContainerPort) -> Self {
         self.exposed_ports.push(port);
         self
     }
@@ -55,7 +57,7 @@ impl Image for GenericImage {
         self.entrypoint.as_deref()
     }
 
-    fn expose_ports(&self) -> &[ExposedPort] {
+    fn expose_ports(&self) -> &[ContainerPort] {
         &self.exposed_ports
     }
 }

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -26,11 +26,11 @@ const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 /// ## Example
 ///
 /// ```rust,no_run
-/// use testcontainers::{core::{WaitFor, ExposedPort}, runners::AsyncRunner, GenericImage};
+/// use testcontainers::{core::{WaitFor, ContainerPort}, runners::AsyncRunner, GenericImage};
 ///
 /// async fn test_redis() {
 ///     let container = GenericImage::new("redis", "7.2.4")
-///         .with_exposed_port(ExposedPort::Tcp(6379))
+///         .with_exposed_port(ContainerPort::Tcp(6379))
 ///         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
 ///         .start()
 ///         .await;
@@ -137,7 +137,7 @@ where
             if !is_container_networked {
                 let mapped_ports = runnable_image
                     .ports()
-                    .map(|ports| ports.iter().map(|p| p.internal).collect::<Vec<_>>())
+                    .map(|ports| ports.iter().map(|p| p.container_port).collect::<Vec<_>>())
                     .unwrap_or_default();
 
                 let ports_to_expose = runnable_image
@@ -157,10 +157,10 @@ where
                 let empty: Vec<_> = Vec::new();
                 let bindings = runnable_image.ports().unwrap_or(&empty).iter().map(|p| {
                     (
-                        format!("{}", p.internal),
+                        format!("{}", p.container_port),
                         Some(vec![PortBinding {
                             host_ip: None,
-                            host_port: Some(p.local.to_string()),
+                            host_port: Some(p.host_port.to_string()),
                         }]),
                     )
                 });
@@ -261,7 +261,7 @@ impl From<CgroupnsMode> for HostConfigCgroupnsModeEnum {
 mod tests {
     use super::*;
     use crate::{
-        core::{ExposedPort, WaitFor},
+        core::{ContainerPort, WaitFor},
         images::generic::GenericImage,
         ImageExt,
     };
@@ -285,12 +285,12 @@ mod tests {
     #[tokio::test]
     async fn async_run_command_should_map_exposed_port() -> anyhow::Result<()> {
         let image = GenericImage::new("simple_web_server", "latest")
-            .with_exposed_port(ExposedPort::Tcp(5000))
+            .with_exposed_port(ContainerPort::Tcp(5000))
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
         let container = image.start().await?;
         container
-            .get_host_port_ipv4(ExposedPort::Tcp(5000))
+            .get_host_port_ipv4(ContainerPort::Tcp(5000))
             .await
             .expect("Port should be mapped");
         Ok(())
@@ -307,15 +307,15 @@ mod tests {
         let generic_server = GenericImage::new("simple_web_server", "latest")
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             // Explicitly expose the port, which otherwise would not be available.
-            .with_exposed_port(ExposedPort::Udp(udp_port))
-            .with_exposed_port(ExposedPort::Sctp(sctp_port));
+            .with_exposed_port(ContainerPort::Udp(udp_port))
+            .with_exposed_port(ContainerPort::Sctp(sctp_port));
 
         let container = generic_server.start().await?;
         container
-            .get_host_port_ipv4(ExposedPort::Udp(udp_port))
+            .get_host_port_ipv4(ContainerPort::Udp(udp_port))
             .await?;
         container
-            .get_host_port_ipv4(ExposedPort::Sctp(sctp_port))
+            .get_host_port_ipv4(ContainerPort::Sctp(sctp_port))
             .await?;
 
         let container_details = client.inspect(container.id()).await?;
@@ -350,8 +350,8 @@ mod tests {
         let client = Client::lazy_client().await?;
         let image = GenericImage::new("hello-world", "latest");
         let container = image
-            .with_mapped_port((123, ExposedPort::Tcp(456)))
-            .with_mapped_port((555, ExposedPort::Tcp(888)))
+            .with_mapped_port(123, ContainerPort::Tcp(456))
+            .with_mapped_port(555, ContainerPort::Tcp(888))
             .start()
             .await?;
 
@@ -383,8 +383,8 @@ mod tests {
 
         let image = GenericImage::new("hello-world", "latest");
         let container = image
-            .with_mapped_port((123, ExposedPort::Udp(udp_port)))
-            .with_mapped_port((555, ExposedPort::Sctp(sctp_port)))
+            .with_mapped_port(123, ContainerPort::Udp(udp_port))
+            .with_mapped_port(555, ContainerPort::Sctp(sctp_port))
             .start()
             .await?;
 

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -26,7 +26,7 @@ const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 /// ## Example
 ///
 /// ```rust,no_run
-/// use testcontainers::{core::{WaitFor, ContainerPort}, runners::AsyncRunner, GenericImage};
+/// use testcontainers::{core::{WaitFor, IntoContainerPort}, runners::AsyncRunner, GenericImage};
 ///
 /// async fn test_redis() {
 ///     let container = GenericImage::new("redis", "7.2.4")

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -5,7 +5,7 @@ use crate::{core::error::Result, Container, ContainerRequest, Image};
 /// ## Example
 ///
 /// ```rust,no_run
-/// use testcontainers::{core::{WaitFor, ContainerPort}, runners::SyncRunner, GenericImage};
+/// use testcontainers::{core::{WaitFor, IntoContainerPort}, runners::SyncRunner, GenericImage};
 ///
 /// fn test_redis() {
 ///     let container = GenericImage::new("redis", "7.2.4")
@@ -51,6 +51,7 @@ fn build_sync_runner() -> Result<tokio::runtime::Runtime> {
 #[cfg(test)]
 mod tests {
     use std::{
+        borrow::Cow,
         collections::BTreeMap,
         sync::{Arc, OnceLock},
     };
@@ -60,7 +61,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{client::Client, mounts::Mount, ContainerPort, IntoContainerPort, WaitFor},
+        core::{client::Client, mounts::Mount, IntoContainerPort, WaitFor},
         images::generic::GenericImage,
         ImageExt,
     };
@@ -107,11 +108,13 @@ mod tests {
             vec![WaitFor::message_on_stdout("Hello from Docker!")]
         }
 
-        fn env_vars(&self) -> Box<dyn Iterator<Item = (&String, &String)> + '_> {
+        fn env_vars(
+            &self,
+        ) -> impl IntoIterator<Item = (impl Into<Cow<'_, str>>, impl Into<Cow<'_, str>>)> {
             Box::new(self.env_vars.iter())
         }
 
-        fn mounts(&self) -> Box<dyn Iterator<Item = &Mount> + '_> {
+        fn mounts(&self) -> impl IntoIterator<Item = &Mount> {
             Box::new(self.mounts.iter())
         }
     }

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -5,11 +5,11 @@ use crate::{core::error::Result, Container, ContainerRequest, Image};
 /// ## Example
 ///
 /// ```rust,no_run
-/// use testcontainers::{core::{WaitFor, ExposedPort}, runners::SyncRunner, GenericImage};
+/// use testcontainers::{core::{WaitFor, ContainerPort}, runners::SyncRunner, GenericImage};
 ///
 /// fn test_redis() {
 ///     let container = GenericImage::new("redis", "7.2.4")
-///         .with_exposed_port(ExposedPort::Tcp(6379))
+///         .with_exposed_port(ContainerPort::Tcp(6379))
 ///         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
 ///         .start()
 ///         .unwrap();
@@ -60,7 +60,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{client::Client, mounts::Mount, ExposedPort, WaitFor},
+        core::{client::Client, mounts::Mount, ContainerPort, WaitFor},
         images::generic::GenericImage,
         ImageExt,
     };
@@ -134,11 +134,11 @@ mod tests {
     #[test]
     fn sync_run_command_should_map_exposed_port() -> anyhow::Result<()> {
         let image = GenericImage::new("simple_web_server", "latest")
-            .with_exposed_port(ExposedPort::Tcp(5000))
+            .with_exposed_port(ContainerPort::Tcp(5000))
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
         let container = image.start()?;
-        let res = container.get_host_port_ipv4(ExposedPort::Tcp(5000));
+        let res = container.get_host_port_ipv4(ContainerPort::Tcp(5000));
         assert!(res.is_ok());
         Ok(())
     }
@@ -147,8 +147,8 @@ mod tests {
     fn sync_run_command_should_expose_only_requested_ports() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
         let container = image
-            .with_mapped_port((124, ExposedPort::Tcp(456)))
-            .with_mapped_port((556, ExposedPort::Tcp(888)))
+            .with_mapped_port(124, ContainerPort::Tcp(456))
+            .with_mapped_port(556, ContainerPort::Tcp(888))
             .start()?;
 
         let container_details = inspect(container.id());

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -9,7 +9,7 @@ use crate::{core::error::Result, Container, ContainerRequest, Image};
 ///
 /// fn test_redis() {
 ///     let container = GenericImage::new("redis", "7.2.4")
-///         .with_exposed_port(ContainerPort::Tcp(6379))
+///         .with_exposed_port(6379.tcp())
 ///         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
 ///         .start()
 ///         .unwrap();
@@ -60,7 +60,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        core::{client::Client, mounts::Mount, ContainerPort, WaitFor},
+        core::{client::Client, mounts::Mount, ContainerPort, IntoContainerPort, WaitFor},
         images::generic::GenericImage,
         ImageExt,
     };
@@ -134,11 +134,11 @@ mod tests {
     #[test]
     fn sync_run_command_should_map_exposed_port() -> anyhow::Result<()> {
         let image = GenericImage::new("simple_web_server", "latest")
-            .with_exposed_port(ContainerPort::Tcp(5000))
+            .with_exposed_port(5000.tcp())
             .with_wait_for(WaitFor::message_on_stdout("server is ready"))
             .with_wait_for(WaitFor::seconds(1));
         let container = image.start()?;
-        let res = container.get_host_port_ipv4(ContainerPort::Tcp(5000));
+        let res = container.get_host_port_ipv4(5000.tcp());
         assert!(res.is_ok());
         Ok(())
     }
@@ -147,8 +147,8 @@ mod tests {
     fn sync_run_command_should_expose_only_requested_ports() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
         let container = image
-            .with_mapped_port(124, ContainerPort::Tcp(456))
-            .with_mapped_port(556, ContainerPort::Tcp(888))
+            .with_mapped_port(124, 456.tcp())
+            .with_mapped_port(556, 888.tcp())
             .start()?;
 
         let container_details = inspect(container.id());

--- a/testcontainers/tests/dual_stack_host_ports.rs
+++ b/testcontainers/tests/dual_stack_host_ports.rs
@@ -3,7 +3,7 @@
 use std::net::{Ipv6Addr, TcpListener};
 
 use testcontainers::{
-    core::{ExposedPort, WaitFor},
+    core::{ContainerPort, WaitFor},
     runners::SyncRunner,
     GenericImage,
 };
@@ -20,8 +20,8 @@ fn test_ipv4_ipv6_host_ports() -> anyhow::Result<()> {
     // Run one container, and check what ephemeral ports it uses. Perform test HTTP requests to
     // both bound ports.
     let first_container = image.clone().start()?;
-    let first_ipv4_port = first_container.get_host_port_ipv4(ExposedPort::Tcp(80))?;
-    let first_ipv6_port = first_container.get_host_port_ipv6(ExposedPort::Tcp(80))?;
+    let first_ipv4_port = first_container.get_host_port_ipv4(ContainerPort::Tcp(80))?;
+    let first_ipv6_port = first_container.get_host_port_ipv6(ContainerPort::Tcp(80))?;
     assert_eq!(
         "foo",
         reqwest::blocking::get(format!("http://127.0.0.1:{first_ipv4_port}"))?.text()?,
@@ -45,8 +45,8 @@ fn test_ipv4_ipv6_host_ports() -> anyhow::Result<()> {
     // of both IPv4 and IPv6 host port bindings is correct, because at this point,
     // `second_ipv4_port` and `second_ipv6_port` are very unlikely to be the same.
     let second_container = image.start()?;
-    let second_ipv4_port = second_container.get_host_port_ipv4(ExposedPort::Tcp(80))?;
-    let second_ipv6_port = second_container.get_host_port_ipv6(ExposedPort::Tcp(80))?;
+    let second_ipv4_port = second_container.get_host_port_ipv4(ContainerPort::Tcp(80))?;
+    let second_ipv6_port = second_container.get_host_port_ipv6(ContainerPort::Tcp(80))?;
     assert_eq!(
         "foo",
         reqwest::blocking::get(format!("http://127.0.0.1:{second_ipv4_port}"))?.text()?,

--- a/testcontainers/tests/dual_stack_host_ports.rs
+++ b/testcontainers/tests/dual_stack_host_ports.rs
@@ -3,7 +3,7 @@
 use std::net::{Ipv6Addr, TcpListener};
 
 use testcontainers::{
-    core::{ContainerPort, WaitFor},
+    core::{IntoContainerPort, WaitFor},
     runners::SyncRunner,
     GenericImage,
 };
@@ -20,8 +20,8 @@ fn test_ipv4_ipv6_host_ports() -> anyhow::Result<()> {
     // Run one container, and check what ephemeral ports it uses. Perform test HTTP requests to
     // both bound ports.
     let first_container = image.clone().start()?;
-    let first_ipv4_port = first_container.get_host_port_ipv4(ContainerPort::Tcp(80))?;
-    let first_ipv6_port = first_container.get_host_port_ipv6(ContainerPort::Tcp(80))?;
+    let first_ipv4_port = first_container.get_host_port_ipv4(80.tcp())?;
+    let first_ipv6_port = first_container.get_host_port_ipv6(80.tcp())?;
     assert_eq!(
         "foo",
         reqwest::blocking::get(format!("http://127.0.0.1:{first_ipv4_port}"))?.text()?,
@@ -45,8 +45,8 @@ fn test_ipv4_ipv6_host_ports() -> anyhow::Result<()> {
     // of both IPv4 and IPv6 host port bindings is correct, because at this point,
     // `second_ipv4_port` and `second_ipv6_port` are very unlikely to be the same.
     let second_container = image.start()?;
-    let second_ipv4_port = second_container.get_host_port_ipv4(ContainerPort::Tcp(80))?;
-    let second_ipv6_port = second_container.get_host_port_ipv6(ContainerPort::Tcp(80))?;
+    let second_ipv4_port = second_container.get_host_port_ipv4(80.tcp())?;
+    let second_ipv6_port = second_container.get_host_port_ipv6(80.tcp())?;
     assert_eq!(
         "foo",
         reqwest::blocking::get(format!("http://127.0.0.1:{second_ipv4_port}"))?.text()?,

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "blocking")]
 
 use testcontainers::{
-    core::{CmdWaitFor, ContainerPort, ExecCommand, Host, WaitFor},
+    core::{CmdWaitFor, ExecCommand, Host, IntoContainerPort, WaitFor},
     runners::SyncRunner,
     *,
 };
@@ -40,7 +40,7 @@ fn generic_image_with_custom_entrypoint() -> anyhow::Result<()> {
     let generic = get_server_container(None);
 
     let node = generic.start()?;
-    let port = node.get_host_port_ipv4(ContainerPort::Tcp(80))?;
+    let port = node.get_host_port_ipv4(80.tcp())?;
     assert_eq!(
         "foo",
         reqwest::blocking::get(format!("http://{}:{port}", node.get_host()?))?.text()?
@@ -49,7 +49,7 @@ fn generic_image_with_custom_entrypoint() -> anyhow::Result<()> {
     let generic = get_server_container(None).with_entrypoint("./bar");
 
     let node = generic.start()?;
-    let port = node.get_host_port_ipv4(ContainerPort::Tcp(80))?;
+    let port = node.get_host_port_ipv4(80.tcp())?;
     assert_eq!(
         "bar",
         reqwest::blocking::get(format!("http://{}:{port}", node.get_host()?))?.text()?
@@ -67,10 +67,10 @@ fn generic_image_exposed_ports() -> anyhow::Result<()> {
     let generic_server = GenericImage::new("no_expose_port", "latest")
         .with_wait_for(WaitFor::message_on_stdout("listening on 0.0.0.0:8080"))
         // Explicitly expose the port, which otherwise would not be available.
-        .with_exposed_port(ContainerPort::Tcp(target_port));
+        .with_exposed_port(target_port.tcp());
 
     let node = generic_server.start()?;
-    let port = node.get_host_port_ipv4(ContainerPort::Tcp(target_port))?;
+    let port = node.get_host_port_ipv4(target_port.tcp())?;
     assert!(reqwest::blocking::get(format!("http://127.0.0.1:{port}"))?
         .status()
         .is_success());
@@ -81,7 +81,7 @@ fn generic_image_exposed_ports() -> anyhow::Result<()> {
 fn generic_image_running_with_extra_hosts_added() -> anyhow::Result<()> {
     let server_1 = get_server_container(None);
     let node = server_1.start()?;
-    let port = node.get_host_port_ipv4(ContainerPort::Tcp(80))?;
+    let port = node.get_host_port_ipv4(80.tcp())?;
 
     let msg = WaitFor::message_on_stdout("foo");
     let server_2 = GenericImage::new("curlimages/curl", "latest")
@@ -110,7 +110,7 @@ fn generic_image_port_not_exposed() -> anyhow::Result<()> {
     let node = generic_server.start()?;
 
     // Without exposing the port with `with_exposed_port()`, we cannot get a mapping to it.
-    let res = node.get_host_port_ipv4(ContainerPort::Tcp(target_port));
+    let res = node.get_host_port_ipv4(target_port.tcp());
     assert!(res.is_err());
     Ok(())
 }

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "blocking")]
 
 use testcontainers::{
-    core::{CmdWaitFor, ExecCommand, ExposedPort, Host, WaitFor},
+    core::{CmdWaitFor, ContainerPort, ExecCommand, Host, WaitFor},
     runners::SyncRunner,
     *,
 };
@@ -40,7 +40,7 @@ fn generic_image_with_custom_entrypoint() -> anyhow::Result<()> {
     let generic = get_server_container(None);
 
     let node = generic.start()?;
-    let port = node.get_host_port_ipv4(ExposedPort::Tcp(80))?;
+    let port = node.get_host_port_ipv4(ContainerPort::Tcp(80))?;
     assert_eq!(
         "foo",
         reqwest::blocking::get(format!("http://{}:{port}", node.get_host()?))?.text()?
@@ -49,7 +49,7 @@ fn generic_image_with_custom_entrypoint() -> anyhow::Result<()> {
     let generic = get_server_container(None).with_entrypoint("./bar");
 
     let node = generic.start()?;
-    let port = node.get_host_port_ipv4(ExposedPort::Tcp(80))?;
+    let port = node.get_host_port_ipv4(ContainerPort::Tcp(80))?;
     assert_eq!(
         "bar",
         reqwest::blocking::get(format!("http://{}:{port}", node.get_host()?))?.text()?
@@ -67,10 +67,10 @@ fn generic_image_exposed_ports() -> anyhow::Result<()> {
     let generic_server = GenericImage::new("no_expose_port", "latest")
         .with_wait_for(WaitFor::message_on_stdout("listening on 0.0.0.0:8080"))
         // Explicitly expose the port, which otherwise would not be available.
-        .with_exposed_port(ExposedPort::Tcp(target_port));
+        .with_exposed_port(ContainerPort::Tcp(target_port));
 
     let node = generic_server.start()?;
-    let port = node.get_host_port_ipv4(ExposedPort::Tcp(target_port))?;
+    let port = node.get_host_port_ipv4(ContainerPort::Tcp(target_port))?;
     assert!(reqwest::blocking::get(format!("http://127.0.0.1:{port}"))?
         .status()
         .is_success());
@@ -81,7 +81,7 @@ fn generic_image_exposed_ports() -> anyhow::Result<()> {
 fn generic_image_running_with_extra_hosts_added() -> anyhow::Result<()> {
     let server_1 = get_server_container(None);
     let node = server_1.start()?;
-    let port = node.get_host_port_ipv4(ExposedPort::Tcp(80))?;
+    let port = node.get_host_port_ipv4(ContainerPort::Tcp(80))?;
 
     let msg = WaitFor::message_on_stdout("foo");
     let server_2 = GenericImage::new("curlimages/curl", "latest")
@@ -110,7 +110,7 @@ fn generic_image_port_not_exposed() -> anyhow::Result<()> {
     let node = generic_server.start()?;
 
     // Without exposing the port with `with_exposed_port()`, we cannot get a mapping to it.
-    let res = node.get_host_port_ipv4(ExposedPort::Tcp(target_port));
+    let res = node.get_host_port_ipv4(ContainerPort::Tcp(target_port));
     assert!(res.is_err());
     Ok(())
 }


### PR DESCRIPTION
Follow-up PR after #655 (kudos to @estigma88 :tada: )

- rename `ExposedPort` to `ContainerPort`
  - minor internal renaming to align terminology
- `with_mapped_port`: accept two arguments  instead of tuple
- introduce `IntoContainerPort` to make a shortcut for conversion from `u16` to `ContainerPort`