### PR TITLE
refactor: use multi-threaded runtime for blocking feature

### DIFF
--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -47,10 +47,13 @@ where
 }
 
 impl<I: Image> Container<I> {
-    pub(crate) fn new(runtime: tokio::runtime::Runtime, async_impl: ContainerAsync<I>) -> Self {
+    pub(crate) fn new(
+        runtime: Arc<tokio::runtime::Runtime>,
+        async_impl: ContainerAsync<I>,
+    ) -> Self {
         Self {
             inner: Some(ActiveContainer {
-                runtime: Arc::new(runtime),
+                runtime,
                 async_impl,
             }),
         }


### PR DESCRIPTION
We need this to support log-consumers/followers, since it requires the spawned tasks to run regardless of the `block_on` call.