### PR TITLE
feat: reusable containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
----
 name: Continuous Integration
 
 on:
@@ -63,11 +62,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: |
-          cargo hack test \
-            --clean-per-run \
-            --feature-powerset \
-            --group-features experimental,reusable-containers
+        run: cargo hack test --each-feature --clean-per-run
 
   fmt:
     name: Rustfmt check
@@ -124,5 +119,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # For PRs, we use squash-strategy, so commits names not so matter
+          # For PRs we gonna use squash-strategy, so commits names not so matter
           ignoreCommits: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: Continuous Integration
 
 on:
@@ -62,7 +63,11 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --each-feature --clean-per-run
+        run: |
+          cargo hack test \
+            --clean-per-run \
+            --feature-powerset \
+            --group-features experimental,reusable-containers
 
   fmt:
     name: Rustfmt check
@@ -119,5 +124,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # For PRs we gonna use squash-strategy, so commits names not so matter
+          # For PRs, we use squash-strategy, so commits names not so matter
           ignoreCommits: "true"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
 tokio-tar = "0.3.1"
 tokio-util = { version = "0.7.10", features = ["io"] }
+ulid = { version = "1.1.3", optional = true }
 url = { version = "2", features = ["serde"] }
 
 [features]
@@ -49,7 +50,7 @@ experimental = []
 watchdog = ["signal-hook", "conquer-once"]
 http_wait = ["reqwest"]
 properties-config = ["serde-java-properties"]
-reusable-containers = []
+reusable-containers = ["dep:ulid"]
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -45,9 +45,11 @@ url = { version = "2", features = ["serde"] }
 [features]
 default = []
 blocking = []
+experimental = []
 watchdog = ["signal-hook", "conquer-once"]
 http_wait = ["reqwest"]
 properties-config = ["serde-java-properties"]
+reusable-containers = []
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -46,7 +46,6 @@ url = { version = "2", features = ["serde"] }
 [features]
 default = []
 blocking = []
-experimental = []
 watchdog = ["signal-hook", "conquer-once"]
 http_wait = ["reqwest"]
 properties-config = ["serde-java-properties"]

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -35,7 +35,7 @@ serde-java-properties = { version = "0.2.0", optional = true }
 serde_json = "1"
 serde_with = "3.7.0"
 signal-hook = { version = "0.3", optional = true }
-thiserror = "1.0.60"
+thiserror = "2.0.3"
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
 tokio-tar = "0.3.1"

--- a/testcontainers/src/core.rs
+++ b/testcontainers/src/core.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "reusable-containers")]
+pub use self::image::ReuseDirective;
 pub use self::{
     containers::*,
     image::{ContainerState, ExecCommand, Image, ImageExt},

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     io::{self},
     str::FromStr,
 };
@@ -6,8 +7,8 @@ use std::{
 use bollard::{
     auth::DockerCredentials,
     container::{
-        Config, CreateContainerOptions, LogOutput, LogsOptions, RemoveContainerOptions,
-        UploadToContainerOptions,
+        Config, CreateContainerOptions, ListContainersOptions, LogOutput, LogsOptions,
+        RemoveContainerOptions, UploadToContainerOptions,
     },
     errors::Error as BollardError,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
@@ -66,6 +67,8 @@ pub enum ClientError {
     #[error("failed to map ports: {0}")]
     PortMapping(#[from] PortMappingError),
 
+    #[error("failed to list containers: {0}")]
+    ListContainers(BollardError),
     #[error("failed to create a container: {0}")]
     CreateContainer(BollardError),
     #[error("failed to remove a container: {0}")]
@@ -416,6 +419,48 @@ impl Client {
         };
 
         Some(bollard_credentials)
+    }
+
+    /// Get the `id` of the first running container whose `name`, `network`,
+    /// and `labels` match the supplied values
+    #[cfg_attr(not(feature = "reusable-containers"), allow(dead_code))]
+    pub(crate) async fn get_running_container_id(
+        &self,
+        name: Option<&str>,
+        network: Option<&str>,
+        labels: &HashMap<String, String>,
+    ) -> Result<Option<String>, ClientError> {
+        let filters = [
+            Some(("status".to_string(), vec!["running".to_string()])),
+            name.map(|value| ("name".to_string(), vec![value.to_string()])),
+            network.map(|value| ("network".to_string(), vec![value.to_string()])),
+            Some((
+                "label".to_string(),
+                labels
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .collect(),
+            )),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<HashMap<_, _>>();
+
+        let options = Some(ListContainersOptions {
+            filters,
+            all: false,
+            size: false,
+            limit: Some(1),
+        });
+
+        Ok(self
+            .bollard
+            .list_containers(options)
+            .await
+            .map_err(ClientError::ListContainers)?
+            .into_iter()
+            .next()
+            .and_then(|container| container.id))
     }
 }
 

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -356,27 +356,18 @@ where
     I: fmt::Debug + Image,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let with_feature_flag_fields = {
-            #[cfg(not(feature = "reusable-containers"))]
-            {
-                std::fmt::DebugStruct::finish
-            }
-            #[cfg(feature = "reusable-containers")]
-            {
-                |repr: &mut std::fmt::DebugStruct<'_, '_>| -> std::fmt::Result {
-                    repr.field("reuse", &self.reuse).finish()
-                }
-            }
-        };
+        let mut repr = f.debug_struct("ContainerAsync");
 
-        with_feature_flag_fields(
-            f.debug_struct("ContainerAsync")
-                .field("id", &self.id)
-                .field("image", &self.image)
-                .field("command", &self.docker_client.config.command())
-                .field("network", &self.network)
-                .field("dropped", &self.dropped),
-        )
+        repr.field("id", &self.id)
+            .field("image", &self.image)
+            .field("command", &self.docker_client.config.command())
+            .field("network", &self.network)
+            .field("dropped", &self.dropped);
+
+        #[cfg(feature = "reusable-containers")]
+        repr.field("reuse", &self.reuse);
+
+        repr.finish()
     }
 }
 

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -532,10 +532,10 @@ mod tests {
                     .iter()
                     .map(|(key, value)| format!("{key}={value}"))
                     .chain([
-                        "managed-by=testcontainers".to_string(),
-                        "com.testcontainers.reuse=true".to_string(),
+                        "org.testcontainers.reuse=true".to_string(),
+                        "org.testcontainers.managed-by=testcontainers".to_string(),
                         format!(
-                            "com.testcontainers.session-id={}",
+                            "org.testcontainers.session-id={}",
                             crate::runners::async_runner::session_id()
                         ),
                     ])
@@ -594,9 +594,9 @@ mod tests {
                     .iter()
                     .map(|(key, value)| format!("{key}={value}"))
                     .chain([
-                        "managed-by=testcontainers".to_string(),
+                        "org.testcontainers.managed-by=testcontainers".to_string(),
                         format!(
-                            "com.testcontainers.session-id={}",
+                            "org.testcontainers.session-id={}",
                             crate::runners::async_runner::session_id()
                         ),
                     ])

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -558,8 +558,9 @@ mod tests {
     #[cfg(feature = "reusable-containers")]
     #[tokio::test]
     async fn async_reused_containers_are_not_confused() -> anyhow::Result<()> {
-        use crate::ImageExt;
         use std::collections::HashSet;
+
+        use crate::ImageExt;
 
         let labels = [
             ("foo", "bar"),

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -577,7 +577,7 @@ mod tests {
     async fn async_reused_containers_are_not_confused() -> anyhow::Result<()> {
         use std::collections::HashSet;
 
-        use crate::ImageExt;
+        use crate::{ImageExt, ReuseDirective};
 
         let labels = [
             ("foo", "bar"),
@@ -586,13 +586,13 @@ mod tests {
         ];
 
         let initial_image = GenericImage::new("testcontainers/helloworld", "1.1.0")
-            .with_reuse(true)
+            .with_reuse(ReuseDirective::Always)
             .with_labels(labels);
 
         let similar_image = initial_image
             .image
             .clone()
-            .with_reuse(false)
+            .with_reuse(ReuseDirective::Never)
             .with_labels(&initial_image.labels);
 
         let initial_container = initial_image.start().await?;
@@ -642,7 +642,7 @@ mod tests {
         let client = crate::core::client::docker_client_instance().await?;
 
         let image = GenericImage::new("testcontainers/helloworld", "1.1.0")
-            .with_reuse(true)
+            .with_reuse(ReuseDirective::Always)
             .with_labels([
                 ("foo", "bar"),
                 ("baz", "qux"),

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -244,41 +244,32 @@ impl PortMapping {
 
 impl<I: Image + Debug> Debug for ContainerRequest<I> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let with_feature_flag_fields = {
-            #[cfg(not(feature = "reusable-containers"))]
-            {
-                std::fmt::DebugStruct::finish
-            }
-            #[cfg(feature = "reusable-containers")]
-            {
-                |repr: &mut std::fmt::DebugStruct<'_, '_>| -> std::fmt::Result {
-                    repr.field("reusable", &self.reuse).finish()
-                }
-            }
-        };
+        let mut repr = f.debug_struct("ContainerRequest");
 
-        with_feature_flag_fields(
-            f.debug_struct("ContainerRequest")
-                .field("image", &self.image)
-                .field("overridden_cmd", &self.overridden_cmd)
-                .field("image_name", &self.image_name)
-                .field("image_tag", &self.image_tag)
-                .field("container_name", &self.container_name)
-                .field("network", &self.network)
-                .field("labels", &self.labels)
-                .field("env_vars", &self.env_vars)
-                .field("hosts", &self.hosts)
-                .field("mounts", &self.mounts)
-                .field("ports", &self.ports)
-                .field("ulimits", &self.ulimits)
-                .field("privileged", &self.privileged)
-                .field("cap_add", &self.cap_add)
-                .field("cap_drop", &self.cap_drop)
-                .field("shm_size", &self.shm_size)
-                .field("cgroupns_mode", &self.cgroupns_mode)
-                .field("userns_mode", &self.userns_mode)
-                .field("startup_timeout", &self.startup_timeout)
-                .field("working_dir", &self.working_dir),
-        )
+        repr.field("image", &self.image)
+            .field("overridden_cmd", &self.overridden_cmd)
+            .field("image_name", &self.image_name)
+            .field("image_tag", &self.image_tag)
+            .field("container_name", &self.container_name)
+            .field("network", &self.network)
+            .field("labels", &self.labels)
+            .field("env_vars", &self.env_vars)
+            .field("hosts", &self.hosts)
+            .field("mounts", &self.mounts)
+            .field("ports", &self.ports)
+            .field("ulimits", &self.ulimits)
+            .field("privileged", &self.privileged)
+            .field("cap_add", &self.cap_add)
+            .field("cap_drop", &self.cap_drop)
+            .field("shm_size", &self.shm_size)
+            .field("cgroupns_mode", &self.cgroupns_mode)
+            .field("userns_mode", &self.userns_mode)
+            .field("startup_timeout", &self.startup_timeout)
+            .field("working_dir", &self.working_dir);
+
+        #[cfg(feature = "reusable-containers")]
+        repr.field("reusable", &self.reuse);
+
+        repr.finish()
     }
 }

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -42,7 +42,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) working_dir: Option<String>,
     pub(crate) log_consumers: Vec<Box<dyn LogConsumer + 'static>>,
     #[cfg(feature = "reusable-containers")]
-    pub(crate) reuse: bool,
+    pub(crate) reuse: crate::ReuseDirective,
 }
 
 /// Represents a port mapping between a host's external port and the internal port of a container.
@@ -189,7 +189,7 @@ impl<I: Image> ContainerRequest<I> {
 
     /// Indicates that the container will not be stopped when it is dropped
     #[cfg(feature = "reusable-containers")]
-    pub fn reuse(&self) -> bool {
+    pub fn reuse(&self) -> crate::ReuseDirective {
         self.reuse
     }
 }
@@ -220,7 +220,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             working_dir: None,
             log_consumers: vec![],
             #[cfg(feature = "reusable-containers")]
-            reuse: false,
+            reuse: false.into(),
         }
     }
 }

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -32,6 +32,8 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) ports: Option<Vec<PortMapping>>,
     pub(crate) ulimits: Option<Vec<ResourcesUlimits>>,
     pub(crate) privileged: bool,
+    pub(crate) cap_add: Option<Vec<String>>,
+    pub(crate) cap_drop: Option<Vec<String>>,
     pub(crate) shm_size: Option<u64>,
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
     pub(crate) userns_mode: Option<String>,
@@ -111,6 +113,14 @@ impl<I: Image> ContainerRequest<I> {
         self.privileged
     }
 
+    pub fn cap_add(&self) -> Option<&Vec<String>> {
+        self.cap_add.as_ref()
+    }
+
+    pub fn cap_drop(&self) -> Option<&Vec<String>> {
+        self.cap_drop.as_ref()
+    }
+
     pub fn cgroupns_mode(&self) -> Option<CgroupnsMode> {
         self.cgroupns_mode
     }
@@ -187,6 +197,8 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             ports: None,
             ulimits: None,
             privileged: false,
+            cap_add: None,
+            cap_drop: None,
             shm_size: None,
             cgroupns_mode: None,
             userns_mode: None,
@@ -229,6 +241,8 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("ports", &self.ports)
             .field("ulimits", &self.ulimits)
             .field("privileged", &self.privileged)
+            .field("cap_add", &self.cap_add)
+            .field("cap_drop", &self.cap_drop)
             .field("shm_size", &self.shm_size)
             .field("cgroupns_mode", &self.cgroupns_mode)
             .field("userns_mode", &self.userns_mode)

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -25,6 +25,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) image_tag: Option<String>,
     pub(crate) container_name: Option<String>,
     pub(crate) network: Option<String>,
+    pub(crate) labels: BTreeMap<String, String>,
     pub(crate) env_vars: BTreeMap<String, String>,
     pub(crate) hosts: BTreeMap<String, Host>,
     pub(crate) mounts: Vec<Mount>,
@@ -72,6 +73,10 @@ impl<I: Image> ContainerRequest<I> {
 
     pub fn network(&self) -> &Option<String> {
         &self.network
+    }
+
+    pub fn labels(&self) -> &BTreeMap<String, String> {
+        &self.labels
     }
 
     pub fn container_name(&self) -> &Option<String> {
@@ -190,6 +195,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             image_tag: None,
             container_name: None,
             network: None,
+            labels: BTreeMap::default(),
             env_vars: BTreeMap::default(),
             hosts: BTreeMap::default(),
             mounts: Vec::new(),
@@ -235,6 +241,7 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("image_tag", &self.image_tag)
             .field("container_name", &self.container_name)
             .field("network", &self.network)
+            .field("labels", &self.labels)
             .field("env_vars", &self.env_vars)
             .field("hosts", &self.hosts)
             .field("mounts", &self.mounts)

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -220,7 +220,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             working_dir: None,
             log_consumers: vec![],
             #[cfg(feature = "reusable-containers")]
-            reuse: false.into(),
+            reuse: crate::ReuseDirective::Never,
         }
     }
 }

--- a/testcontainers/src/core/image.rs
+++ b/testcontainers/src/core/image.rs
@@ -2,6 +2,8 @@ use std::{borrow::Cow, fmt::Debug};
 
 pub use exec::ExecCommand;
 pub use image_ext::ImageExt;
+#[cfg(feature = "reusable-containers")]
+pub use image_ext::ReuseDirective;
 
 use crate::{
     core::{

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -31,27 +31,6 @@ impl std::fmt::Display for ReuseDirective {
     }
 }
 
-#[cfg(feature = "reusable-containers")]
-impl From<bool> for ReuseDirective {
-    fn from(value: bool) -> Self {
-        match value {
-            true => Self::Always,
-            false => Self::Never,
-        }
-    }
-}
-
-#[cfg(feature = "reusable-containers")]
-impl From<&str> for ReuseDirective {
-    fn from(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "true" | "always" => Self::Always,
-            value if value.ends_with("session") => Self::CurrentSession,
-            _ => Self::Never,
-        }
-    }
-}
-
 /// Represents an extension for the [`Image`] trait.
 /// Allows to override image defaults and container configuration.
 pub trait ImageExt<I: Image> {
@@ -186,7 +165,7 @@ pub trait ImageExt<I: Image> {
     /// to change. Containers marked as `reuse` **_will not_** be stopped or cleaned up when their associated
     /// `Container` or `ContainerAsync` is dropped.
     #[cfg(feature = "reusable-containers")]
-    fn with_reuse(self, reuse: impl Into<ReuseDirective>) -> ContainerRequest<I>;
+    fn with_reuse(self, reuse: ReuseDirective) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -395,9 +374,9 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     }
 
     #[cfg(feature = "reusable-containers")]
-    fn with_reuse(self, reuse: impl Into<ReuseDirective>) -> ContainerRequest<I> {
+    fn with_reuse(self, reuse: ReuseDirective) -> ContainerRequest<I> {
         ContainerRequest {
-            reuse: reuse.into(),
+            reuse,
             ..self.into()
         }
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -90,6 +90,12 @@ pub trait ImageExt<I: Image> {
     /// Sets the container to run in privileged mode.
     fn with_privileged(self, privileged: bool) -> ContainerRequest<I>;
 
+    /// Adds the capabilities to the container
+    fn with_cap_add(self, capability: impl Into<String>) -> ContainerRequest<I>;
+
+    /// Drops the capabilities from the container's capabilities
+    fn with_cap_drop(self, capability: impl Into<String>) -> ContainerRequest<I>;
+
     /// cgroup namespace mode for the container. Possible values are:
     /// - [`CgroupnsMode::Private`]: the container runs in its own private cgroup namespace
     /// - [`CgroupnsMode::Host`]: use the host system's cgroup namespace
@@ -229,6 +235,26 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
             privileged,
             ..container_req
         }
+    }
+
+    fn with_cap_add(self, capability: impl Into<String>) -> ContainerRequest<I> {
+        let mut container_req = self.into();
+        container_req
+            .cap_add
+            .get_or_insert_with(Vec::new)
+            .push(capability.into());
+
+        container_req
+    }
+
+    fn with_cap_drop(self, capability: impl Into<String>) -> ContainerRequest<I> {
+        let mut container_req = self.into();
+        container_req
+            .cap_drop
+            .get_or_insert_with(Vec::new)
+            .push(capability.into());
+
+        container_req
     }
 
     fn with_cgroupns_mode(self, cgroupns_mode: CgroupnsMode) -> ContainerRequest<I> {

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -11,6 +11,47 @@ use crate::{
     ContainerRequest, Image,
 };
 
+#[cfg(feature = "reusable-containers")]
+#[derive(Eq, Copy, Clone, Debug, Default, PartialEq)]
+pub enum ReuseDirective {
+    #[default]
+    Never,
+    Always,
+    CurrentSession,
+}
+
+#[cfg(feature = "reusable-containers")]
+impl std::fmt::Display for ReuseDirective {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Never => "never",
+            Self::Always => "always",
+            Self::CurrentSession => "current-session",
+        })
+    }
+}
+
+#[cfg(feature = "reusable-containers")]
+impl From<bool> for ReuseDirective {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Self::Always,
+            false => Self::Never,
+        }
+    }
+}
+
+#[cfg(feature = "reusable-containers")]
+impl From<&str> for ReuseDirective {
+    fn from(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "true" | "always" => Self::Always,
+            value if value.ends_with("session") => Self::CurrentSession,
+            _ => Self::Never,
+        }
+    }
+}
+
 /// Represents an extension for the [`Image`] trait.
 /// Allows to override image defaults and container configuration.
 pub trait ImageExt<I: Image> {
@@ -145,7 +186,7 @@ pub trait ImageExt<I: Image> {
     /// to change. Containers marked as `reuse` **_will not_** be stopped or cleaned up when their associated
     /// `Container` or `ContainerAsync` is dropped.
     #[cfg(feature = "reusable-containers")]
-    fn with_reuse(self, reuse: bool) -> ContainerRequest<I>;
+    fn with_reuse(self, reuse: impl Into<ReuseDirective>) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -354,9 +395,9 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     }
 
     #[cfg(feature = "reusable-containers")]
-    fn with_reuse(self, reuse: bool) -> ContainerRequest<I> {
+    fn with_reuse(self, reuse: impl Into<ReuseDirective>) -> ContainerRequest<I> {
         ContainerRequest {
-            reuse,
+            reuse: reuse.into(),
             ..self.into()
         }
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -48,6 +48,18 @@ pub trait ImageExt<I: Image> {
     /// Sets the network the container will be connected to.
     fn with_network(self, network: impl Into<String>) -> ContainerRequest<I>;
 
+    /// Adds the specified labels to the container.
+    ///
+    /// **Note**: in addition to all keys in the `com.testcontainers.*` namespace, there
+    /// are certain labels that are used by `testcontainers` internally which will always
+    /// be unconditionally overwritten, and so should not be expected or relied upon to
+    /// be applied correctly if they are included in `labels`. Currently, they are:
+    /// - `managed-by`
+    fn with_labels(
+        self,
+        labels: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> ContainerRequest<I>;
+
     /// Adds an environment variable to the container.
     fn with_env_var(self, name: impl Into<String>, value: impl Into<String>)
         -> ContainerRequest<I>;
@@ -162,6 +174,21 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
             network: Some(network.into()),
             ..container_req
         }
+    }
+
+    fn with_labels(
+        self,
+        labels: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> ContainerRequest<I> {
+        let mut container_req = self.into();
+
+        container_req.labels.extend(
+            labels
+                .into_iter()
+                .map(|(key, value)| (key.into(), value.into())),
+        );
+
+        container_req
     }
 
     fn with_env_var(

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -131,6 +131,16 @@ pub trait ImageExt<I: Image> {
     ///
     /// Allows to follow the container logs for the whole lifecycle of the container, starting from the creation.
     fn with_log_consumer(self, log_consumer: impl LogConsumer + 'static) -> ContainerRequest<I>;
+
+    /// Flag the container as being exempt from the default `testcontainers` remove-on-drop lifecycle,
+    /// indicating that the container should be kept running, and that executions with the same configuration
+    /// reuse it instead of starting a "fresh" container instance.
+    ///
+    /// **NOTE:** Reusable Containers is an experimental feature, and its behavior is therefore subject
+    /// to change. Containers marked as `reuse` **_will not_** be stopped or cleaned up when their associated
+    /// `Container` or `ContainerAsync` is dropped.
+    #[cfg(feature = "reusable-containers")]
+    fn with_reuse(self, reuse: bool) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -328,5 +338,13 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         let mut container_req = self.into();
         container_req.log_consumers.push(Box::new(log_consumer));
         container_req
+    }
+
+    #[cfg(feature = "reusable-containers")]
+    fn with_reuse(self, reuse: bool) -> ContainerRequest<I> {
+        ContainerRequest {
+            reuse,
+            ..self.into()
+        }
     }
 }

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -78,6 +78,8 @@ pub mod core;
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub use crate::core::Container;
+#[cfg(feature = "reusable-containers")]
+pub use crate::core::ReuseDirective;
 pub use crate::core::{
     copy::{CopyDataSource, CopyToContainer, CopyToContainerError},
     error::TestcontainersError,

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -93,3 +93,8 @@ mod images;
 pub use images::generic::GenericImage;
 
 pub mod runners;
+
+#[cfg(all(feature = "reusable-containers", not(feature = "experimental")))]
+compile_error!(
+    "the `reusable-containers` feature cannot be enabled without also enabling `experimental`"
+);

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -93,8 +93,3 @@ mod images;
 pub use images::generic::GenericImage;
 
 pub mod runners;
-
-#[cfg(all(feature = "reusable-containers", not(feature = "experimental")))]
-compile_error!(
-    "the `reusable-containers` feature cannot be enabled without also enabling `experimental`"
-);

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -312,6 +312,9 @@ mod tests {
         let mut labels = HashMap::from([
             ("foo".to_string(), "bar".to_string()),
             ("baz".to_string(), "qux".to_string()),
+            // include a `managed-by` value to guard against future changes
+            // inadvertently allowing users to override keys we rely on to
+            // internally ensure sane and correct behavior
             ("managed-by".to_string(), "the-time-wizard".to_string()),
         ]);
 

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -105,6 +105,33 @@ where
                 ]),
         );
 
+        #[cfg(feature = "reusable-containers")]
+        {
+            if container_req.reuse() {
+                if let Some(container_id) = client
+                    .get_running_container_id(
+                        container_req.container_name().as_deref(),
+                        container_req.network().as_deref(),
+                        &labels,
+                    )
+                    .await?
+                {
+                    let network = if let Some(network) = container_req.network() {
+                        Network::new(network, client.clone()).await?
+                    } else {
+                        None
+                    };
+
+                    return Ok(ContainerAsync::construct(
+                        container_id,
+                        client,
+                        container_req,
+                        network,
+                    ));
+                }
+            }
+        }
+
         let mut config: Config<String> = Config {
             image: Some(container_req.descriptor()),
             labels: Some(labels),

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -548,7 +548,7 @@ mod tests {
         }
 
         // containers have been dropped, should clean up networks
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(1)).await;
         let client = Client::lazy_client().await?;
         assert!(!client.network_exists("awesome-net-2").await?);
         Ok(())

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -94,12 +94,12 @@ where
                     ),
                     #[cfg(feature = "reusable-containers")]
                     (
-                        "com.testcontainers.reuse".to_string(),
+                        "org.testcontainers.reuse".to_string(),
                         container_req.reuse().to_string(),
                     ),
                     #[cfg(feature = "reusable-containers")]
                     (
-                        "com.testcontainers.session-id".to_string(),
+                        "org.testcontainers.session-id".to_string(),
                         session_id().to_string(),
                     ),
                 ]),
@@ -385,9 +385,9 @@ mod tests {
 
         #[cfg(feature = "reusable-containers")]
         labels.extend([
-            ("com.testcontainers.reuse".to_string(), false.to_string()),
+            ("org.testcontainers.reuse".to_string(), false.to_string()),
             (
-                "com.testcontainers.session-id".to_string(),
+                "org.testcontainers.session-id".to_string(),
                 session_id().to_string(),
             ),
         ]);

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -644,7 +644,7 @@ mod tests {
 
         assert_eq!(
             expected_capability,
-            capabilities.get(0).expect("No capabilities added"),
+            capabilities.first().expect("No capabilities added"),
             "cap_add must contain {expected_capability}"
         );
 
@@ -671,7 +671,7 @@ mod tests {
 
         assert_eq!(
             expected_capability,
-            capabilities.get(0).expect("No capabilities dropped"),
+            capabilities.first().expect("No capabilities dropped"),
             "cap_drop must contain {expected_capability}"
         );
 


### PR DESCRIPTION
PR implements reusable containers inline with [the existing](https://java.testcontainers.org/features/reuse/) reusable containers feature(s) of `testcontainers` for other languages.


> [!IMPORTANT]
> This PR follows from (and is branched from) #756. PR 756 *must* be merged prior to merging this PR
 