### PR TITLE
refactor: replace dirs crate with etcetera

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -21,9 +21,9 @@ bollard = { version = "0.17.0", features = ["ssl"] }
 bollard-stubs = "=1.45.0-rc.26.0.1"
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
-dirs = "5.0.1"
 docker_credential = "1.3.1"
 either = "1.12.0"
+etcetera = "0.8.0"
 futures = "0.3"
 log = "0.4"
 memchr = "2.7.2"

--- a/testcontainers/src/core/env/config.rs
+++ b/testcontainers/src/core/env/config.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use dirs::{home_dir, runtime_dir};
+use etcetera::BaseStrategy;
 
 use crate::core::env::GetEnvValue;
 
@@ -62,7 +62,7 @@ struct TestcontainersProperties {
 #[cfg(feature = "properties-config")]
 impl TestcontainersProperties {
     async fn load() -> Option<Result<Self, ConfigurationError>> {
-        let home_dir = dirs::home_dir()?;
+        let home_dir = home_dir()?;
         let properties_path = home_dir.join(TESTCONTAINERS_PROPERTIES);
 
         let content = tokio::fs::read(properties_path).await.ok()?;
@@ -195,6 +195,14 @@ fn validate_path(path: String) -> Option<String> {
     }
 }
 
+fn home_dir() -> Option<PathBuf> {
+    etcetera::home_dir().ok()
+}
+
+fn runtime_dir() -> Option<PathBuf> {
+    etcetera::choose_base_strategy().ok()?.runtime_dir()
+}
+
 /// Read the Docker authentication configuration in the following order:
 ///
 /// 1. `DOCKER_AUTH_CONFIG` environment variable, unmarshalling the string value from its JSON representation and using it as the Docker config.
@@ -210,7 +218,7 @@ where
             let mut path_to_config = match E::get_env_value("DOCKER_CONFIG").map(PathBuf::from) {
                 Some(path_to_config) => path_to_config,
                 None => {
-                    let home_dir = dirs::home_dir()?;
+                    let home_dir = home_dir()?;
                     home_dir.join(DEFAULT_DOCKER_CONFIG_PATH)
                 }
             };


### PR DESCRIPTION
I recently learned that [`dirs`](https://crates.io/crates/dirs) depends on [`option-ext`](https://crates.io/crates/option-ext) via [`dir-sys`](https://crates.io/crates/dirs-sys) (as of `dir-sys` 0.4.1 that came in as part of `dirs` 5.0.1), which is MPL 2.0 licensed.

[It does not appear that the author is interested reconsidering their stance on licensing](https://github.com/dirs-dev/dirs-sys-rs/issues/21#issuecomment-1531528155), which unfortunately creates some complications for projects under the CNCF umbrella (as well as many corporate projects), and so I thought I would propose switching `dirs` out for `etcetera` since it is MIT or Apache 2.0 licensed.

As you can see from the linked thread, this is a fairly common limitation for adoption, so in the interest of enabling further adoption, I believe it would be in the best interest for `testcontainers-rs` to reconsider this dependency, especially considering how trivial it is to replace 🙂 

FWIW, I have done testing on my end to ensure that the changes I'm proposing produce similar results under Mac OS and Linux, but since I don't have direct access to Windows I can't say with 100% certainty that they do though from reading through the code across both libraries, I feel fairly confident that they should.