### PR TITLE
feat(async, network): add support for aliases, connect & disconnect

### DIFF
--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -101,6 +101,11 @@ pub enum ClientError {
     #[error("failed to remove a network: {0}")]
     RemoveNetwork(BollardError),
 
+    #[error("failed to connect container to network")]
+    ConnectionError(BollardError),
+    #[error("failed to disconnect container from network")]
+    DisconnectionError(BollardError),
+
     #[error("failed to initialize exec command: {0}")]
     InitExec(BollardError),
     #[error("failed to inspect exec command: {0}")]
@@ -114,7 +119,7 @@ pub enum ClientError {
 /// The internal client.
 pub(crate) struct Client {
     pub(crate) config: env::Config,
-    bollard: Docker,
+    pub(crate) bollard: Docker,
 }
 
 impl Client {
@@ -429,11 +434,11 @@ impl Client {
             match result {
                 Ok(r) => {
                     if let Some(s) = r.stream {
-                        log::info!("{}", s);
+                        log::info!("{s}");
                     }
                 }
                 Err(err) => {
-                    log::error!("{:?}", err);
+                    log::error!("{err:?}");
                     return Err(ClientError::BuildImage {
                         descriptor: descriptor.into(),
                         err,

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::{Debug, Formatter},
     net::IpAddr,
     time::Duration,
@@ -25,6 +25,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) image_tag: Option<String>,
     pub(crate) container_name: Option<String>,
     pub(crate) network: Option<String>,
+    pub(crate) network_aliases: HashSet<String>,
     pub(crate) labels: BTreeMap<String, String>,
     pub(crate) env_vars: BTreeMap<String, String>,
     pub(crate) hosts: BTreeMap<String, Host>,
@@ -228,6 +229,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             image_tag: None,
             container_name: None,
             network: None,
+            network_aliases: HashSet::new(),
             labels: BTreeMap::default(),
             env_vars: BTreeMap::default(),
             hosts: BTreeMap::default(),

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -69,6 +69,9 @@ pub trait ImageExt<I: Image> {
     /// Sets the network the container will be connected to.
     fn with_network(self, network: impl Into<String>) -> ContainerRequest<I>;
 
+    // Adds the specified network alias to the container.
+    fn with_net_alias(self, network_alias: impl Into<String>) -> ContainerRequest<I>;
+
     /// Adds the specified label to the container.
     ///
     /// **Note**: all keys in the `org.testcontainers.*` namespace should be regarded
@@ -247,6 +250,12 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
             network: Some(network.into()),
             ..container_req
         }
+    }
+
+    fn with_net_alias(self, network_alias: impl Into<String>) -> ContainerRequest<I> {
+        let mut container_req = self.into();
+        container_req.network_aliases.insert(network_alias.into());
+        container_req
     }
 
     fn with_label(self, key: impl Into<String>, value: impl Into<String>) -> ContainerRequest<I> {

--- a/testcontainers/src/core/network.rs
+++ b/testcontainers/src/core/network.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, OnceLock, Weak},
 };
@@ -19,16 +19,18 @@ fn created_networks() -> &'static Mutex<HashMap<String, Weak<Network>>> {
     CREATED_NETWORKS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-pub(crate) struct Network {
-    name: String,
-    id: String,
-    client: Arc<Client>,
+pub struct Network {
+    pub name: String,
+    pub id: String,
+    pub(crate) client: Arc<Client>,
+    pub aliases: HashSet<String>,
 }
 
 impl Network {
     pub(crate) async fn new(
         name: impl Into<String>,
         client: Arc<Client>,
+        aliases: HashSet<String>,
     ) -> Result<Option<Arc<Self>>, ClientError> {
         let name = name.into();
         let mut guard = created_networks().lock().await;
@@ -46,6 +48,7 @@ impl Network {
                 name: name.clone(),
                 id,
                 client,
+                aliases,
             });
 
             guard.insert(name, Arc::downgrade(&created));

--- a/testcontainers/src/core/ports.rs
+++ b/testcontainers/src/core/ports.rs
@@ -101,17 +101,13 @@ impl TryFrom<PortMap> for Ports {
                     let mapping = match binding.host_ip.map(|ip| ip.parse()) {
                         Some(Ok(IpAddr::V4(_))) => {
                             log::debug!(
-                                "Registering IPv4 port mapping: {} -> {}",
-                                container_port,
-                                host_port
+                                "Registering IPv4 port mapping: {container_port} -> {host_port}",
                             );
                             &mut ipv4_mapping
                         }
                         Some(Ok(IpAddr::V6(_))) => {
                             log::debug!(
-                                "Registering IPv6 port mapping: {} -> {}",
-                                container_port,
-                                host_port
+                                "Registering IPv6 port mapping: {container_port} -> {host_port}",
                             );
                             &mut ipv6_mapping
                         }

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -172,7 +172,12 @@ where
                 host_config.network_mode = Some(network.to_string());
                 host_config
             });
-            Network::new(network, client.clone()).await?
+            Network::new(
+                network,
+                client.clone(),
+                container_req.network_aliases.clone(),
+            )
+            .await?
         } else {
             None
         };

--- a/testcontainers/tests/async_runner.rs
+++ b/testcontainers/tests/async_runner.rs
@@ -284,7 +284,7 @@ async fn async_copy_files_to_container() -> anyhow::Result<()> {
     let mut out = String::new();
     container.stdout(false).read_to_string(&mut out).await?;
 
-    println!("{}", out);
+    println!("{out}");
     assert!(out.contains("foofoofoo"));
     assert!(out.contains("barbarbar"));
 


### PR DESCRIPTION
Attempts to partially solve:
https://github.com/testcontainers/testcontainers-rs/issues/252

The scope of this PR is only the async container (but not the sync). At a quick glance it looks like it should plausibly work, but I haven't tested it. This also includes minor refactoring to make clippy stop complaining about arguments in `format!()` macro. 

Feel free to look through the changes and test it and see if there's anything you'd like to modify before merging!