### PR TITLE
feat: expose configured bollard client

### DIFF
--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -9,7 +9,7 @@ pub use self::{
 mod image;
 
 pub(crate) mod async_drop;
-pub(crate) mod client;
+pub mod client;
 pub(crate) mod containers;
 pub(crate) mod copy;
 pub(crate) mod env;

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -36,6 +36,8 @@ mod bollard_client;
 mod exec;
 mod factory;
 
+pub use factory::docker_client_instance;
+
 static IN_A_CONTAINER: OnceCell<bool> = OnceCell::const_new();
 
 // See https://github.com/docker/docker/blob/a9fa38b1edf30b23cae3eade0be48b3d4b1de14b/daemon/initlayer/setup_unix.go#L25

--- a/testcontainers/src/core/client/factory.rs
+++ b/testcontainers/src/core/client/factory.rs
@@ -11,7 +11,6 @@ static DOCKER_CLIENT: OnceLock<Mutex<Weak<Client>>> = OnceLock::new();
 
 impl Client {
     /// Returns a client instance, reusing already created or initializing a new one.
-    // We don't expose this function to the public API for now. We can do it later if needed.
     pub(crate) async fn lazy_client() -> Result<Arc<Client>, ClientError> {
         let mut guard = DOCKER_CLIENT
             .get_or_init(|| Mutex::new(Weak::new()))
@@ -28,4 +27,15 @@ impl Client {
             Ok(client)
         }
     }
+}
+
+/// Returns a configured Docker client instance.
+///
+/// This function provides access to the underlying Docker client ([`bollard`]).
+/// While this method is publicly exposed, it is not intended for frequent use.
+/// It can be useful in scenarios where you need to interact with the Docker API directly using an already configured client.
+///
+/// This method returns a lazily-created client, reusing an existing one if available.
+pub async fn docker_client_instance() -> Result<bollard::Docker, ClientError> {
+    Client::lazy_client().await.map(|c| c.bollard.clone())
 }


### PR DESCRIPTION
This PR allows to access bollard client directly if needed. It's aligned with implementations of testcontainers for other languages. Definitely may be useful in some specific cases and allows to bypass some limitations. We could wrap and expose only particular API methods and hide the details from the user, but it's too much work and this way seems more pragmatic.

Later we also can re-export bollard and bollard_stubs on demand (in order to simplify version managment of deps for users)