### PR TITLE
docs(quickstart): make the first example runnable

### DIFF
--- a/docs/quickstart/testcontainers.md
+++ b/docs/quickstart/testcontainers.md
@@ -21,15 +21,20 @@ cargo add testcontainers --features blocking
 ## 3. Spin up Redis
 
 ```rust
-use testcontainers::{core::{IntoContainerPort, WaitFor}, runners::AsyncRunner, GenericImage};
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    GenericImage,
+};
 
 #[tokio::test]
-async fn test_redis() -> Result<(), Box<dyn std::error::Error + 'static>> {
-    let container = GenericImage::new("redis", "7.2.4")
+async fn test_redis() {
+    let _container = GenericImage::new("redis", "7.2.4")
         .with_exposed_port(6379.tcp())
         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
-        .start()?
-        .await;
+        .start()
+        .await
+        .unwrap();
 }
 ```
 


### PR DESCRIPTION
This solves #749.