### PR TITLE
fix: make tls features optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --at-least-one-of ring,aws-lc-rs,ssl --feature-powerset --depth 2 --clean-per-run
+        run: cargo hack test --feature-powerset --depth 2 --clean-per-run
 
   fmt:
     name: Rustfmt check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Build
-        run: cargo hack build --at-least-one-of ring,aws-lc-rs,ssl --feature-powerset --depth 2 --keep-going
+        run: cargo hack build --feature-powerset --depth 2 --keep-going
 
   test:
     name: Test

--- a/testcontainers/src/core/client/bollard_client.rs
+++ b/testcontainers/src/core/client/bollard_client.rs
@@ -12,13 +12,14 @@ pub(super) fn init(config: &env::Config) -> Result<Docker, bollard::errors::Erro
     let host_url = Url::from_str(host)?;
 
     match host_url.scheme() {
+        #[cfg(any(feature = "ring", feature = "aws-lc-rs"))
         "https" => connect_with_ssl(config),
         "http" | "tcp" => {
+            #[cfg(any(feature = "ring", feature = "aws-lc-rs"))
             if config.tls_verify() {
-                connect_with_ssl(config)
-            } else {
-                Docker::connect_with_http(host, DEFAULT_TIMEOUT.as_secs(), API_DEFAULT_VERSION)
+                return connect_with_ssl(config);
             }
+            Docker::connect_with_http(host, DEFAULT_TIMEOUT.as_secs(), API_DEFAULT_VERSION)
         }
         #[cfg(unix)]
         "unix" => Docker::connect_with_unix(host, DEFAULT_TIMEOUT.as_secs(), API_DEFAULT_VERSION),
@@ -32,6 +33,7 @@ pub(super) fn init(config: &env::Config) -> Result<Docker, bollard::errors::Erro
     }
 }
 
+#[cfg(any(feature = "ring", feature = "aws-lc-rs"))
 fn connect_with_ssl(config: &env::Config) -> Result<Docker, bollard::errors::Error> {
     let cert_path = config.cert_path().expect("cert path not found");
 

--- a/testcontainers/src/core/client/bollard_client.rs
+++ b/testcontainers/src/core/client/bollard_client.rs
@@ -12,10 +12,10 @@ pub(super) fn init(config: &env::Config) -> Result<Docker, bollard::errors::Erro
     let host_url = Url::from_str(host)?;
 
     match host_url.scheme() {
-        #[cfg(any(feature = "ring", feature = "aws-lc-rs"))
+        #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
         "https" => connect_with_ssl(config),
         "http" | "tcp" => {
-            #[cfg(any(feature = "ring", feature = "aws-lc-rs"))
+            #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             if config.tls_verify() {
                 return connect_with_ssl(config);
             }
@@ -33,7 +33,7 @@ pub(super) fn init(config: &env::Config) -> Result<Docker, bollard::errors::Erro
     }
 }
 
-#[cfg(any(feature = "ring", feature = "aws-lc-rs"))
+#[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
 fn connect_with_ssl(config: &env::Config) -> Result<Docker, bollard::errors::Error> {
     let cert_path = config.cert_path().expect("cert path not found");
 


### PR DESCRIPTION
Allows to disable TLS features (with `default-features=false`)

`ring` still enabled by default

Closes #799