### PR TITLE
feat: add user configuration for container commands

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -43,6 +43,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) log_consumers: Vec<Box<dyn LogConsumer + 'static>>,
     #[cfg(feature = "reusable-containers")]
     pub(crate) reuse: crate::ReuseDirective,
+    pub(crate) user: Option<String>,
 }
 
 /// Represents a port mapping between a host's external port and the internal port of a container.
@@ -192,6 +193,11 @@ impl<I: Image> ContainerRequest<I> {
     pub fn reuse(&self) -> crate::ReuseDirective {
         self.reuse
     }
+
+    /// Returns the configured user that commands are run as inside the container.
+    pub fn user(&self) -> Option<&str> {
+        self.user.as_deref()
+    }
 }
 
 impl<I: Image> From<I> for ContainerRequest<I> {
@@ -221,6 +227,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             log_consumers: vec![],
             #[cfg(feature = "reusable-containers")]
             reuse: crate::ReuseDirective::Never,
+            user: None,
         }
     }
 }
@@ -265,7 +272,8 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("cgroupns_mode", &self.cgroupns_mode)
             .field("userns_mode", &self.userns_mode)
             .field("startup_timeout", &self.startup_timeout)
-            .field("working_dir", &self.working_dir);
+            .field("working_dir", &self.working_dir)
+            .field("user", &self.user);
 
         #[cfg(feature = "reusable-containers")]
         repr.field("reusable", &self.reuse);

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -166,6 +166,9 @@ pub trait ImageExt<I: Image> {
     /// `Container` or `ContainerAsync` is dropped.
     #[cfg(feature = "reusable-containers")]
     fn with_reuse(self, reuse: ReuseDirective) -> ContainerRequest<I>;
+
+    /// Sets the user that commands are run as inside the container.
+    fn with_user(self, user: impl Into<String>) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -378,6 +381,14 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         ContainerRequest {
             reuse,
             ..self.into()
+        }
+    }
+
+    fn with_user(self, user: impl Into<String>) -> ContainerRequest<I> {
+        let container_req = self.into();
+        ContainerRequest {
+            user: Some(user.into()),
+            ..container_req
         }
     }
 }


### PR DESCRIPTION
This was inspired by https://github.com/testcontainers/testcontainers-rs/issues/762 and my project's requirement to use an image that requires running with root user inside the container.

This pull request introduces the ability to configure a user that commands are run as inside a container in the `testcontainers` library. The most important changes include adding a new `user` field to the `ContainerRequest` struct, implementing methods to set and retrieve the user, and updating relevant tests to ensure this functionality works correctly.

Enhancements to `ContainerRequest`:

* [`testcontainers/src/core/containers/request.rs`](diffhunk://#diff-450493263e745439645d3062a1defe3bdedcadacabb123fe7664244e42570049R46): Added a new `user` field to the `ContainerRequest` struct and provided a method to retrieve the user. [[1]](diffhunk://#diff-450493263e745439645d3062a1defe3bdedcadacabb123fe7664244e42570049R46) [[2]](diffhunk://#diff-450493263e745439645d3062a1defe3bdedcadacabb123fe7664244e42570049R196-R200) [[3]](diffhunk://#diff-450493263e745439645d3062a1defe3bdedcadacabb123fe7664244e42570049R230) [[4]](diffhunk://#diff-450493263e745439645d3062a1defe3bdedcadacabb123fe7664244e42570049L268-R276)

Enhancements to `ImageExt`:

* [`testcontainers/src/core/image/image_ext.rs`](diffhunk://#diff-5d7331a740328676b08bc371893a5aa3e743d351bccafc3da0e2c55ffbf2004fR169-R171): Added a new method `with_user` to the `ImageExt` trait to set the user for the container. [[1]](diffhunk://#diff-5d7331a740328676b08bc371893a5aa3e743d351bccafc3da0e2c55ffbf2004fR169-R171) [[2]](diffhunk://#diff-5d7331a740328676b08bc371893a5aa3e743d351bccafc3da0e2c55ffbf2004fR386-R393)

Updates to `async_runner`:

* [`testcontainers/src/runners/async_runner.rs`](diffhunk://#diff-24518a824e97296d94c621275ed17e1f3fa9ae37e0b66158ee4dcf549c21b868R152): Updated the `async_runner` to include the user configuration and added a new test to verify that the user is correctly set inside the container. [[1]](diffhunk://#diff-24518a824e97296d94c621275ed17e1f3fa9ae37e0b66158ee4dcf549c21b868R152) [[2]](diffhunk://#diff-24518a824e97296d94c621275ed17e1f3fa9ae37e0b66158ee4dcf549c21b868R877-R894)