### PR TITLE
feat: add `cap_add` and `cap_drop` support

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -31,6 +31,8 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) ports: Option<Vec<PortMapping>>,
     pub(crate) ulimits: Option<Vec<ResourcesUlimits>>,
     pub(crate) privileged: bool,
+    pub(crate) cap_add: Option<Vec<String>>,
+    pub(crate) cap_drop: Option<Vec<String>>,
     pub(crate) shm_size: Option<u64>,
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
     pub(crate) userns_mode: Option<String>,
@@ -101,6 +103,14 @@ impl<I: Image> ContainerRequest<I> {
 
     pub fn privileged(&self) -> bool {
         self.privileged
+    }
+
+    pub fn cap_add(&self) -> Option<&Vec<String>> {
+        self.cap_add.as_ref()
+    }
+
+    pub fn cap_drop(&self) -> Option<&Vec<String>> {
+        self.cap_drop.as_ref()
     }
 
     pub fn cgroupns_mode(&self) -> Option<CgroupnsMode> {
@@ -178,6 +188,8 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             ports: None,
             ulimits: None,
             privileged: false,
+            cap_add: None,
+            cap_drop: None,
             shm_size: None,
             cgroupns_mode: None,
             userns_mode: None,
@@ -220,6 +232,8 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("ports", &self.ports)
             .field("ulimits", &self.ulimits)
             .field("privileged", &self.privileged)
+            .field("cap_add", &self.cap_add)
+            .field("cap_drop", &self.cap_drop)
             .field("shm_size", &self.shm_size)
             .field("cgroupns_mode", &self.cgroupns_mode)
             .field("userns_mode", &self.userns_mode)

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -79,6 +79,12 @@ pub trait ImageExt<I: Image> {
     /// Sets the container to run in privileged mode.
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
 
+    /// Adds the capabilities to the container
+    fn with_cap_add(self, capabilities: Vec<String>) -> ContainerRequest<I>;
+
+    /// Drops the capabilities from the container's capabilities
+    fn with_cap_drop(self, capabilities: Vec<String>) -> ContainerRequest<I>;
+
     /// cgroup namespace mode for the container. Possible values are:
     /// - [`CgroupnsMode::Private`]: the container runs in its own private cgroup namespace
     /// - [`CgroupnsMode::Host`]: use the host system's cgroup namespace
@@ -202,6 +208,22 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         let container_req = self.into();
         ContainerRequest {
             privileged,
+            ..container_req
+        }
+    }
+
+    fn with_cap_add(self, capabilities: Vec<String>) -> ContainerRequest<I> {
+        let container_req = self.into();
+        ContainerRequest {
+            cap_add: Some(capabilities),
+            ..container_req
+        }
+    }
+
+    fn with_cap_drop(self, capabilities: Vec<String>) -> ContainerRequest<I> {
+        let container_req = self.into();
+        ContainerRequest {
+            cap_drop: Some(capabilities),
             ..container_req
         }
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -80,10 +80,10 @@ pub trait ImageExt<I: Image> {
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
 
     /// Adds the capabilities to the container
-    fn with_cap_add(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I>;
+    fn with_cap_add(self, capability: impl Into<String>) -> ContainerRequest<I>;
 
     /// Drops the capabilities from the container's capabilities
-    fn with_cap_drop(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I>;
+    fn with_cap_drop(self, capability: impl Into<String>) -> ContainerRequest<I>;
 
     /// cgroup namespace mode for the container. Possible values are:
     /// - [`CgroupnsMode::Private`]: the container runs in its own private cgroup namespace
@@ -212,22 +212,22 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    fn with_cap_add(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I> {
+    fn with_cap_add(self, capability: impl Into<String>) -> ContainerRequest<I> {
         let mut container_req = self.into();
         container_req
             .cap_add
             .get_or_insert_with(Vec::new)
-            .extend(capabilities);
+            .push(capability.into());
 
         container_req
     }
 
-    fn with_cap_drop(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I> {
+    fn with_cap_drop(self, capability: impl Into<String>) -> ContainerRequest<I> {
         let mut container_req = self.into();
         container_req
             .cap_drop
             .get_or_insert_with(Vec::new)
-            .extend(capabilities);
+            .push(capability.into());
 
         container_req
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -80,10 +80,10 @@ pub trait ImageExt<I: Image> {
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
 
     /// Adds the capabilities to the container
-    fn with_cap_add(self, capabilities: Vec<String>) -> ContainerRequest<I>;
+    fn with_cap_add(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I>;
 
     /// Drops the capabilities from the container's capabilities
-    fn with_cap_drop(self, capabilities: Vec<String>) -> ContainerRequest<I>;
+    fn with_cap_drop(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I>;
 
     /// cgroup namespace mode for the container. Possible values are:
     /// - [`CgroupnsMode::Private`]: the container runs in its own private cgroup namespace
@@ -212,7 +212,7 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    fn with_cap_add(self, capabilities: Vec<String>) -> ContainerRequest<I> {
+    fn with_cap_add(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I> {
         let mut container_req = self.into();
         container_req
             .cap_add
@@ -222,7 +222,7 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         container_req
     }
 
-    fn with_cap_drop(self, capabilities: Vec<String>) -> ContainerRequest<I> {
+    fn with_cap_drop(self, capabilities: impl IntoIterator<Item = String>) -> ContainerRequest<I> {
         let mut container_req = self.into();
         container_req
             .cap_drop

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -213,19 +213,23 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     }
 
     fn with_cap_add(self, capabilities: Vec<String>) -> ContainerRequest<I> {
-        let container_req = self.into();
-        ContainerRequest {
-            cap_add: Some(capabilities),
-            ..container_req
-        }
+        let mut container_req = self.into();
+        container_req
+            .cap_add
+            .get_or_insert_with(Vec::new)
+            .extend(capabilities);
+
+        container_req
     }
 
     fn with_cap_drop(self, capabilities: Vec<String>) -> ContainerRequest<I> {
-        let container_req = self.into();
-        ContainerRequest {
-            cap_drop: Some(capabilities),
-            ..container_req
-        }
+        let mut container_req = self.into();
+        container_req
+            .cap_drop
+            .get_or_insert_with(Vec::new)
+            .extend(capabilities);
+
+        container_req
     }
 
     fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> ContainerRequest<I> {

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -571,7 +571,7 @@ mod tests {
         let image = GenericImage::new("hello-world", "latest");
         let expected_capability = "NET_ADMIN";
         let container = image
-            .with_cap_add(vec![expected_capability.to_string()])
+            .with_cap_add(expected_capability.to_string())
             .start()
             .await?;
 
@@ -598,7 +598,7 @@ mod tests {
         let image = GenericImage::new("hello-world", "latest");
         let expected_capability = "AUDIT_WRITE";
         let container = image
-            .with_cap_drop(vec![expected_capability.to_string()])
+            .with_cap_drop(expected_capability.to_string())
             .start()
             .await?;
 

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -69,6 +69,8 @@ where
                 extra_hosts: Some(extra_hosts),
                 cgroupns_mode: container_req.cgroupns_mode().map(|mode| mode.into()),
                 userns_mode: container_req.userns_mode().map(|v| v.to_string()),
+                cap_add: container_req.cap_add().cloned(),
+                cap_drop: container_req.cap_drop().cloned(),
                 ..Default::default()
             }),
             working_dir: container_req.working_dir().map(|dir| dir.to_string()),
@@ -561,6 +563,60 @@ mod tests {
             .privileged
             .expect("Privileged");
         assert!(privileged, "privileged must be `true`");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn async_run_command_should_have_cap_add() -> anyhow::Result<()> {
+        let image = GenericImage::new("hello-world", "latest");
+        let expected_capability = "NET_ADMIN";
+        let container = image
+            .with_cap_add(vec![expected_capability.to_string()])
+            .start()
+            .await?;
+
+        let client = Client::lazy_client().await?;
+        let container_details = client.inspect(container.id()).await?;
+
+        let capabilities = container_details
+            .host_config
+            .expect("HostConfig")
+            .cap_add
+            .expect("CapAdd");
+
+        assert_eq!(
+            expected_capability,
+            capabilities.get(0).expect("No capabilities added"),
+            "cap_add must contain {expected_capability}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn async_run_command_should_have_cap_drop() -> anyhow::Result<()> {
+        let image = GenericImage::new("hello-world", "latest");
+        let expected_capability = "AUDIT_WRITE";
+        let container = image
+            .with_cap_drop(vec![expected_capability.to_string()])
+            .start()
+            .await?;
+
+        let client = Client::lazy_client().await?;
+        let container_details = client.inspect(container.id()).await?;
+
+        let capabilities = container_details
+            .host_config
+            .expect("HostConfig")
+            .cap_drop
+            .expect("CapAdd");
+
+        assert_eq!(
+            expected_capability,
+            capabilities.get(0).expect("No capabilities dropped"),
+            "cap_drop must contain {expected_capability}"
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
Hi :wave: This PR implements #578 and adds tests for the added functionality.
Specifically, this PR adds support for adding and dropping capabilities for containers.
Have a nice weekend!