### PR TITLE
feat: add option to stop containers with a timeout

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -162,9 +162,16 @@ impl Client {
             .map_err(ClientError::RemoveContainer)
     }
 
-    pub(crate) async fn stop(&self, id: &str) -> Result<(), ClientError> {
+    pub(crate) async fn stop(
+        &self,
+        id: &str,
+        timeout_seconds: Option<i64>,
+    ) -> Result<(), ClientError> {
         self.bollard
-            .stop_container(id, None)
+            .stop_container(
+                id,
+                timeout_seconds.map(|t| bollard::container::StopContainerOptions { t }),
+            )
             .await
             .map_err(ClientError::StopContainer)
     }

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -504,10 +504,10 @@ where
                     message,
                 } => io::Error::new(
                     io::ErrorKind::UnexpectedEof,
-                    format!("Docker container has been dropped: {}", message),
+                    format!("Docker container has been dropped: {message}"),
                 ),
                 bollard::errors::Error::IOError { err } => err,
-                err => io::Error::new(io::ErrorKind::Other, err),
+                err => io::Error::other(err),
             })
             .boxed();
         LogStream::new(stream)

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -183,7 +183,7 @@ where
         let network_settings = self.docker_client.inspect_network(&network_mode).await?;
 
         network_settings.driver.ok_or_else(|| {
-            TestcontainersError::other(format!("network {} is not in bridge mode", network_mode))
+            TestcontainersError::other(format!("network {network_mode} is not in bridge mode"))
         })?;
 
         let container_network_settings = container_settings

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -127,9 +127,19 @@ where
         })
     }
 
-    /// Stops the container (not the same with `pause`).
+    /// Stops the container (not the same with `pause`) using the default 10 second timeout.
     pub fn stop(&self) -> Result<()> {
         self.rt().block_on(self.async_impl().stop())
+    }
+
+    /// Stops the container with timeout before issuing SIGKILL (not the same with `pause`).
+    ///
+    /// Set Some(-1) to wait indefinitely, None to use system configured default and Some(0)
+    /// to forcibly stop the container immediately - otherwise the runtime will issue SIGINT
+    /// and then wait timeout_seconds seconds for the process to stop before issuing SIGKILL.
+    pub fn stop_with_timeout(&self, timeout_seconds: Option<i64>) -> Result<()> {
+        self.rt()
+            .block_on(self.async_impl().stop_with_timeout(timeout_seconds))
     }
 
     /// Starts the container.

--- a/testcontainers/src/core/logs/consumer/logging_consumer.rs
+++ b/testcontainers/src/core/logs/consumer/logging_consumer.rs
@@ -47,7 +47,7 @@ impl LoggingConsumer {
         let message = message.trim_end_matches(['\n', '\r']);
 
         if let Some(prefix) = &self.prefix {
-            Cow::Owned(format!("{} {}", prefix, message))
+            Cow::Owned(format!("{prefix} {message}"))
         } else {
             Cow::Borrowed(message)
         }

--- a/testcontainers/src/core/logs/stream.rs
+++ b/testcontainers/src/core/logs/stream.rs
@@ -79,12 +79,8 @@ impl LogStream {
                     }
                     Err(err) => {
                         let err = Arc::new(err);
-                        handle_error!(
-                            stdout_tx.send(Err(io::Error::new(io::ErrorKind::Other, err.clone())))
-                        );
-                        handle_error!(
-                            stderr_tx.send(Err(io::Error::new(io::ErrorKind::Other, err)))
-                        );
+                        handle_error!(stdout_tx.send(Err(io::Error::other(err.clone()))));
+                        handle_error!(stderr_tx.send(Err(io::Error::other(err))));
                     }
                 }
             }

--- a/testcontainers/src/core/wait/mod.rs
+++ b/testcontainers/src/core/wait/mod.rs
@@ -41,7 +41,7 @@ pub enum WaitFor {
     /// Wait for a certain HTTP response.
     #[cfg(feature = "http_wait")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http_wait")))]
-    Http(HttpWaitStrategy),
+    Http(Box<HttpWaitStrategy>),
     /// Wait for the container to exit.
     Exit(ExitWaitStrategy),
 }
@@ -74,7 +74,7 @@ impl WaitFor {
     #[cfg(feature = "http_wait")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http_wait")))]
     pub fn http(http_strategy: HttpWaitStrategy) -> WaitFor {
-        WaitFor::Http(http_strategy)
+        WaitFor::Http(Box::new(http_strategy))
     }
 
     /// Wait for the container to exit.
@@ -121,7 +121,7 @@ impl WaitFor {
 #[cfg_attr(docsrs, doc(cfg(feature = "http_wait")))]
 impl From<HttpWaitStrategy> for WaitFor {
     fn from(value: HttpWaitStrategy) -> Self {
-        Self::Http(value)
+        Self::Http(Box::new(value))
     }
 }
 

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -290,8 +290,7 @@ where
             res => res,
         }?;
 
-        let copy_to_sources: Vec<&CopyToContainer> =
-            container_req.copy_to_sources().map(Into::into).collect();
+        let copy_to_sources: Vec<&CopyToContainer> = container_req.copy_to_sources().collect();
 
         for copy_to_source in copy_to_sources {
             client

--- a/testcontainers/src/watchdog.rs
+++ b/testcontainers/src/watchdog.rs
@@ -34,7 +34,7 @@ static WATCHDOG: Lazy<Mutex<Watchdog>> = Lazy::new(|| {
                     .unwrap_or_default()
                 {
                     signal_docker
-                        .stop(&container_id)
+                        .stop(&container_id, None)
                         .await
                         .expect("failed to stop container");
                     signal_docker


### PR DESCRIPTION
Previously containers were stopped with no timeout (SIGKILL) which was interfering with clean shutdown of processes being tested. 

This commit adds a new API of stop_with_timeout(timeout_secconds) in addition to the original stop(). The original stop() interface calls stop_with_timeout using the default '0'.

EDIT:

It would seem my original diagnosis was incorrect and the default timeout is 10 seconds, but my CI system was somehow setting the default to 1 second. I will fix the docs and put in the correct default. I think there is still some value in here - apologies for the time waste getting to this point!