### PR TITLE
ci: distribute feature-set test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [ main ]
+    branches: [main]
 
 concurrency:
   group: ${{ github.ref }}
@@ -43,6 +43,12 @@ jobs:
         toolchain:
           - stable
           - nightly
+        partition:
+          - 1/5
+          - 2/5
+          - 3/5
+          - 4/5
+          - 5/5
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -62,7 +68,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --feature-powerset --depth 2 --clean-per-run
+        run: cargo hack test --feature-powerset --depth 2 --clean-per-run --partition ${{ matrix.partition }}
 
   fmt:
     name: Rustfmt check


### PR DESCRIPTION
Use cargo-hacks `--partition` option to distribute feature-set test execution to a set of runners with the goal to speed up feedback cycles.