### PR TITLE
refactor(features): breakout `buildkit` functionality

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = { version = "0.1" }
-bollard = { version = "0.19.1", features = ["buildkit"] }
+bollard = { version = "0.19.1" }
 bollard-stubs = "=1.49.0-rc.28.3.3"
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
@@ -51,7 +51,8 @@ ulid = { version = "1.1.3" }
 url = { version = "2", features = ["serde"] }
 
 [features]
-default = ["ring"]
+default = ["ring", "buildkit"]
+buildkit = ["bollard/buildkit"]
 ring = ["bollard/ssl"]
 aws-lc-rs = ["bollard/aws-lc-rs"]
 ssl = ["bollard/ssl_providerless"]
@@ -63,6 +64,7 @@ reusable-containers = []
 device-requests = []
 
 [dev-dependencies]
+testcontainers = { path = ".", features = ["buildkit"]}
 anyhow = "1.0.86"
 pretty_env_logger = "0.5"
 reqwest = { version = "0.12.4", features = [

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -4,6 +4,9 @@ use std::{
     str::FromStr,
 };
 
+#[cfg(feature = "buildkit")]
+use bollard::query_parameters::{BuildImageOptionsBuilder, BuilderVersion};
+
 use bollard::{
     auth::DockerCredentials,
     body_full,
@@ -12,11 +15,11 @@ use bollard::{
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
     models::{ContainerCreateBody, NetworkCreateRequest},
     query_parameters::{
-        BuildImageOptionsBuilder, BuilderVersion, CreateContainerOptions,
-        CreateImageOptionsBuilder, InspectContainerOptions, InspectContainerOptionsBuilder,
-        InspectNetworkOptions, InspectNetworkOptionsBuilder, ListContainersOptionsBuilder,
-        ListNetworksOptions, LogsOptionsBuilder, RemoveContainerOptionsBuilder,
-        StartContainerOptions, StopContainerOptionsBuilder, UploadToContainerOptionsBuilder,
+        CreateContainerOptions, CreateImageOptionsBuilder, InspectContainerOptions,
+        InspectContainerOptionsBuilder, InspectNetworkOptions, InspectNetworkOptionsBuilder,
+        ListContainersOptionsBuilder, ListNetworksOptions, LogsOptionsBuilder,
+        RemoveContainerOptionsBuilder, StartContainerOptions, StopContainerOptionsBuilder,
+        UploadToContainerOptionsBuilder,
     },
     Docker,
 };
@@ -398,6 +401,7 @@ impl Client {
         Ok(state.exit_code)
     }
 
+    #[cfg(feature = "buildkit")]
     pub(crate) async fn build_image(
         &self,
         descriptor: &str,

--- a/testcontainers/src/lib.rs
+++ b/testcontainers/src/lib.rs
@@ -84,6 +84,8 @@
 //! [`testcontainers-modules`]: https://crates.io/crates/testcontainers-modules
 
 pub mod core;
+#[cfg(feature = "buildkit")]
+pub use crate::core::BuildableImage;
 #[cfg(feature = "blocking")]
 #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
 pub use crate::core::Container;
@@ -92,14 +94,17 @@ pub use crate::core::ReuseDirective;
 pub use crate::core::{
     copy::{CopyDataSource, CopyToContainer, CopyToContainerError},
     error::TestcontainersError,
-    BuildableImage, ContainerAsync, ContainerRequest, Healthcheck, Image, ImageExt,
+    ContainerAsync, ContainerRequest, Healthcheck, Image, ImageExt,
 };
 
 #[cfg(feature = "watchdog")]
 #[cfg_attr(docsrs, doc(cfg(feature = "watchdog")))]
 pub(crate) mod watchdog;
 
+#[cfg(feature = "buildkit")]
 mod buildables;
+#[cfg(feature = "buildkit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "buildkit")))]
 pub use buildables::generic::GenericBuildableImage;
 
 /// All available Docker images.

--- a/testcontainers/src/runners/mod.rs
+++ b/testcontainers/src/runners/mod.rs
@@ -1,13 +1,17 @@
-pub(crate) mod async_builder;
 pub(crate) mod async_runner;
 
+#[cfg(feature = "buildkit")]
+pub(crate) mod async_builder;
+
+#[cfg(feature = "buildkit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "buildkit")))]
 pub use self::{async_builder::AsyncBuilder, async_runner::AsyncRunner};
 
-#[cfg(feature = "blocking")]
+#[cfg(all(feature = "blocking", feature = "buildkit"))]
 pub(crate) mod sync_builder;
 
-#[cfg(feature = "blocking")]
-#[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+#[cfg(all(feature = "blocking", feature = "buildkit"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "blocking", feature = "buildkit"))))]
 pub use self::sync_builder::SyncBuilder;
 
 #[cfg(feature = "blocking")]


### PR DESCRIPTION
Remove `buildkit` from hardcoded `bollard` dependencies and add a `buildkit` feature that propagates to `bollard/buildkit`. This new `buildkit` feature is included in the `default` feature set.