### PR TITLE
build: propagate ring/aws-lc-rs feature flags to bollard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Build
-        run: cargo hack build --each-feature --keep-going
+        run: cargo hack build --at-least-one-of ring,aws-lc-rs,ssl --feature-powerset --depth 2 --keep-going
 
   test:
     name: Test
@@ -62,7 +62,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --each-feature --clean-per-run
+        run: cargo hack test --at-least-one-of ring,aws-lc-rs,ssl --feature-powerset --depth 2 --clean-per-run
 
   fmt:
     name: Rustfmt check

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -31,3 +31,13 @@ Configuration is fetched in the following order:
 1. `DOCKER_AUTH_CONFIG` environment variable, unmarshalling the string value from its JSON representation and using it as the Docker config.
 2. `DOCKER_CONFIG` environment variable, as an alternative path to the directory containing Docker `config.json` file.
 3. else it will load the default Docker config file, which lives in the user's home, e.g. `~/.docker/config.json`.
+
+## bollard, rustls and SSL Cryptography providers
+`testcontainers` uses [`bollard`](https://docs.rs/bollard/latest/bollard/) to interact with the Docker API. 
+
+`bollard` in turn has options provided by `rustls` to configure its SSL cryptography providers.
+
+The `testcontainers` feature flags to control this are as follows:
+* `ring` - use `rustls` with `ring` as the cryptography provider (default)
+* `aws-lc-rs` - use `rustls` with `aws-lc-rs` as the cryptography provider
+* `ssl` - use `rustls` with a custom cryptography provider configuration - see [bollard](https://docs.rs/bollard/latest/bollard/#feature-flags) and [rustls](https://docs.rs/rustls/latest/rustls/#cryptography-providers) documentation for more.

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = { version = "0.1" }
-bollard = { version = "0.18.1", features = ["ssl"] }
+bollard = { version = "0.18.1"}
 bollard-stubs = "=1.47.1-rc.27.3.1"
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
@@ -44,7 +44,10 @@ ulid = { version = "1.1.3", optional = true }
 url = { version = "2", features = ["serde"] }
 
 [features]
-default = []
+default = ["ssl"]
+ssl = ["bollard/ssl"]
+aws-lc-rs = ["bollard/aws-lc-rs"]
+ssl_providerless = ["bollard/ssl_providerless"]
 blocking = []
 watchdog = ["signal-hook", "conquer-once"]
 http_wait = ["reqwest"]

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -44,10 +44,10 @@ ulid = { version = "1.1.3", optional = true }
 url = { version = "2", features = ["serde"] }
 
 [features]
-default = ["ssl"]
-ssl = ["bollard/ssl"]
+default = ["ring"]
+ring = ["bollard/ssl"]
 aws-lc-rs = ["bollard/aws-lc-rs"]
-ssl_providerless = ["bollard/ssl_providerless"]
+ssl = ["bollard/ssl_providerless"]
 blocking = []
 watchdog = ["signal-hook", "conquer-once"]
 http_wait = ["reqwest"]


### PR DESCRIPTION
In order for consumers to be able to switch between `ring` and `aws-lc-rs` cleanly without `testcontainers_rs` bringing in the wrong library, add feature flags that are propagated through to `bollard` to switch between the two ssl providers.