### PR TITLE
fix: docker socket detection on unix

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -312,7 +312,7 @@ impl Client {
     }
 
     pub(crate) async fn docker_hostname(&self) -> Result<url::Host, ClientError> {
-        let docker_host = self.config.docker_host();
+        let docker_host = &self.config.docker_host();
         let docker_host_url = Url::from_str(docker_host)
             .map_err(|e| ConfigurationError::InvalidDockerHost(e.to_string()))?;
 

--- a/testcontainers/src/core/client/bollard_client.rs
+++ b/testcontainers/src/core/client/bollard_client.rs
@@ -8,7 +8,7 @@ use crate::core::env;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 pub(super) fn init(config: &env::Config) -> Result<Docker, bollard::errors::Error> {
-    let host = config.docker_host();
+    let host = &config.docker_host();
     let host_url = Url::from_str(host)?;
 
     match host_url.scheme() {
@@ -36,7 +36,7 @@ fn connect_with_ssl(config: &env::Config) -> Result<Docker, bollard::errors::Err
     let cert_path = config.cert_path().expect("cert path not found");
 
     Docker::connect_with_ssl(
-        config.docker_host(),
+        &config.docker_host(),
         &cert_path.join("key.pem"),
         &cert_path.join("cert.pem"),
         &cert_path.join("ca.pem"),

--- a/testcontainers/src/core/env/config.rs
+++ b/testcontainers/src/core/env/config.rs
@@ -1,9 +1,10 @@
-use dirs::{home_dir, runtime_dir};
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
     str::FromStr,
 };
+
+use dirs::{home_dir, runtime_dir};
 
 use crate::core::env::GetEnvValue;
 

--- a/testcontainers/src/core/env/config.rs
+++ b/testcontainers/src/core/env/config.rs
@@ -140,26 +140,20 @@ impl Config {
             .map(Cow::Borrowed)
             .unwrap_or_else(|| {
                 if cfg!(unix) {
-                    check_path_exists("/var/run/docker.sock".into())
+                    validate_path("/var/run/docker.sock".into())
                         .or_else(|| {
                             runtime_dir().and_then(|dir| {
-                                check_path_exists(format!(
-                                    "{}/.docker/run/docker.sock",
-                                    dir.display()
-                                ))
+                                validate_path(format!("{}/.docker/run/docker.sock", dir.display()))
                             })
                         })
                         .or_else(|| {
                             home_dir().and_then(|dir| {
-                                check_path_exists(format!(
-                                    "{}/.docker/run/docker.sock",
-                                    dir.display()
-                                ))
+                                validate_path(format!("{}/.docker/run/docker.sock", dir.display()))
                             })
                         })
                         .or_else(|| {
                             home_dir().and_then(|dir| {
-                                check_path_exists(format!(
+                                validate_path(format!(
                                     "{}/.docker/desktop/docker.sock",
                                     dir.display()
                                 ))
@@ -191,8 +185,8 @@ impl Config {
     }
 }
 
-/// Checks if the path exists and returns it if it does.
-fn check_path_exists(path: String) -> Option<String> {
+/// Validate the path exists and return it if it does.
+fn validate_path(path: String) -> Option<String> {
     if Path::new(&path).exists() {
         Some(path)
     } else {

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -40,7 +40,13 @@
 //! 1. Docker host from the `tc.host` property in the `~/.testcontainers.properties` file.
 //! 2. `DOCKER_HOST` environment variable.
 //! 3. Docker host from the "docker.host" property in the `~/.testcontainers.properties` file.
-//! 4. Else, the default Docker socket will be returned.
+//! 4. Read the default Docker socket path, without the unix schema. E.g. `/var/run/docker.sock`.
+//! 5. Read the rootless Docker socket path, checking in the following alternative locations:
+//!    1. `${XDG_RUNTIME_DIR}/.docker/run/docker.sock`.
+//!    2. `${HOME}/.docker/run/docker.sock`.
+//!    3. `${HOME}/.docker/desktop/docker.sock`.
+//!    4. `/run/user/${UID}/docker.sock`, where `${UID}` is the user ID of the current user.
+//! 6. The default Docker socket including schema will be returned if none of the above are set.
 //!
 //! ### Docker authentication
 //!

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -45,7 +45,6 @@
 //!    1. `${XDG_RUNTIME_DIR}/.docker/run/docker.sock`.
 //!    2. `${HOME}/.docker/run/docker.sock`.
 //!    3. `${HOME}/.docker/desktop/docker.sock`.
-//!    4. `/run/user/${UID}/docker.sock`, where `${UID}` is the user ID of the current user.
 //! 6. The default Docker socket including schema will be returned if none of the above are set.
 //!
 //! ### Docker authentication


### PR DESCRIPTION
Docker Desktop on macOS creates the socket in the user's home directory from version 4.13.0.[[1](https://github.com/docker/for-mac/issues/6529)][[2](https://github.com/testcontainers/testcontainers-java/issues/6165)]

And the Docker team [has the intention to move away](https://github.com/docker/for-mac/issues/6529#issuecomment-1710091807) from the root-owned `/var/run/docker.sock`

There is a option named `Allow the default Docket Socket to be used (requires password)` in the Docker Desktop, but the created symbolic link `/var/run/docker.sock` [doesn't persist](https://github.com/lando/lando/issues/3533#issuecomment-1464252377) between OS restart or OS upgrade.

Without this patch or creating a symbolic link, macOS devs have to face the ```called `Result::unwrap()` on an `Err` value: Client(Init(SocketNotFoundError("/var/run/docker.sock")))``` error.

I have used `Cow` to avoid the need of cloning the fields of `Config` struct. I am open to suggestion or other approaches.

Thanks!