### PR TITLE
feat(wait)!: enhance `LogWaitStrategy` to wait for message appearance multiple times

### DIFF
--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -204,13 +204,13 @@ where
         match cmd_ready_condition {
             CmdWaitFor::StdOutMessage { message } => {
                 exec.stdout()
-                    .wait_for_message(&message)
+                    .wait_for_message(&message, 1)
                     .await
                     .map_err(ExecError::from)?;
             }
             CmdWaitFor::StdErrMessage { message } => {
                 exec.stderr()
-                    .wait_for_message(&message)
+                    .wait_for_message(&message, 1)
                     .await
                     .map_err(ExecError::from)?;
             }

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -39,9 +39,7 @@ where
     /// up.
     ///
     /// The conditions returned from this method are evaluated **in the order** they are returned. Therefore
-    /// you most likely want to start with a [`WaitFor::StdOutMessage`] or [`WaitFor::StdErrMessage`] and
-    /// potentially follow up with a [`WaitFor::Duration`] in case the container usually needs a little
-    /// more time before it is ready.
+    /// you most likely want to start with a [`WaitFor::Log`] or [`WaitFor::Http`].
     fn ready_conditions(&self) -> Vec<WaitFor>;
 
     /// Returns the environment variables that needs to be set when a container is created.

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -134,13 +134,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn given_logs_when_line_contains_message_should_find_it() {
-        let mut log_stream = WaitingStreamWrapper::new(Box::pin(futures::stream::iter([Ok(r"
-            Message one
-            Message two
-            Message three
-            Message three
-        "
-        .into())])));
+        let mut log_stream = WaitingStreamWrapper::new(Box::pin(futures::stream::iter([
+            Ok("Message one"),
+            Ok("Message two"),
+            Ok("Message three"),
+            Ok("Message three"),
+        ])));
 
         let result = log_stream.wait_for_message("Message three", 2).await;
         assert!(result.is_ok());

--- a/testcontainers/src/core/logs.rs
+++ b/testcontainers/src/core/logs.rs
@@ -135,10 +135,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn given_logs_when_line_contains_message_should_find_it() {
         let mut log_stream = WaitingStreamWrapper::new(Box::pin(futures::stream::iter([
-            Ok("Message one"),
-            Ok("Message two"),
-            Ok("Message three"),
-            Ok("Message three"),
+            Ok("Message one".into()),
+            Ok("Message two".into()),
+            Ok("Message three".into()),
+            Ok("Message three".into()),
         ])));
 
         let result = log_stream.wait_for_message("Message three", 2).await;

--- a/testcontainers/src/core/wait/log_strategy.rs
+++ b/testcontainers/src/core/wait/log_strategy.rs
@@ -1,0 +1,68 @@
+use bytes::Bytes;
+
+use crate::{
+    core::{
+        client::Client,
+        error::WaitContainerError,
+        logs::{LogSource, WaitingStreamWrapper},
+        wait::WaitStrategy,
+    },
+    ContainerAsync, Image,
+};
+
+#[derive(Debug, Clone)]
+pub struct LogWaitStrategy {
+    source: LogSource,
+    message: Bytes,
+    times: usize,
+}
+
+impl LogWaitStrategy {
+    /// Create a new [`LogWaitStrategy`] that waits for the given message to appear in the standard output logs.
+    /// Shortcut for `LogWaitStrategy::new(LogSource::StdOut, message)`.
+    pub fn stdout(message: impl AsRef<[u8]>) -> Self {
+        Self::new(LogSource::StdOut, message)
+    }
+
+    /// Create a new [`LogWaitStrategy`] that waits for the given message to appear in the standard error logs.
+    /// Shortcut for `LogWaitStrategy::new(LogSource::StdErr, message)`.
+    pub fn stderr(message: impl AsRef<[u8]>) -> Self {
+        Self::new(LogSource::StdErr, message)
+    }
+
+    /// Create a new `LogWaitStrategy` with the given log source and message.
+    /// The message is expected to appear in the logs exactly once by default.
+    pub fn new(source: LogSource, message: impl AsRef<[u8]>) -> Self {
+        Self {
+            source,
+            message: Bytes::from(message.as_ref().to_vec()),
+            times: 1,
+        }
+    }
+
+    /// Set the number of times the message should appear in the logs.
+    pub fn with_times(mut self, times: usize) -> Self {
+        self.times = times;
+        self
+    }
+}
+
+impl WaitStrategy for LogWaitStrategy {
+    async fn wait_until_ready<I: Image>(
+        self,
+        client: &Client,
+        container: &ContainerAsync<I>,
+    ) -> crate::core::error::Result<()> {
+        let log_stream = match self.source {
+            LogSource::StdOut => client.stdout_logs(container.id(), true),
+            LogSource::StdErr => client.stderr_logs(container.id(), true),
+        };
+
+        WaitingStreamWrapper::new(log_stream)
+            .wait_for_message(self.message, self.times)
+            .await
+            .map_err(WaitContainerError::from)?;
+
+        Ok(())
+    }
+}

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -5,7 +5,7 @@ use reqwest::StatusCode;
 use testcontainers::{
     core::{
         logs::{consumer::logging_consumer::LoggingConsumer, LogFrame},
-        wait::HttpWaitStrategy,
+        wait::{HttpWaitStrategy, LogWaitStrategy},
         CmdWaitFor, ExecCommand, IntoContainerPort, WaitFor,
     },
     runners::AsyncRunner,
@@ -98,7 +98,9 @@ async fn async_run_exec() -> anyhow::Result<()> {
     let _ = pretty_env_logger::try_init();
 
     let image = GenericImage::new("simple_web_server", "latest")
-        .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+        .with_wait_for(WaitFor::log(
+            LogWaitStrategy::stdout("server is ready").with_times(2),
+        ))
         .with_wait_for(WaitFor::seconds(1));
     let container = image.start().await?;
 

--- a/testcontainers/tests/sync_runner.rs
+++ b/testcontainers/tests/sync_runner.rs
@@ -4,7 +4,7 @@ use reqwest::StatusCode;
 use testcontainers::{
     core::{
         logs::{consumer::logging_consumer::LoggingConsumer, LogFrame},
-        wait::HttpWaitStrategy,
+        wait::{HttpWaitStrategy, LogWaitStrategy},
         CmdWaitFor, ExecCommand, Host, IntoContainerPort, WaitFor,
     },
     runners::SyncRunner,
@@ -150,7 +150,9 @@ fn sync_run_exec() -> anyhow::Result<()> {
     let _ = pretty_env_logger::try_init();
 
     let image = GenericImage::new("simple_web_server", "latest")
-        .with_wait_for(WaitFor::message_on_stdout("server is ready"))
+        .with_wait_for(WaitFor::log(
+            LogWaitStrategy::stdout("server is ready").with_times(2),
+        ))
         .with_wait_for(WaitFor::seconds(1));
     let container = image.start()?;
 

--- a/testimages/src/bin/simple_web_server.rs
+++ b/testimages/src/bin/simple_web_server.rs
@@ -13,6 +13,7 @@ async fn main() {
     let addr = SocketAddr::from(([0, 0, 0, 0], 80));
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     println!("server is ready");
+    println!("server is ready"); // duplicate line to test `times` parameter of `WaitFor::Log`
     axum::serve(listener, app.into_make_service())
         .with_graceful_shutdown(shutdown_signal())
         .await


### PR DESCRIPTION
The interface has been changed a bit to support advanced configuration of the strategy. For example, to wait for a message to appear twice in `stdout`:

```rs
WaitFor::log(
    LogWaitStrategy::stdout("server is ready").with_times(2),
)
```

Closes #675