### PR TITLE
chore: update MSRV from 1.82 to 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ keywords = ["docker", "testcontainers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/testcontainers/testcontainers-rs"
-rust-version = "1.82"
+rust-version = "1.86"


### PR DESCRIPTION
Extracted from https://github.com/testcontainers/testcontainers-rs/pull/828