### PR TITLE
chore: add `#![forbid(unsafe_code)]` to the library

### DIFF
--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(unsafe_code)]
 
 //! A library for integration testing against docker containers from within Rust.
 //!


### PR DESCRIPTION
The motivation is to make [`cargo-geiger`](https://github.com/geiger-rs/cargo-geiger) be sure that there is no unsafe code