### PR TITLE
feat: support waiting for commands exit regardless of exit code

### DIFF
--- a/docs/features/exec_commands.md
+++ b/docs/features/exec_commands.md
@@ -2,18 +2,27 @@
 # Command Execution in Containers
 
 Some test scenarios require running commands within a container.
-In order to achieve this, the `testcontainers` library provides the ability to execute commands in 3 different ways:
-- `exec` method of [ContainerAsync] (or [Container]) 
-Allows to run a command in an already running container.
-- [Image::exec_after_start](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html#method.exec_after_start)
-Only if you implement your own `Image`: Allows to define commands to be executed after the container is started and ready.
-- [Image::exec_before_ready](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html#method.exec_before_ready)
-Only if you implement your own `Image`: Allows to define commands to be executed executed after 
-the container has started, but before the `Image::ready_conditions` are awaited for.
+In order to achieve this, the `testcontainers` library provides the ability
+to execute commands in 3 different ways:
 
+- `exec` method of [ContainerAsync] (or [Container])
+
+Allows to run a command in an already running container.
+
+- [Image::exec_after_start](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html#method.exec_after_start)
+
+Only if you implement your own `Image`: Allows to define commands
+to be executed after the container is started and ready.
+
+- [Image::exec_before_ready](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html#method.exec_before_ready)
+
+Only if you implement your own `Image`: Allows to define commands
+to be executed executed after the container has started,
+but before the `Image::ready_conditions` are awaited for.
 
 Here we will focus on the first option, which is the most common one.
-The method expects an [ExecCommand] struct, and returns an [ExecResult] (or [SyncExecResult]) struct.
+The method expects an [ExecCommand] struct,
+and returns an [ExecResult](or [SyncExecResult]) struct.
 
 ## [ExecCommand]
 
@@ -21,7 +30,7 @@ The [ExecCommand] struct represents a command to be executed within a container.
 It includes the command itself and conditions to be checked
 on the command output and the container.
 
-### Usage
+### ExecCommand Usage
 
 To create a new [ExecCommand]:
 
@@ -35,15 +44,15 @@ let command = ExecCommand::new(vec!["echo", "Hello, World!"])
 
 The [CmdWaitFor] enum defines conditions to be checked on the command's output.
 
-
 ## [ExecResult] / [SyncExecResult]
 
-For async version, the [ExecResult] struct represents the result of an executed command in a container.
+For async version, the [ExecResult] struct represents the result
+of an executed command in a container.
 For non-async (`blocking` feature), the [SyncExecResult] struct is used instead.
 
 The structs represents the result of an executed command in a container.
 
-### Usage
+### ExecResult Usage
 
 To execute a command and handle the result:
 

--- a/docs/features/exec_commands.md
+++ b/docs/features/exec_commands.md
@@ -1,0 +1,62 @@
+
+# Command Execution in Containers
+
+Some test scenarios require running commands within a container.
+In order to achieve this, the `testcontainers` library provides the ability to execute commands in 3 different ways:
+- `exec` method of [ContainerAsync] (or [Container]) 
+Allows to run a command in an already running container.
+- [Image::exec_after_start](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html#method.exec_after_start)
+Only if you implement your own `Image`: Allows to define commands to be executed after the container is started and ready.
+- [Image::exec_before_ready](https://docs.rs/testcontainers/latest/testcontainers/core/trait.Image.html#method.exec_before_ready)
+Only if you implement your own `Image`: Allows to define commands to be executed executed after 
+the container has started, but before the `Image::ready_conditions` are awaited for.
+
+
+Here we will focus on the first option, which is the most common one.
+The method expects an [ExecCommand] struct, and returns an [ExecResult] (or [SyncExecResult]) struct.
+
+## [ExecCommand]
+
+The [ExecCommand] struct represents a command to be executed within a container.
+It includes the command itself and conditions to be checked
+on the command output and the container.
+
+### Usage
+
+To create a new [ExecCommand]:
+
+```rust
+let command = ExecCommand::new(vec!["echo", "Hello, World!"])
+    .with_container_ready_conditions(vec![/* conditions */])
+    .with_cmd_ready_condition(CmdWaitFor::message_on_stdout("Hello, World!"));
+```
+
+## [CmdWaitFor]
+
+The [CmdWaitFor] enum defines conditions to be checked on the command's output.
+
+
+## [ExecResult] / [SyncExecResult]
+
+For async version, the [ExecResult] struct represents the result of an executed command in a container.
+For non-async (`blocking` feature), the [SyncExecResult] struct is used instead.
+
+The structs represents the result of an executed command in a container.
+
+### Usage
+
+To execute a command and handle the result:
+
+```rust
+let result = container.exec(command).await?;
+let exit_code = result.exit_code().await?;
+let stdout = result.stdout_to_vec().await?;
+let stderr = result.stderr_to_vec().await?;
+```
+
+[Container]: https://docs.rs/testcontainers/latest/testcontainers/core/struct.Container.html
+[ContainerAsync]: https://docs.rs/testcontainers/latest/testcontainers/core/struct.ContainerAsync.html
+[ExecCommand]: https://docs.rs/testcontainers/latest/testcontainers/core/struct.ExecCommand.html
+[CmdWaitFor]: https://docs.rs/testcontainers/latest/testcontainers/core/enum.CmdWaitFor.html
+[ExecResult]: https://docs.rs/testcontainers/latest/testcontainers/core/struct.ExecResult.html
+[SyncExecResult]: https://docs.rs/testcontainers/latest/testcontainers/core/struct.SyncExecResult.html

--- a/docs/system_requirements/docker.md
+++ b/docs/system_requirements/docker.md
@@ -7,5 +7,7 @@ These Docker environments are automatically detected and used by Testcontainers 
 It is possible to configure Testcontainers to work for other Docker setups, such as a remote Docker host or Docker alternatives. 
 However, these are not actively tested in the main development workflow, so not all Testcontainers features might be available and additional manual configuration might be necessary.
 
+See [custom configuration](../features/configuration.md) for more information on how to configure Testcontainers for your specific Docker setup.
+
 If you have further questions about configuration details for your setup or whether it supports running Testcontainers-based tests, 
 please contact the Testcontainers team and other users from the Testcontainers community on [Slack](https://slack.testcontainers.org/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Features:
       - features/configuration.md
       - features/wait_strategies.md
+      - features/exec_commands.md
   - System Requirements:
       - system_requirements/docker.md
   - Contributing:

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -239,17 +239,16 @@ where
                     .await
                     .map_err(ExecError::from)?;
             }
-            CmdWaitFor::ExitCode { code } => {
+            CmdWaitFor::Exit { code } => {
                 let exec_id = exec.id().to_string();
                 loop {
                     let inspect = self.docker_client.inspect_exec(&exec_id).await?;
 
                     if let Some(actual) = inspect.exit_code {
-                        if actual != code {
-                            Err(ExecError::ExitCodeMismatch {
-                                expected: code,
-                                actual,
-                            })?;
+                        if let Some(expected) = code {
+                            if actual != expected {
+                                Err(ExecError::ExitCodeMismatch { expected, actual })?;
+                            }
                         }
                         break;
                     } else {

--- a/testcontainers/src/core/wait/cmd_wait.rs
+++ b/testcontainers/src/core/wait/cmd_wait.rs
@@ -12,36 +12,47 @@ pub enum CmdWaitFor {
     StdErrMessage { message: Bytes },
     /// Wait for a certain amount of time.
     Duration { length: Duration },
-    /// Wait for the command's exit code to be equal to the provided one.
-    ExitCode { code: i64 },
+    /// Wait for the command to exit and optionally check the exit code.
+    Exit { code: Option<i64> },
 }
 
 impl CmdWaitFor {
+    /// Wait for a message on the stdout stream of the command's output.
     pub fn message_on_stdout(message: impl AsRef<[u8]>) -> Self {
         Self::StdOutMessage {
             message: Bytes::from(message.as_ref().to_vec()),
         }
     }
 
+    /// Wait for a message on the stderr stream of the command's output.
     pub fn message_on_stderr(message: impl AsRef<[u8]>) -> Self {
         Self::StdErrMessage {
             message: Bytes::from(message.as_ref().to_vec()),
         }
     }
 
+    /// Wait for the command to exit (regardless of the exit code).
+    pub fn exit() -> Self {
+        Self::Exit { code: None }
+    }
+
+    /// Wait for the command's exit code to be equal to the provided one.
     pub fn exit_code(code: i64) -> Self {
-        Self::ExitCode { code }
+        Self::Exit { code: Some(code) }
     }
 
-    pub fn seconds(length: u64) -> Self {
-        Self::Duration {
-            length: Duration::from_secs(length),
-        }
+    /// Wait for a certain amount of time.
+    pub fn duration(duration: Duration) -> Self {
+        Self::Duration { length: duration }
     }
 
-    pub fn millis(length: u64) -> Self {
-        Self::Duration {
-            length: Duration::from_millis(length),
-        }
+    /// Wait for a certain amount of time (in seconds).
+    pub fn seconds(secs: u64) -> Self {
+        Self::duration(Duration::from_secs(secs))
+    }
+
+    /// Wait for a certain amount of time (in millis)
+    pub fn millis(millis: u64) -> Self {
+        Self::duration(Duration::from_millis(millis))
     }
 }


### PR DESCRIPTION
It was possible via explicit error handling in the client code, but it's a nice shortcut

Closes https://github.com/testcontainers/testcontainers-rs/issues/744