### PR TITLE
feat: add support for devices request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --feature-powerset --depth 2 --clean-per-run --partition ${{ matrix.partition }}
+        run: cargo hack test --feature-powerset --exclude-features device-requests --depth 2 --clean-per-run --partition ${{ matrix.partition }}
 
   fmt:
     name: Rustfmt check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           tool: cargo-hack
       - name: Tests
-        run: cargo hack test --feature-powerset --exclude-features device-requests --depth 2 --clean-per-run --partition ${{ matrix.partition }}
+        run: cargo hack test --feature-powerset --depth 2 --clean-per-run --partition ${{ matrix.partition }}
 
   fmt:
     name: Rustfmt check

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -60,6 +60,7 @@ watchdog = ["signal-hook", "conquer-once"]
 http_wait = ["reqwest"]
 properties-config = ["serde-java-properties"]
 reusable-containers = []
+device-requests = []
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -6,6 +6,8 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "device-requests")]
+use bollard::models::DeviceRequest;
 use bollard_stubs::models::ResourcesUlimits;
 
 use crate::{
@@ -48,6 +50,8 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) user: Option<String>,
     pub(crate) ready_conditions: Option<Vec<WaitFor>>,
     pub(crate) health_check: Option<Healthcheck>,
+    #[cfg(feature = "device-requests")]
+    pub(crate) device_requests: Option<Vec<DeviceRequest>>,
 }
 
 /// Represents a port mapping between a host's external port and the internal port of a container.
@@ -217,6 +221,11 @@ impl<I: Image> ContainerRequest<I> {
     pub fn health_check(&self) -> Option<&Healthcheck> {
         self.health_check.as_ref()
     }
+
+    #[cfg(feature = "device-requests")]
+    pub fn device_requests(&self) -> Option<&[DeviceRequest]> {
+        self.device_requests.as_deref()
+    }
 }
 
 impl<I: Image> From<I> for ContainerRequest<I> {
@@ -251,6 +260,8 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             user: None,
             ready_conditions: None,
             health_check: None,
+            #[cfg(feature = "device-requests")]
+            device_requests: None,
         }
     }
 }
@@ -302,6 +313,9 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
 
         #[cfg(feature = "reusable-containers")]
         repr.field("reusable", &self.reuse);
+
+        #[cfg(feature = "device-requests")]
+        repr.field("device_requests", &self.device_requests);
 
         repr.finish()
     }

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -223,15 +223,15 @@ pub trait ImageExt<I: Image> {
     /// use testcontainers::bollard::models::DeviceRequest;
     ///
     /// let device_request = DeviceRequest {
-    ///     driver: Some("nvidia"),
+    ///     driver: Some(String::from("nvidia")),
     ///     count: Some(-1), // expose all
-    ///     capabilities: [["gpu"]],
+    ///     capabilities: Some(vec![vec![String::from("gpu")]]),
     ///     device_ids: None,
     ///     options: None,
     /// };
     ///
     /// let image = GenericImage::new("ubuntu", "24.04")
-    ///     .with_device_requests([device_request]);
+    ///     .with_device_requests(vec![device_request]);
     /// ```
     #[cfg(feature = "device-requests")]
     fn with_device_requests(self, device_requests: Vec<DeviceRequest>) -> ContainerRequest<I>;

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -220,7 +220,7 @@ pub trait ImageExt<I: Image> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use testcontainers::{GenericImage, bollard::models::DeviceRequest};
+    /// use testcontainers::{GenericImage, ImageExt as _, bollard::models::DeviceRequest};
     ///
     /// let device_request = DeviceRequest {
     ///     driver: Some(String::from("nvidia")),

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -220,7 +220,7 @@ pub trait ImageExt<I: Image> {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use testcontainers::bollard::models::DeviceRequest;
+    /// use testcontainers::{GenericImage, bollard::models::DeviceRequest};
     ///
     /// let device_request = DeviceRequest {
     ///     driver: Some(String::from("nvidia")),

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -381,11 +381,13 @@ mod tests {
 
     #[cfg(feature = "device-requests")]
     mod device_requests_imports {
-        pub use crate::core::ExecCommand;
+        pub use std::process::Command;
+
         pub use anyhow::{bail, Context};
         pub use bollard::Docker;
-        pub use std::process::Command;
         pub use tokio::io::AsyncReadExt;
+
+        pub use crate::core::ExecCommand;
     }
 
     #[cfg(feature = "device-requests")]

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -532,7 +532,7 @@ mod tests {
         };
 
         // The image must have nvidia drivers installed, so we don't use the simple server here
-        let image = crate::GenericImage::new("ubuntu", "24.04")
+        let image = GenericImage::new("ubuntu", "24.04")
             .with_device_requests(vec![device_request])
             .with_cmd(["sleep", "infinity"]); // keep the container running to have time to run the command
         let container = image.start().await?;

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -501,7 +501,7 @@ mod tests {
         use log::warn;
         use tokio::io::AsyncReadExt;
 
-        use crate::core::ExecCommand;
+        use crate::{core::ExecCommand, GenericImage};
 
         let _ = pretty_env_logger::try_init();
 


### PR DESCRIPTION
This should expose the Bollard API to make device requests and enable usage of host's GPUs for tests.

I didn't find a good way to integrate with CI since the test I wrote depends on an actual GPU. I wrapped the feature on a feature flag and then skipped testing that feature flag in CI.

Closes #831 