### PR TITLE
feat: allow `security_opt` and `readonly_rootfs` to be configured

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -35,6 +35,8 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) privileged: bool,
     pub(crate) cap_add: Option<Vec<String>>,
     pub(crate) cap_drop: Option<Vec<String>>,
+    pub(crate) readonly_rootfs: Option<bool>,
+    pub(crate) security_opt: Option<Vec<String>>,
     pub(crate) shm_size: Option<u64>,
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
     pub(crate) userns_mode: Option<String>,
@@ -198,6 +200,14 @@ impl<I: Image> ContainerRequest<I> {
     pub fn user(&self) -> Option<&str> {
         self.user.as_deref()
     }
+
+    pub fn security_opt(&self) -> Option<&Vec<String>> {
+        self.security_opt.as_ref()
+    }
+
+    pub fn readonly_rootfs(&self) -> Option<bool> {
+        self.readonly_rootfs
+    }
 }
 
 impl<I: Image> From<I> for ContainerRequest<I> {
@@ -219,6 +229,8 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             privileged: false,
             cap_add: None,
             cap_drop: None,
+            security_opt: None,
+            readonly_rootfs: None,
             shm_size: None,
             cgroupns_mode: None,
             userns_mode: None,

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -35,8 +35,8 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) privileged: bool,
     pub(crate) cap_add: Option<Vec<String>>,
     pub(crate) cap_drop: Option<Vec<String>>,
-    pub(crate) readonly_rootfs: Option<bool>,
-    pub(crate) security_opt: Option<Vec<String>>,
+    pub(crate) readonly_rootfs: bool,
+    pub(crate) security_opts: Vec<String>,
     pub(crate) shm_size: Option<u64>,
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
     pub(crate) userns_mode: Option<String>,
@@ -201,11 +201,11 @@ impl<I: Image> ContainerRequest<I> {
         self.user.as_deref()
     }
 
-    pub fn security_opt(&self) -> Option<&Vec<String>> {
-        self.security_opt.as_ref()
+    pub fn security_opts(&self) -> &Vec<String> {
+        self.security_opts.as_ref()
     }
 
-    pub fn readonly_rootfs(&self) -> Option<bool> {
+    pub fn readonly_rootfs(&self) -> bool {
         self.readonly_rootfs
     }
 }
@@ -229,8 +229,8 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             privileged: false,
             cap_add: None,
             cap_drop: None,
-            security_opt: None,
-            readonly_rootfs: None,
+            security_opts: Vec::new(),
+            readonly_rootfs: false,
             shm_size: None,
             cgroupns_mode: None,
             userns_mode: None,

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -36,7 +36,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) cap_add: Option<Vec<String>>,
     pub(crate) cap_drop: Option<Vec<String>>,
     pub(crate) readonly_rootfs: bool,
-    pub(crate) security_opts: Vec<String>,
+    pub(crate) security_opts: Option<Vec<String>>,
     pub(crate) shm_size: Option<u64>,
     pub(crate) cgroupns_mode: Option<CgroupnsMode>,
     pub(crate) userns_mode: Option<String>,
@@ -201,7 +201,7 @@ impl<I: Image> ContainerRequest<I> {
         self.user.as_deref()
     }
 
-    pub fn security_opts(&self) -> &Vec<String> {
+    pub fn security_opts(&self) -> Option<&Vec<String>> {
         self.security_opts.as_ref()
     }
 
@@ -229,7 +229,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             privileged: false,
             cap_add: None,
             cap_drop: None,
-            security_opts: Vec::new(),
+            security_opts: None,
             readonly_rootfs: false,
             shm_size: None,
             cgroupns_mode: None,

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -169,6 +169,12 @@ pub trait ImageExt<I: Image> {
 
     /// Sets the user that commands are run as inside the container.
     fn with_user(self, user: impl Into<String>) -> ContainerRequest<I>;
+
+    /// Sets the container's root filesystem to be mounted as read-only
+    fn with_readonly_rootfs(self, readonly_rootfs: Option<bool>) -> ContainerRequest<I>;
+
+    /// Sets security options for the container
+    fn with_security_opt(self, security_opt: Option<Vec<String>>) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -388,6 +394,22 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         let container_req = self.into();
         ContainerRequest {
             user: Some(user.into()),
+            ..container_req
+        }
+    }
+
+    fn with_readonly_rootfs(self, readonly_rootfs: Option<bool>) -> ContainerRequest<I> {
+        let container_req = self.into();
+        ContainerRequest {
+            readonly_rootfs,
+            ..container_req
+        }
+    }
+
+    fn with_security_opt(self, security_opt: Option<Vec<String>>) -> ContainerRequest<I> {
+        let container_req = self.into();
+        ContainerRequest {
+            security_opt,
             ..container_req
         }
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -407,12 +407,12 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     }
 
     fn with_security_opt(self, security_opt: impl Into<String>) -> ContainerRequest<I> {
-        let container_req = self.into();
-        let mut security_opts = container_req.security_opts;
-        security_opts.push(security_opt.into());
-        ContainerRequest {
-            security_opts,
-            ..container_req
-        }
+        let mut container_req = self.into();
+        container_req
+            .security_opts
+            .get_or_insert_with(Vec::new)
+            .push(security_opt.into());
+
+        container_req
     }
 }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -171,10 +171,13 @@ pub trait ImageExt<I: Image> {
     fn with_user(self, user: impl Into<String>) -> ContainerRequest<I>;
 
     /// Sets the container's root filesystem to be mounted as read-only
-    fn with_readonly_rootfs(self, readonly_rootfs: Option<bool>) -> ContainerRequest<I>;
+    fn with_readonly_rootfs(self, readonly_rootfs: bool) -> ContainerRequest<I>;
 
     /// Sets security options for the container
-    fn with_security_opt(self, security_opt: Option<Vec<String>>) -> ContainerRequest<I>;
+    fn with_security_opt(
+        self,
+        security_opt: impl IntoIterator<Item = impl Into<String>>,
+    ) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -398,18 +401,21 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
         }
     }
 
-    fn with_readonly_rootfs(self, readonly_rootfs: Option<bool>) -> ContainerRequest<I> {
+    fn with_readonly_rootfs(self, readonly_rootfs: bool) -> ContainerRequest<I> {
         let container_req = self.into();
         ContainerRequest {
-            readonly_rootfs,
+            readonly_rootfs: Some(readonly_rootfs),
             ..container_req
         }
     }
 
-    fn with_security_opt(self, security_opt: Option<Vec<String>>) -> ContainerRequest<I> {
+    fn with_security_opt(
+        self,
+        security_opt: impl IntoIterator<Item = impl Into<String>>,
+    ) -> ContainerRequest<I> {
         let container_req = self.into();
         ContainerRequest {
-            security_opt,
+            security_opt: Some(security_opt.into_iter().map(Into::into).collect()),
             ..container_req
         }
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -174,10 +174,7 @@ pub trait ImageExt<I: Image> {
     fn with_readonly_rootfs(self, readonly_rootfs: bool) -> ContainerRequest<I>;
 
     /// Sets security options for the container
-    fn with_security_opt(
-        self,
-        security_opt: impl IntoIterator<Item = impl Into<String>>,
-    ) -> ContainerRequest<I>;
+    fn with_security_opt(self, security_opt: impl Into<String>) -> ContainerRequest<I>;
 }
 
 /// Implements the [`ImageExt`] trait for the every type that can be converted into a [`ContainerRequest`].
@@ -404,18 +401,17 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     fn with_readonly_rootfs(self, readonly_rootfs: bool) -> ContainerRequest<I> {
         let container_req = self.into();
         ContainerRequest {
-            readonly_rootfs: Some(readonly_rootfs),
+            readonly_rootfs,
             ..container_req
         }
     }
 
-    fn with_security_opt(
-        self,
-        security_opt: impl IntoIterator<Item = impl Into<String>>,
-    ) -> ContainerRequest<I> {
+    fn with_security_opt(self, security_opt: impl Into<String>) -> ContainerRequest<I> {
         let container_req = self.into();
+        let mut security_opts = container_req.security_opts;
+        security_opts.push(security_opt.into());
         ContainerRequest {
-            security_opt: Some(security_opt.into_iter().map(Into::into).collect()),
+            security_opts,
             ..container_req
         }
     }

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -147,7 +147,7 @@ where
                 cap_add: container_req.cap_add().cloned(),
                 cap_drop: container_req.cap_drop().cloned(),
                 readonly_rootfs: Some(container_req.readonly_rootfs()),
-                security_opt: Some(container_req.security_opts().clone()),
+                security_opt: container_req.security_opts().cloned(),
                 ..Default::default()
             }),
             working_dir: container_req.working_dir().map(|dir| dir.to_string()),

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -146,6 +146,8 @@ where
                 userns_mode: container_req.userns_mode().map(|v| v.to_string()),
                 cap_add: container_req.cap_add().cloned(),
                 cap_drop: container_req.cap_drop().cloned(),
+                readonly_rootfs: container_req.readonly_rootfs(),
+                security_opt: container_req.security_opt().cloned(),
                 ..Default::default()
             }),
             working_dir: container_req.working_dir().map(|dir| dir.to_string()),

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -146,8 +146,8 @@ where
                 userns_mode: container_req.userns_mode().map(|v| v.to_string()),
                 cap_add: container_req.cap_add().cloned(),
                 cap_drop: container_req.cap_drop().cloned(),
-                readonly_rootfs: container_req.readonly_rootfs(),
-                security_opt: container_req.security_opt().cloned(),
+                readonly_rootfs: Some(container_req.readonly_rootfs()),
+                security_opt: Some(container_req.security_opts().clone()),
                 ..Default::default()
             }),
             working_dir: container_req.working_dir().map(|dir| dir.to_string()),


### PR DESCRIPTION
I want to implement a Talos test container, and there is no way to change some arguments.

```
docker run --rm -it \
  --name tutorial \
  --hostname talos-cp \
  --read-only \
  --privileged \
  --security-opt seccomp=unconfined \
  --mount type=tmpfs,destination=/run \
  --mount type=tmpfs,destination=/system \
  --mount type=tmpfs,destination=/tmp \
  --mount type=volume,destination=/system/state \
  --mount type=volume,destination=/var \
  --mount type=volume,destination=/etc/cni \
  --mount type=volume,destination=/etc/kubernetes \
  --mount type=volume,destination=/usr/libexec/kubernetes \
  --mount type=volume,destination=/opt \
  -e PLATFORM=container \
  ghcr.io/siderolabs/talos:v1.9.5
```