### PR TITLE
refactor: remove bollard_stubs dependency as bollard re-exports it

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 async-trait = { version = "0.1" }
 bollard = { version = "0.19.1", features = ["buildkit"] }
-bollard-stubs = "=1.49.0-rc.28.3.3"
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
 docker_credential = "1.3.1"

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -10,7 +10,10 @@ use bollard::{
     container::LogOutput,
     errors::Error as BollardError,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
-    models::{ContainerCreateBody, NetworkCreateRequest},
+    models::{
+        ContainerCreateBody, ContainerInspectResponse, ExecInspectResponse, Network,
+        NetworkCreateRequest,
+    },
     query_parameters::{
         BuildImageOptionsBuilder, BuilderVersion, CreateContainerOptions,
         CreateImageOptionsBuilder, InspectContainerOptions, InspectContainerOptionsBuilder,
@@ -20,7 +23,6 @@ use bollard::{
     },
     Docker,
 };
-use bollard_stubs::models::{ContainerInspectResponse, ExecInspectResponse, Network};
 use futures::{StreamExt, TryStreamExt};
 use tokio::sync::OnceCell;
 use url::Url;

--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -8,7 +8,7 @@ use std::{
 
 #[cfg(feature = "device-requests")]
 use bollard::models::DeviceRequest;
-use bollard_stubs::models::ResourcesUlimits;
+use bollard::models::ResourcesUlimits;
 
 use crate::{
     core::{

--- a/testcontainers/src/core/healthcheck.rs
+++ b/testcontainers/src/core/healthcheck.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use bollard_stubs::models::HealthConfig;
+use bollard::models::HealthConfig;
 
 /// Represents a custom health check configuration for a container.
 ///

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 #[cfg(feature = "device-requests")]
 use bollard::models::DeviceRequest;
-use bollard_stubs::models::ResourcesUlimits;
+use bollard::models::ResourcesUlimits;
 
 use crate::{
     core::{

--- a/testcontainers/src/core/ports.rs
+++ b/testcontainers/src/core/ports.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::IpAddr, num::ParseIntError};
 
-use bollard_stubs::models::{PortBinding, PortMap};
+use bollard::models::{PortBinding, PortMap};
 
 /// Represents a port that is exposed by a container.
 ///
@@ -163,7 +163,7 @@ impl From<u16> for ContainerPort {
 
 #[cfg(test)]
 mod tests {
-    use bollard_stubs::models::ContainerInspectResponse;
+    use bollard::models::ContainerInspectResponse;
 
     use super::*;
 

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -111,4 +111,3 @@ pub mod runners;
 /// Re-export of the `bollard` crate to allow direct interaction with the Docker API.
 /// This also solves potential version conflicts between `testcontainers` and `bollard` deps.
 pub use bollard;
-pub use bollard_stubs;

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -2,10 +2,11 @@ use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use bollard::{
-    models::{ContainerCreateBody, HostConfig, PortBinding},
+    models::{
+        ContainerCreateBody, HostConfig, HostConfigCgroupnsModeEnum, PortBinding, ResourcesUlimits,
+    },
     query_parameters::{CreateContainerOptions, CreateContainerOptionsBuilder},
 };
-use bollard_stubs::models::{HostConfigCgroupnsModeEnum, ResourcesUlimits};
 
 use crate::{
     core::{

--- a/testcontainers/src/runners/sync_runner.rs
+++ b/testcontainers/src/runners/sync_runner.rs
@@ -83,7 +83,7 @@ mod tests {
         sync::{Arc, OnceLock},
     };
 
-    use bollard_stubs::models::ContainerInspectResponse;
+    use bollard::models::ContainerInspectResponse;
     use tokio::runtime::Runtime;
 
     use super::*;


### PR DESCRIPTION
`bollard` already re-exports the correct version of the `bollard_stubs`, so use them directly. This makes it easier to work on and with `testcontainers-rs.`

I am unsure why we have an explicit dependency here, so just close this PR if there is a reason to have it this way.