### PR TITLE
build: bump MSRV to `1.81`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["docker", "testcontainers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/testcontainers/testcontainers-rs"
-rust-version = "1.75"
+rust-version = "1.81"
 
 [workspace.dependencies]
 testimages = { path = "testimages" }


### PR DESCRIPTION
Some underlying dependencies (e.g `home`) updated their MSRV within a compatible version update.

`home` is used by several important deps (e.g `bollard`), so it's already affected users of the crate

However, it's common practice to use newer rust version for testing (in CI and etc)