### PR TITLE
fix!: drop `Clone` impl for `ContainerRequest`

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Represents a request to start a container, allowing customization of the container.
 #[must_use]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ContainerRequest<I: Image> {
     pub(crate) image: I,
     pub(crate) overridden_cmd: Vec<String>,


### PR DESCRIPTION
`Image` can be cloned just fine, but `ContainerRequest` is not intended to be, and is not, a truly safe structure for cloning. It allows to override unique container properties: container name, port mappings and log consumers (soon).

If necessary, you can always use a reusable constructor/method to create multiple similar `ContainerRequests`.