### PR TITLE
test: deflake the test `start_containers_in_parallel`

### DIFF
--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -83,8 +83,7 @@ async fn start_containers_in_parallel() -> anyhow::Result<()> {
 
     // Make sure the image is already pulled, since otherwise pulling it may cause the deadline
     // below to be exceeded.
-    let run_pull = image.clone().start().await?;
-    drop(run_pull);
+    let _ = image.clone().pull_image().await?;
 
     let run_1 = image.clone().start();
     let run_2 = image.clone().start();

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -81,6 +81,11 @@ async fn start_containers_in_parallel() -> anyhow::Result<()> {
 
     let image = GenericImage::new("hello-world", "latest").with_wait_for(WaitFor::seconds(2));
 
+    // Make sure the image is already pulled, since otherwise pulling it may cause the deadline
+    // below to be exceeded.
+    let run_pull = image.clone().start().await?;
+    drop(run_pull);
+
     let run_1 = image.clone().start();
     let run_2 = image.clone().start();
     let run_3 = image.clone().start();


### PR DESCRIPTION
The test often fails, especially in GitHub actions. The test attempts to start four containers on the same image and sets a deadline to prove that they start in parallel rather than in serial. The failure messages indicate tha this deadline is exceeded.

This appears to happen when the image of the container being started has to be pulled. Sometimes the pull operation takes so much time that the deadline is exceeded just due to that.

This adds some lines to the test which start and then stop a container on the same image before attempting to start the containers in parallel. Doing so ensures that the image has already been pulled when the real test starts running. Then the containers should start in close to the intended two seconds, so the test should pass more reliably.

Manual experiments appear to support this thesis: Before this change, running

```sh
$ docker image rm hello-world
$ cargo test --test async_runner --no-default-features --features blocking start_containers_in_parallel
```

would consistently fail due to an exceeded deadline. With this change, the test consistently passes.

Note: This and other tests still depend on access to the Docker Hub and fail when they cannot pull the images they need. This can also lead to flakiness.