### PR TITLE
chore: relax log level for log producer error

### DIFF
--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -77,7 +77,7 @@ where
                         }
                     }
                     Err(err) => {
-                        log::error!("Failed to read log frame for container {container_id}: {err}",);
+                        log::warn!("Failed to read log frame for container {container_id}: {err}",);
                     }
                 }
             }


### PR DESCRIPTION
The error might be expected, e.g. container has been stopped.