### PR TITLE
feat: added CommandStrategy with SuccessfulCommand enum

### DIFF
--- a/testcontainers/src/core/image/exec.rs
+++ b/testcontainers/src/core/image/exec.rs
@@ -1,6 +1,6 @@
 use crate::core::{CmdWaitFor, WaitFor};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExecCommand {
     pub(crate) cmd: Vec<String>,
     pub(crate) cmd_ready_condition: CmdWaitFor,

--- a/testcontainers/src/core/wait/command_strategy.rs
+++ b/testcontainers/src/core/wait/command_strategy.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use crate::{
+    core::{client::Client, error::WaitContainerError, wait::WaitStrategy, ExecCommand},
+    ContainerAsync, Image,
+};
+
+#[derive(Debug, Clone)]
+pub struct CommandStrategy {
+    expected_code: i64,
+    poll_interval: Duration,
+    command: ExecCommand,
+    fail_fast: bool,
+}
+
+impl CommandStrategy {
+    /// Create a new `CommandStrategy` with default settings.
+    pub fn new() -> Self {
+        Self {
+            command: ExecCommand::default(),
+            expected_code: 0,
+            poll_interval: Duration::from_millis(100),
+            fail_fast: false,
+        }
+    }
+
+    /// Creates a new `CommandStrategy` with default settings and a preset command to execute.
+    pub fn command(command: ExecCommand) -> Self {
+        CommandStrategy::default().with_exec_command(command)
+    }
+
+    /// Set the fail fast flag for the strategy, meaning that if the command's first run does not
+    /// have the expected exit code, the strategy will exit with failure. If the flag is not set,
+    /// the strategy will continue to poll the container until the expected exit code is reached.
+    pub fn with_fail_fast(mut self, fail_fast: bool) -> Self {
+        self.fail_fast = fail_fast;
+        self
+    }
+
+    /// Set the command for executing the command on the container.
+    pub fn with_exec_command(mut self, command: ExecCommand) -> Self {
+        self.command = command;
+        self
+    }
+
+    /// Set the poll interval for checking the container's status.
+    pub fn with_poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+}
+
+impl WaitStrategy for CommandStrategy {
+    async fn wait_until_ready<I: Image>(
+        self,
+        client: &Client,
+        container: &ContainerAsync<I>,
+    ) -> crate::core::error::Result<()> {
+        loop {
+            let container_state = client
+                .inspect(container.id())
+                .await?
+                .state
+                .ok_or(WaitContainerError::StateUnavailable)?;
+
+            let is_running = container_state.running.unwrap_or_default();
+
+            if is_running {
+                let exec_result = client
+                    .exec(container.id(), self.command.clone().cmd)
+                    .await?;
+
+                let inspect_result = client.inspect_exec(&exec_result.id).await?;
+                let mut running = inspect_result.running.unwrap_or(false);
+
+                loop {
+                    if !running {
+                        break;
+                    }
+
+                    let inspect_result = client.inspect_exec(&exec_result.id).await?;
+                    let exit_code = inspect_result.exit_code;
+                    running = inspect_result.running.unwrap_or(false);
+
+                    if self.fail_fast && exit_code != Some(self.expected_code) {
+                        return Err(WaitContainerError::UnexpectedExitCode {
+                            expected: self.expected_code,
+                            actual: exit_code,
+                        }
+                        .into());
+                    }
+
+                    if exit_code == Some(self.expected_code) {
+                        return Ok(());
+                    }
+
+                    tokio::time::sleep(self.poll_interval).await;
+                }
+
+                continue;
+            }
+        }
+    }
+}
+
+impl Default for CommandStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/testcontainers/src/core/wait/mod.rs
+++ b/testcontainers/src/core/wait/mod.rs
@@ -1,5 +1,6 @@
 use std::{env::var, fmt::Debug, time::Duration};
 
+pub use command_strategy::CommandStrategy;
 pub use exit_strategy::ExitWaitStrategy;
 pub use health_strategy::HealthWaitStrategy;
 #[cfg(feature = "http_wait")]
@@ -12,7 +13,10 @@ use crate::{
     ContainerAsync, Image,
 };
 
+use super::{CmdWaitFor, ExecCommand};
+
 pub(crate) mod cmd_wait;
+pub(crate) mod command_strategy;
 pub(crate) mod exit_strategy;
 pub(crate) mod health_strategy;
 #[cfg(feature = "http_wait")]
@@ -44,6 +48,8 @@ pub enum WaitFor {
     Http(HttpWaitStrategy),
     /// Wait for the container to exit.
     Exit(ExitWaitStrategy),
+    /// Wait for a certain command to exit with a successful code.
+    SuccessfulCommand(CommandStrategy),
 }
 
 impl WaitFor {
@@ -144,6 +150,9 @@ impl WaitStrategy for WaitFor {
                 strategy.wait_until_ready(client, container).await?;
             }
             WaitFor::Exit(strategy) => {
+                strategy.wait_until_ready(client, container).await?;
+            }
+            WaitFor::SuccessfulCommand(strategy) => {
                 strategy.wait_until_ready(client, container).await?;
             }
             WaitFor::Nothing => {}


### PR DESCRIPTION
Potentially resolves #702 

This introduces a new wait strategy, `CommandStrategy`. The goal here is to wait for a successful command (exit code 0) prior to marking a container as ready. This polls the container state to ensure it's running first, and then executes the given command. Once the command has an exit code of 0, then the strategy has completed.

There are options to fail fast, as well as customize the exit code, just to expose flexibility for the strategy.

Open to changes / updates, if required -- this language is not my day-to-day.