### PR TITLE
refactor: internal log processing structures

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3"
 log = "0.4"
 memchr = "2.7.2"
 parse-display = "0.9.0"
+pin-project-lite = "0.2.14"
 reqwest = { version = "0.12.5", features = ["rustls-tls", "rustls-tls-native-roots", "hickory-dns", "json", "charset", "http2"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde-java-properties = { version = "0.2.0", optional = true }

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -13,7 +13,7 @@ pub(crate) mod client;
 pub(crate) mod containers;
 pub(crate) mod env;
 pub mod error;
-pub(crate) mod logs;
+pub mod logs;
 pub(crate) mod mounts;
 pub(crate) mod network;
 pub mod ports;

--- a/testcontainers/src/core/client/exec.rs
+++ b/testcontainers/src/core/client/exec.rs
@@ -1,9 +1,9 @@
-use crate::core::logs::LogStreamAsync;
+use crate::core::logs::WaitingStreamWrapper;
 
 pub(crate) struct ExecResult {
     pub(crate) id: String,
-    pub(crate) stdout: LogStreamAsync,
-    pub(crate) stderr: LogStreamAsync,
+    pub(crate) stdout: WaitingStreamWrapper,
+    pub(crate) stderr: WaitingStreamWrapper,
 }
 
 impl ExecResult {
@@ -11,11 +11,11 @@ impl ExecResult {
         &self.id
     }
 
-    pub(crate) fn stdout(&mut self) -> &mut LogStreamAsync {
+    pub(crate) fn stdout(&mut self) -> &mut WaitingStreamWrapper {
         &mut self.stdout
     }
 
-    pub(crate) fn stderr(&mut self) -> &mut LogStreamAsync {
+    pub(crate) fn stderr(&mut self) -> &mut WaitingStreamWrapper {
         &mut self.stderr
     }
 }

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -1,6 +1,7 @@
 use std::{fmt, net::IpAddr, pin::Pin, str::FromStr, sync::Arc, time::Duration};
 
 use tokio::io::{AsyncBufRead, AsyncReadExt};
+use tokio_stream::StreamExt;
 
 use crate::{
     core::{
@@ -264,7 +265,7 @@ where
     ///   - pass `false` to read logs from startup to present.
     pub fn stdout(&self, follow: bool) -> Pin<Box<dyn AsyncBufRead + Send>> {
         let stdout = self.docker_client.stdout_logs(&self.id, follow);
-        Box::pin(tokio_util::io::StreamReader::new(stdout.into_inner()))
+        Box::pin(tokio_util::io::StreamReader::new(stdout))
     }
 
     /// Returns an asynchronous reader for stderr.
@@ -274,7 +275,7 @@ where
     ///   - pass `false` to read logs from startup to present.
     pub fn stderr(&self, follow: bool) -> Pin<Box<dyn AsyncBufRead + Send>> {
         let stderr = self.docker_client.stderr_logs(&self.id, follow);
-        Box::pin(tokio_util::io::StreamReader::new(stderr.into_inner()))
+        Box::pin(tokio_util::io::StreamReader::new(stderr))
     }
 
     /// Returns stdout as a vector of bytes available at the moment of call (from container startup to present).

--- a/testcontainers/src/core/logs/stream.rs
+++ b/testcontainers/src/core/logs/stream.rs
@@ -1,0 +1,106 @@
+use std::{
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use futures::{stream::BoxStream, Stream, StreamExt};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use crate::core::logs::LogFrame;
+
+pub(crate) type RawLogStream = BoxStream<'static, Result<Bytes, io::Error>>;
+
+pin_project_lite::pin_project! {
+    pub(crate) struct LogStream {
+        #[pin]
+        inner: BoxStream<'static, Result<LogFrame, io::Error>>,
+    }
+}
+
+impl LogStream {
+    pub fn new(stream: BoxStream<'static, Result<LogFrame, io::Error>>) -> Self {
+        Self { inner: stream }
+    }
+
+    /// Filters the log stream to only include stdout messages.
+    pub(crate) fn into_stdout(self) -> RawLogStream {
+        self.inner
+            .filter_map(|record| async move {
+                match record {
+                    Ok(LogFrame::StdOut(bytes)) => Some(Ok(bytes)),
+                    Ok(LogFrame::StdErr(_)) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .boxed()
+    }
+
+    /// Filters the log stream to only include stderr messages.
+    pub(crate) fn into_stderr(self) -> RawLogStream {
+        self.inner
+            .filter_map(|record| async move {
+                match record {
+                    Ok(LogFrame::StdErr(bytes)) => Some(Ok(bytes)),
+                    Ok(LogFrame::StdOut(_)) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .boxed()
+    }
+
+    /// Splits the log stream into two streams, one for stdout and one for stderr.
+    pub(crate) async fn split(self) -> (RawLogStream, RawLogStream) {
+        let (stdout_tx, stdout_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (stderr_tx, stderr_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            macro_rules! handle_error {
+                ($res:expr) => {
+                    if let Err(err) = $res {
+                        log::debug!(
+                            "Receiver has been dropped, stop producing messages: {}",
+                            err
+                        );
+                        break;
+                    }
+                };
+            }
+            let mut output = self;
+            while let Some(chunk) = output.next().await {
+                match chunk {
+                    Ok(LogFrame::StdOut(message)) => {
+                        handle_error!(stdout_tx.send(Ok(message)));
+                    }
+                    Ok(LogFrame::StdErr(message)) => {
+                        handle_error!(stderr_tx.send(Ok(message)));
+                    }
+                    Err(err) => {
+                        let err = Arc::new(err);
+                        handle_error!(
+                            stdout_tx.send(Err(io::Error::new(io::ErrorKind::Other, err.clone())))
+                        );
+                        handle_error!(
+                            stderr_tx.send(Err(io::Error::new(io::ErrorKind::Other, err)))
+                        );
+                    }
+                }
+            }
+        });
+
+        let stdout = UnboundedReceiverStream::new(stdout_rx).boxed();
+        let stderr = UnboundedReceiverStream::new(stderr_rx).boxed();
+        (stdout, stderr)
+    }
+}
+
+impl Stream for LogStream {
+    type Item = Result<LogFrame, io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        this.inner.poll_next(cx)
+    }
+}


### PR DESCRIPTION
Preliminary refactoring to clean up the code and prepare the code-base before introducing log consumers.
