### PR TITLE
feat: allow configuring resource ulimits

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -6,6 +6,8 @@ use std::{
     time::Duration,
 };
 
+use bollard_stubs::models::ResourcesUlimits;
+
 use crate::{
     core::{
         logs::consumer::LogConsumer, mounts::Mount, ports::ContainerPort, ContainerState,
@@ -41,14 +43,6 @@ pub struct ContainerRequest<I: Image> {
 pub struct PortMapping {
     pub(crate) host_port: u16,
     pub(crate) container_port: ContainerPort,
-}
-
-/// Represents a resource ulimit.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResourcesUlimits {
-    pub(crate) name: Option<String>,
-    pub(crate) soft: Option<i64>,
-    pub(crate) hard: Option<i64>,
 }
 
 #[derive(parse_display::Display, Debug, Clone)]
@@ -102,10 +96,6 @@ impl<I: Image> ContainerRequest<I> {
 
     pub fn ports(&self) -> Option<&Vec<PortMapping>> {
         self.ports.as_ref()
-    }
-
-    pub fn ulimits(&self) -> Option<&Vec<ResourcesUlimits>> {
-        self.ulimits.as_ref()
     }
 
     pub fn privileged(&self) -> bool {

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -6,8 +6,6 @@ use std::{
     time::Duration,
 };
 
-use bollard_stubs::models::ResourcesUlimits;
-
 use crate::{
     core::{
         logs::consumer::LogConsumer, mounts::Mount, ports::ContainerPort, ContainerState,
@@ -43,6 +41,14 @@ pub struct ContainerRequest<I: Image> {
 pub struct PortMapping {
     pub(crate) host_port: u16,
     pub(crate) container_port: ContainerPort,
+}
+
+/// Represents a resource ulimit.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResourcesUlimits {
+    pub(crate) name: Option<String>,
+    pub(crate) soft: Option<i64>,
+    pub(crate) hard: Option<i64>,
 }
 
 #[derive(parse_display::Display, Debug, Clone)]

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -1,17 +1,17 @@
-use std::{
-    borrow::Cow,
-    collections::BTreeMap,
-    fmt::{Debug, Formatter},
-    net::IpAddr,
-    time::Duration,
-};
-
 use crate::{
     core::{
         logs::consumer::LogConsumer, mounts::Mount, ports::ContainerPort, ContainerState,
         ExecCommand, WaitFor,
     },
     Image, TestcontainersError,
+};
+use bollard_stubs::models::ResourcesUlimits;
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    fmt::{Debug, Formatter},
+    net::IpAddr,
+    time::Duration,
 };
 
 /// Represents a request to start a container, allowing customization of the container.
@@ -27,6 +27,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) hosts: BTreeMap<String, Host>,
     pub(crate) mounts: Vec<Mount>,
     pub(crate) ports: Option<Vec<PortMapping>>,
+    pub(crate) ulimits: Option<Vec<ResourcesUlimits>>,
     pub(crate) privileged: bool,
     pub(crate) shm_size: Option<u64>,
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
@@ -93,6 +94,10 @@ impl<I: Image> ContainerRequest<I> {
 
     pub fn ports(&self) -> Option<&Vec<PortMapping>> {
         self.ports.as_ref()
+    }
+
+    pub fn ulimits(&self) -> Option<&Vec<ResourcesUlimits>> {
+        self.ulimits.as_ref()
     }
 
     pub fn privileged(&self) -> bool {
@@ -168,6 +173,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             hosts: BTreeMap::default(),
             mounts: Vec::new(),
             ports: None,
+            ulimits: None,
             privileged: false,
             shm_size: None,
             cgroupns_mode: None,
@@ -208,6 +214,7 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("hosts", &self.hosts)
             .field("mounts", &self.mounts)
             .field("ports", &self.ports)
+            .field("ulimits", &self.ulimits)
             .field("privileged", &self.privileged)
             .field("shm_size", &self.shm_size)
             .field("cgroupns_mode", &self.cgroupns_mode)

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -1,17 +1,19 @@
-use crate::{
-    core::{
-        logs::consumer::LogConsumer, mounts::Mount, ports::ContainerPort, ContainerState,
-        ExecCommand, WaitFor,
-    },
-    Image, TestcontainersError,
-};
-use bollard_stubs::models::ResourcesUlimits;
 use std::{
     borrow::Cow,
     collections::BTreeMap,
     fmt::{Debug, Formatter},
     net::IpAddr,
     time::Duration,
+};
+
+use bollard_stubs::models::ResourcesUlimits;
+
+use crate::{
+    core::{
+        logs::consumer::LogConsumer, mounts::Mount, ports::ContainerPort, ContainerState,
+        ExecCommand, WaitFor,
+    },
+    Image, TestcontainersError,
 };
 
 /// Represents a request to start a container, allowing customization of the container.

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -73,7 +73,7 @@ pub trait ImageExt<I: Image> {
     /// ```rust,no_run
     /// use testcontainers::{GenericImage, ImageExt};
     ///
-    /// let image = GenericImage::new("image", "tag").with_ulimit("nofile", 65536, 65536);
+    /// let image = GenericImage::new("image", "tag").with_ulimit("nofile", 65536, Some(65536));
     /// ```
     fn with_ulimit(self, name: &str, soft: i64, hard: Option<i64>) -> ContainerRequest<I>;
 

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
+use bollard_stubs::models::ResourcesUlimits;
+
 use crate::{
-    core::{
-        logs::consumer::LogConsumer, request::ResourcesUlimits, CgroupnsMode, ContainerPort, Host,
-        Mount, PortMapping,
-    },
+    core::{logs::consumer::LogConsumer, CgroupnsMode, ContainerPort, Host, Mount, PortMapping},
     ContainerRequest, Image,
 };
 

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
-use bollard_stubs::models::ResourcesUlimits;
-
 use crate::{
-    core::{logs::consumer::LogConsumer, CgroupnsMode, ContainerPort, Host, Mount, PortMapping},
+    core::{
+        logs::consumer::LogConsumer, request::ResourcesUlimits, CgroupnsMode, ContainerPort, Host,
+        Mount, PortMapping,
+    },
     ContainerRequest, Image,
 };
 
@@ -74,7 +75,7 @@ pub trait ImageExt<I: Image> {
     ///
     /// let image = GenericImage::new("image", "tag").with_ulimit("nofile", 65536, 65536);
     /// ```
-    fn with_ulimit(self, name: &str, soft: i64, hard: i64) -> ContainerRequest<I>;
+    fn with_ulimit(self, name: &str, soft: i64, hard: Option<i64>) -> ContainerRequest<I>;
 
     /// Sets the container to run in privileged mode.
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
@@ -180,13 +181,13 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    fn with_ulimit(self, name: &str, soft: i64, hard: i64) -> ContainerRequest<I> {
+    fn with_ulimit(self, name: &str, soft: i64, hard: Option<i64>) -> ContainerRequest<I> {
         let container_req = self.into();
         let mut ulimits = container_req.ulimits.unwrap_or_default();
         ulimits.push(ResourcesUlimits {
             name: Some(name.into()),
             soft: Some(soft),
-            hard: Some(hard),
+            hard,
         });
 
         ContainerRequest {

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -1,9 +1,11 @@
+use std::time::Duration;
+
+use bollard_stubs::models::ResourcesUlimits;
+
 use crate::{
     core::{logs::consumer::LogConsumer, CgroupnsMode, ContainerPort, Host, Mount, PortMapping},
     ContainerRequest, Image,
 };
-use bollard_stubs::models::ResourcesUlimits;
-use std::time::Duration;
 
 /// Represents an extension for the [`Image`] trait.
 /// Allows to override image defaults and container configuration.

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -173,7 +173,7 @@ where
         }
 
         // resource ulimits
-        if let Some(ulimits) = container_req.ulimits() {
+        if let Some(ulimits) = &container_req.ulimits {
             config.host_config = config.host_config.map(|mut host_config| {
                 host_config.ulimits = Some(
                     ulimits

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -286,6 +286,26 @@ mod tests {
     }
 
     #[test]
+    fn sync_run_command_should_include_ulimits() -> anyhow::Result<()> {
+        let image = GenericImage::new("hello-world", "latest");
+        let container = image.with_ulimit("nofile", 123, 456).start()?;
+
+        let container_details = inspect(container.id())?;
+
+        let ulimits = container_details
+            .host_config
+            .expect("HostConfig")
+            .ulimits
+            .expect("Privileged");
+
+        assert_eq!(ulimits.len(), 1);
+        assert_eq!(ulimits[0].name, Some("nofile".into()));
+        assert_eq!(ulimits[0].soft, Some(123));
+        assert_eq!(ulimits[0].hard, Some(456));
+        Ok(())
+    }
+
+    #[test]
     fn sync_run_command_should_set_shared_memory_size() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
         let container = image.with_shm_size(1_000_000).start()?;

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -290,7 +290,7 @@ mod tests {
         let image = GenericImage::new("hello-world", "latest");
         let container = image.with_ulimit("nofile", 123, 456).start()?;
 
-        let container_details = inspect(container.id())?;
+        let container_details = inspect(container.id());
 
         let ulimits = container_details
             .host_config

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn sync_run_command_should_include_ulimits() -> anyhow::Result<()> {
         let image = GenericImage::new("hello-world", "latest");
-        let container = image.with_ulimit("nofile", 123, 456).start()?;
+        let container = image.with_ulimit("nofile", 123, Some(456)).start()?;
 
         let container_details = inspect(container.id());
 


### PR DESCRIPTION
Thanks again for working on this project!

This exposes a way to configure resource ulimits (the [`--ulimit`](https://docs.docker.com/reference/cli/docker/container/run/#ulimit) flag for `docker run`).

I'm relying on CI tests because I'm currently on Windows and didn't configure my environment to reflect https://github.com/testcontainers/testcontainers-rs/issues/711, since it seems I'd need to install nasm now, as I received some errors regarding it.