### PR TITLE
feat: support `pause` and `unpause` container

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -77,6 +77,10 @@ pub enum ClientError {
     StartContainer(BollardError),
     #[error("failed to stop a container: {0}")]
     StopContainer(BollardError),
+    #[error("failed to pause a container: {0}")]
+    PauseContainer(BollardError),
+    #[error("failed to unpause/resume a container: {0}")]
+    UnpauseContainer(BollardError),
     #[error("failed to inspect a container: {0}")]
     InspectContainer(BollardError),
 
@@ -174,6 +178,20 @@ impl Client {
             .start_container::<String>(id, None)
             .await
             .map_err(ClientError::Init)
+    }
+
+    pub(crate) async fn pause(&self, id: &str) -> Result<(), ClientError> {
+        self.bollard
+            .pause_container(id)
+            .await
+            .map_err(ClientError::PauseContainer)
+    }
+
+    pub(crate) async fn unpause(&self, id: &str) -> Result<(), ClientError> {
+        self.bollard
+            .unpause_container(id)
+            .await
+            .map_err(ClientError::UnpauseContainer)
     }
 
     pub(crate) async fn exec(

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -288,6 +288,20 @@ where
         Ok(())
     }
 
+    /// Pause the container.
+    /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerPause)
+    pub async fn pause(&self) -> Result<()> {
+       self.docker_client.pause(&self.id).await?;
+       Ok(())
+   }
+
+    /// Resume/Unpause the container.
+    /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerUnpause)
+    pub async fn unpause(&self) -> Result<()> {
+       self.docker_client.unpause(&self.id).await?;
+       Ok(())
+   }
+
     /// Removes the container.
     pub async fn rm(mut self) -> Result<()> {
         log::debug!("Deleting docker container {}", self.id);

--- a/testcontainers/src/core/containers/async_container.rs
+++ b/testcontainers/src/core/containers/async_container.rs
@@ -291,16 +291,16 @@ where
     /// Pause the container.
     /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerPause)
     pub async fn pause(&self) -> Result<()> {
-       self.docker_client.pause(&self.id).await?;
-       Ok(())
-   }
+        self.docker_client.pause(&self.id).await?;
+        Ok(())
+    }
 
     /// Resume/Unpause the container.
     /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerUnpause)
     pub async fn unpause(&self) -> Result<()> {
-       self.docker_client.unpause(&self.id).await?;
-       Ok(())
-   }
+        self.docker_client.unpause(&self.id).await?;
+        Ok(())
+    }
 
     /// Removes the container.
     pub async fn rm(mut self) -> Result<()> {

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -137,6 +137,18 @@ where
         self.rt().block_on(self.async_impl().start())
     }
 
+     /// Pause the container.
+    /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerPause)
+    pub async fn pause(&self) -> Result<()> {
+        self.rt().block_on(self.async_impl().pause())
+    }
+    
+    /// Resume/Unpause the container.
+    /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerUnpause)
+    pub async fn unpause(&self) -> Result<()> {
+         self.rt().block_on(self.async_impl().unpause())
+    }
+
     /// Removes the container.
     pub fn rm(mut self) -> Result<()> {
         if let Some(active) = self.inner.take() {

--- a/testcontainers/src/core/containers/sync_container.rs
+++ b/testcontainers/src/core/containers/sync_container.rs
@@ -137,16 +137,16 @@ where
         self.rt().block_on(self.async_impl().start())
     }
 
-     /// Pause the container.
+    /// Pause the container.
     /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerPause)
     pub async fn pause(&self) -> Result<()> {
         self.rt().block_on(self.async_impl().pause())
     }
-    
+
     /// Resume/Unpause the container.
     /// [Docker Engine API](https://docs.docker.com/reference/api/engine/version/v1.48/#tag/Container/operation/ContainerUnpause)
     pub async fn unpause(&self) -> Result<()> {
-         self.rt().block_on(self.async_impl().unpause())
+        self.rt().block_on(self.async_impl().unpause())
     }
 
     /// Removes the container.


### PR DESCRIPTION
This adds the pause/unpause calls for ContainerAsync/Container because I wanted to have an integration test keeping the same port for a mosquitto container.

fixes #715, #433
