### PR TITLE
fix: added new parse rule for correctly parsing ports without protocol specifier

### DIFF
--- a/testcontainers/src/core/ports.rs
+++ b/testcontainers/src/core/ports.rs
@@ -11,6 +11,7 @@ use bollard_stubs::models::{PortBinding, PortMap};
 )]
 pub enum ContainerPort {
     #[display("{0}/tcp")]
+    #[from_str(regex = r"^(?<0>\d+)(?:/tcp)?$")]
     Tcp(u16),
     #[display("{0}/udp")]
     Udp(u16),
@@ -333,6 +334,7 @@ mod tests {
     "LinkLocalIPv6Address": "",
     "LinkLocalIPv6PrefixLen": 0,
     "Ports": {
+      "18332": [],
       "18332/tcp": [
         {
           "HostIp": "0.0.0.0",


### PR DESCRIPTION
Also edited corresponding test.
**It would be great if you could merge it into the 24 release.**
## Problem
After update of docker  from `27.5.1` to `28.3.0, build 38b7060` error related to port parsing occured. Specifically port parsing fails on port without protocol specifier.
Maybe this [issue](https://github.com/moby/moby/issues/45199) will help clarify things.
Here is `docker inspect` on running `scylladb/scylla:6.0` docker container, created with testcontainers api using different version of docker.
### `docker inspect` (27.5.1 version)
```
"Ports": {
                "10000/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "55062"
                    }
                ],
                "22/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "55056"
                    }
                ]
}
```
### `docker inspect` (28.3.0 version)
```
            "Ports": {
                "10000": [],
                "10000/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "55475"
                    }
                ],
                "22": [],
                "22/tcp": [
                    {
                        "HostIp": "0.0.0.0",
                        "HostPort": "55469"
                    }
                ]
}
```

