### PR TITLE
fix!: use `rustls-tls` as default for `reqwest`

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3"
 log = "0.4"
 memchr = "2.7.2"
 parse-display = "0.9.0"
-reqwest = { version = "0.12.4", features = ["default-tls", "hickory-dns", "json", "charset", "http2"], default-features = false }
+reqwest = { version = "0.12.5", features = ["rustls-tls", "rustls-tls-native-roots", "hickory-dns", "json", "charset", "http2"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde-java-properties = { version = "0.2.0", optional = true }
 serde_json = "1"
@@ -49,6 +49,6 @@ properties-config = ["serde-java-properties"]
 [dev-dependencies]
 anyhow = "1.0.86"
 pretty_env_logger = "0.5"
-reqwest = { version = "0.12.4", features = ["blocking"] }
+reqwest = { version = "0.12.4", features = ["blocking"], default-features = false }
 testimages.workspace = true
 tokio = { version = "1", features = ["macros"] }

--- a/testcontainers/src/core/wait/http_strategy.rs
+++ b/testcontainers/src/core/wait/http_strategy.rs
@@ -70,6 +70,8 @@ impl HttpWaitStrategy {
     /// Set the custom client for the request.
     ///
     /// Allows to customize the client, enabling features like TLS, accept_invalid_certs, proxies, etc.
+    /// If you need to use particular features of `reqwest`, just add `reqwest` to your dependencies with desired features enabled.
+    /// After that, you can create a client with the desired configuration and pass it to the wait strategy.
     pub fn with_client(mut self, client: reqwest::Client) -> Self {
         self.client = Some(client);
         self


### PR DESCRIPTION
Closes #671 

`reqwest` exposes a number of TLS-related features, there is no much sense to re-expose them.

Cargo features are additive (and reqwest follows this rule), so it's always possible to customize by adding `reqwest` dependency with desired feature-set

We can re-consider feature-set provided by `testcontainers` later, but currently we already depend on them through `bollard`: it relies on `rustls` and `rustls-native-certs`

It's even possible to make these features optional (e.g when you don't need tls support neither for docker nor reqwest).