### PR TITLE
feat: add image hook to run commands before ready

### DIFF
--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -313,7 +313,7 @@ where
             let container =
                 ContainerAsync::new(container_id, client.clone(), container_req, network).await?;
 
-            let state = ContainerState::new(container.id(), container.ports().await?);
+            let state = ContainerState::from_container(&container).await?;
             for cmd in container.image().exec_after_start(state)? {
                 container.exec(cmd).await?;
             }


### PR DESCRIPTION
Hey there, i was implementing a module for Dex and needed something like [containerIsStarting in the Java implementation](https://github.com/testcontainers/testcontainers-java/blob/46fe67029112790b74fa694aa782a5e19277b09d/core/src/main/java/org/testcontainers/containers/GenericContainer.java#L707).
I wrote a test and confirmed it works with [my module implementation](https://github.com/yuri-becker/testcontainers-rs-modules-community/blob/419e3fddab318e7af90b5452a5979058085822b7/src/dex/mod.rs#L176) – see https://github.com/testcontainers/testcontainers-rs-modules-community/pull/286 for that PR.

Please let me know what i can improve to get this merged. I hope it is okay to implement this without an issue :)