### PR TITLE
feat: add `working_dir` to `ContainerRequest`,`ImageExt`

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -224,6 +224,7 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("cgroupns_mode", &self.cgroupns_mode)
             .field("userns_mode", &self.userns_mode)
             .field("startup_timeout", &self.startup_timeout)
+            .field("working_dir", &self.working_dir)
             .finish()
     }
 }

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -157,7 +157,7 @@ impl<I: Image> ContainerRequest<I> {
     pub fn startup_timeout(&self) -> Option<Duration> {
         self.startup_timeout
     }
-    
+
     pub fn working_dir(&self) -> Option<&str> {
         self.working_dir.as_deref()
     }

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -35,6 +35,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
     pub(crate) userns_mode: Option<String>,
     pub(crate) startup_timeout: Option<Duration>,
+    pub(crate) working_dir: Option<String>,
     pub(crate) log_consumers: Vec<Box<dyn LogConsumer + 'static>>,
 }
 
@@ -156,6 +157,10 @@ impl<I: Image> ContainerRequest<I> {
     pub fn startup_timeout(&self) -> Option<Duration> {
         self.startup_timeout
     }
+    
+    pub fn working_dir(&self) -> Option<&str> {
+        self.working_dir.as_deref()
+    }
 }
 
 impl<I: Image> From<I> for ContainerRequest<I> {
@@ -177,6 +182,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             cgroupns_mode: None,
             userns_mode: None,
             startup_timeout: None,
+            working_dir: None,
             log_consumers: vec![],
         }
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -94,6 +94,9 @@ pub trait ImageExt<I: Image> {
     /// Sets the startup timeout for the container. The default is 60 seconds.
     fn with_startup_timeout(self, timeout: Duration) -> ContainerRequest<I>;
 
+    /// Sets the working directory. The default is defined by the underlying image, which in turn may default to `/`.
+    fn with_working_dir(self, working_dir: impl Into<String>) -> ContainerRequest<I>;
+
     /// Adds the log consumer to the container.
     ///
     /// Allows to follow the container logs for the whole lifecycle of the container, starting from the creation.
@@ -231,6 +234,14 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         let container_req = self.into();
         ContainerRequest {
             startup_timeout: Some(timeout),
+            ..container_req
+        }
+    }
+
+    fn with_working_dir(self, working_dir: impl Into<String>) -> ContainerRequest<I> {
+        let container_req = self.into();
+        ContainerRequest {
+            working_dir: Some(working_dir.into()),
             ..container_req
         }
     }

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -663,7 +663,10 @@ mod tests {
             .expect("ContainerConfig")
             .working_dir
             .expect("WorkingDir");
-        assert_eq!(expected_working_dir, &working_dir, "working dir must be `foo`");
+        assert_eq!(
+            expected_working_dir, &working_dir,
+            "working dir must be `foo`"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Implements #720 by adding support for setting the working directory on `ImageExt` and `ContainerRequest`. Also adds a test for this feature. This is equivalent to the `-w, --workdir` flag of `docker run`.

The abbreviation `working_dir` (as opposed to e.g. `working_directory`) was chosen to use the same name as the `bollard` crate.