### PR TITLE
feat: impl `From<u16>` for `ContainerPort` with TCP default

### DIFF
--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -90,9 +90,13 @@ where
     /// Returns the mapped host port for an internal port of this docker container, on the host's
     /// IPv4 interfaces.
     ///
+    /// By default, `u16` is considered as TCP port. Also, you can convert `u16` to [`ContainerPort`] port
+    /// by using [`crate::core::IntoContainerPort`] trait.
+    ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method will return an error.
-    pub async fn get_host_port_ipv4(&self, internal_port: ContainerPort) -> Result<u16> {
+    pub async fn get_host_port_ipv4(&self, internal_port: impl Into<ContainerPort>) -> Result<u16> {
+        let internal_port = internal_port.into();
         self.ports()
             .await?
             .map_to_host_port_ipv4(internal_port)
@@ -105,9 +109,13 @@ where
     /// Returns the mapped host port for an internal port of this docker container, on the host's
     /// IPv6 interfaces.
     ///
+    /// By default, `u16` is considered as TCP port. Also, you can convert `u16` to [`ContainerPort`] port
+    /// by using [`crate::core::IntoContainerPort`] trait.
+    ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method will return an error.
-    pub async fn get_host_port_ipv6(&self, internal_port: ContainerPort) -> Result<u16> {
+    pub async fn get_host_port_ipv6(&self, internal_port: impl Into<ContainerPort>) -> Result<u16> {
+        let internal_port = internal_port.into();
         self.ports()
             .await?
             .map_to_host_port_ipv6(internal_port)

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -80,9 +80,12 @@ where
     /// Returns the mapped host port for an internal port of this docker container, on the host's
     /// IPv4 interfaces.
     ///
+    /// By default, `u16` is considered as TCP port. Also, you can convert `u16` to [`ContainerPort`] port
+    /// by using [`crate::core::IntoContainerPort`] trait.
+    ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method returns an error.
-    pub fn get_host_port_ipv4(&self, internal_port: ContainerPort) -> Result<u16> {
+    pub fn get_host_port_ipv4(&self, internal_port: impl Into<ContainerPort>) -> Result<u16> {
         self.rt()
             .block_on(self.async_impl().get_host_port_ipv4(internal_port))
     }
@@ -90,9 +93,12 @@ where
     /// Returns the mapped host port for an internal port of this docker container, on the host's
     /// IPv6 interfaces.
     ///
+    /// By default, `u16` is considered as TCP port. Also, you can convert `u16` to [`ContainerPort`] port
+    /// by using [`crate::core::IntoContainerPort`] trait.
+    ///
     /// This method does **not** magically expose the given port, it simply performs a mapping on
     /// the already exposed ports. If a docker container does not expose a port, this method returns an error.
-    pub fn get_host_port_ipv6(&self, internal_port: ContainerPort) -> Result<u16> {
+    pub fn get_host_port_ipv6(&self, internal_port: impl Into<ContainerPort>) -> Result<u16> {
         self.rt()
             .block_on(self.async_impl().get_host_port_ipv6(internal_port))
     }

--- a/testcontainers/src/core/ports.rs
+++ b/testcontainers/src/core/ports.rs
@@ -2,6 +2,10 @@ use std::{collections::HashMap, net::IpAddr, num::ParseIntError};
 
 use bollard_stubs::models::{PortBinding, PortMap};
 
+/// Represents a port that is exposed by a container.
+///
+/// There is a helper [`IntoContainerPort`] trait to convert a `u16` into a [`ContainerPort`].
+/// Also, `u16` can be directly converted into a `ContainerPort` using `Into::into`, it will default to `ContainerPort::Tcp`.
 #[derive(
     parse_display::Display, parse_display::FromStr, Debug, Clone, Copy, Eq, PartialEq, Hash,
 )]
@@ -15,7 +19,7 @@ pub enum ContainerPort {
 }
 
 /// A trait to allow easy conversion of a `u16` into a `ContainerPort`.
-/// For example, `123.tcp()` is equivalent to `ContainerPort::Tcp(123)`.
+/// For example, `123.udp()` is equivalent to `ContainerPort::Udp(123)`.
 pub trait IntoContainerPort {
     fn tcp(self) -> ContainerPort;
     fn udp(self) -> ContainerPort;
@@ -138,6 +142,12 @@ impl IntoContainerPort for u16 {
 
     fn sctp(self) -> ContainerPort {
         ContainerPort::Sctp(self)
+    }
+}
+
+impl From<u16> for ContainerPort {
+    fn from(port: u16) -> Self {
+        ContainerPort::Tcp(port)
     }
 }
 

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -290,7 +290,7 @@ mod tests {
             .with_wait_for(WaitFor::seconds(1));
         let container = image.start().await?;
         container
-            .get_host_port_ipv4(5000.tcp())
+            .get_host_port_ipv4(5000)
             .await
             .expect("Port should be mapped");
         Ok(())


### PR DESCRIPTION
As a result, it was decided that such a default makes sense - it corresponds to the default behavior of Docker, and is also more common use case.