### PR TITLE
ci: adapt release-plz configuration

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,12 +7,6 @@ name = "testcontainers"
 git_tag_name = "{{ version }}"
 changelog_path = "CHANGELOG.md"
 
-[[package]]
-name = "testimages"
-release = false
-publish = false
-changelog_update = false
-
 [changelog]
 tag_pattern = "[0-9].*"
 sort_commits = "oldest"


### PR DESCRIPTION
The introduction of the builder-API removed the `testimages` package.