### PR TITLE
refactor: preliminary refactoring of `wait` strategies

### DIFF
--- a/testcontainers/src/core/wait/health_strategy.rs
+++ b/testcontainers/src/core/wait/health_strategy.rs
@@ -1,0 +1,40 @@
+use std::time::Duration;
+
+use bollard::models::HealthStatusEnum::*;
+
+use crate::{
+    core::{client::Client, error::WaitContainerError, wait::WaitStrategy},
+    ContainerAsync, Image,
+};
+
+pub(crate) struct HealthWaitStrategy;
+
+impl WaitStrategy for HealthWaitStrategy {
+    async fn wait_until_ready<I: Image>(
+        self,
+        client: &Client,
+        container: &ContainerAsync<I>,
+    ) -> crate::core::error::Result<()> {
+        loop {
+            let health_status = client
+                .inspect(container.id())
+                .await?
+                .state
+                .ok_or(WaitContainerError::StateUnavailable)?
+                .health
+                .and_then(|health| health.status);
+
+            match health_status {
+                Some(HEALTHY) => break,
+                None | Some(EMPTY) | Some(NONE) => Err(
+                    WaitContainerError::HealthCheckNotConfigured(container.id().to_string()),
+                )?,
+                Some(UNHEALTHY) => Err(WaitContainerError::Unhealthy)?,
+                Some(STARTING) => {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/testcontainers/src/core/wait/health_strategy.rs
+++ b/testcontainers/src/core/wait/health_strategy.rs
@@ -56,3 +56,9 @@ impl WaitStrategy for HealthWaitStrategy {
         Ok(())
     }
 }
+
+impl Default for HealthWaitStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/testcontainers/src/core/wait/health_strategy.rs
+++ b/testcontainers/src/core/wait/health_strategy.rs
@@ -7,7 +7,25 @@ use crate::{
     ContainerAsync, Image,
 };
 
-pub(crate) struct HealthWaitStrategy;
+#[derive(Debug, Clone)]
+pub struct HealthWaitStrategy {
+    poll_interval: Duration,
+}
+
+impl HealthWaitStrategy {
+    /// Create a new `HealthWaitStrategy` with default settings.
+    pub fn new() -> Self {
+        Self {
+            poll_interval: Duration::from_millis(100),
+        }
+    }
+
+    /// Set the poll interval for checking the container's health status.
+    pub fn with_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+}
 
 impl WaitStrategy for HealthWaitStrategy {
     async fn wait_until_ready<I: Image>(
@@ -31,7 +49,7 @@ impl WaitStrategy for HealthWaitStrategy {
                 )?,
                 Some(UNHEALTHY) => Err(WaitContainerError::Unhealthy)?,
                 Some(STARTING) => {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    tokio::time::sleep(self.poll_interval).await;
                 }
             }
         }

--- a/testcontainers/src/core/wait/http_strategy.rs
+++ b/testcontainers/src/core/wait/http_strategy.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use url::{Host, Url};
 
 use crate::{
-    core::{error::WaitContainerError, wait::WaitStrategy, ContainerPort},
+    core::{client::Client, error::WaitContainerError, wait::WaitStrategy, ContainerPort},
     ContainerAsync, Image, TestcontainersError,
 };
 
@@ -205,6 +205,7 @@ impl HttpWaitStrategy {
 impl WaitStrategy for HttpWaitStrategy {
     async fn wait_until_ready<I: Image>(
         self,
+        _client: &Client,
         container: &ContainerAsync<I>,
     ) -> crate::core::error::Result<()> {
         let host = container.get_host().await?;

--- a/testcontainers/src/core/wait/mod.rs
+++ b/testcontainers/src/core/wait/mod.rs
@@ -1,10 +1,11 @@
 use std::{env::var, fmt::Debug, time::Duration};
 
 use bytes::Bytes;
+pub use health_strategy::HealthWaitStrategy;
 pub use http_strategy::HttpWaitStrategy;
 
 use crate::{
-    core::{client::Client, error::WaitContainerError, wait::health_strategy::HealthWaitStrategy},
+    core::{client::Client, error::WaitContainerError},
     ContainerAsync, Image,
 };
 
@@ -57,7 +58,7 @@ impl WaitFor {
     /// If you need to customize polling interval, use [`HealthWaitStrategy::with_poll_interval`]
     /// and create the strategy [`WaitFor::Healthcheck`] manually.
     pub fn healthcheck() -> WaitFor {
-        WaitFor::Healthcheck(HealthWaitStrategy::new())
+        WaitFor::Healthcheck(HealthWaitStrategy::default())
     }
 
     /// Wait for a certain HTTP response.


### PR DESCRIPTION
Split implementation into separate strategies.
Also, this PR allows to customize healthcheck polling interval

Later, we will need to:
- introduce log-followers and switch log wait strategy to it, using channels and avoiding multiple log reads.
- 