### PR TITLE
feat: add container hostname support

### DIFF
--- a/testcontainers/src/core/containers/request.rs
+++ b/testcontainers/src/core/containers/request.rs
@@ -27,6 +27,7 @@ pub struct ContainerRequest<I: Image> {
     pub(crate) image_tag: Option<String>,
     pub(crate) container_name: Option<String>,
     pub(crate) network: Option<String>,
+    pub(crate) hostname: Option<String>,
     pub(crate) labels: BTreeMap<String, String>,
     pub(crate) env_vars: BTreeMap<String, String>,
     pub(crate) hosts: BTreeMap<String, Host>,
@@ -217,6 +218,10 @@ impl<I: Image> ContainerRequest<I> {
         self.readonly_rootfs
     }
 
+    pub fn hostname(&self) -> Option<&str> {
+        self.hostname.as_deref()
+    }
+
     /// Returns the custom health check configuration for the container.
     pub fn health_check(&self) -> Option<&Healthcheck> {
         self.health_check.as_ref()
@@ -237,6 +242,7 @@ impl<I: Image> From<I> for ContainerRequest<I> {
             image_tag: None,
             container_name: None,
             network: None,
+            hostname: None,
             labels: BTreeMap::default(),
             env_vars: BTreeMap::default(),
             hosts: BTreeMap::default(),
@@ -293,6 +299,7 @@ impl<I: Image + Debug> Debug for ContainerRequest<I> {
             .field("image_tag", &self.image_tag)
             .field("container_name", &self.container_name)
             .field("network", &self.network)
+            .field("hostname", &self.hostname)
             .field("labels", &self.labels)
             .field("env_vars", &self.env_vars)
             .field("hosts", &self.hosts)

--- a/testcontainers/src/core/image/image_ext.rs
+++ b/testcontainers/src/core/image/image_ext.rs
@@ -95,6 +95,9 @@ pub trait ImageExt<I: Image> {
     /// Adds a host to the container.
     fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> ContainerRequest<I>;
 
+    /// Configures hostname for the container.
+    fn with_hostname(self, hostname: impl Into<String>) -> ContainerRequest<I>;
+
     /// Adds a mount to the container.
     fn with_mount(self, mount: impl Into<Mount>) -> ContainerRequest<I>;
 
@@ -316,6 +319,12 @@ impl<RI: Into<ContainerRequest<I>>, I: Image> ImageExt<I> for RI {
     fn with_host(self, key: impl Into<String>, value: impl Into<Host>) -> ContainerRequest<I> {
         let mut container_req = self.into();
         container_req.hosts.insert(key.into(), value.into());
+        container_req
+    }
+
+    fn with_hostname(self, hostname: impl Into<String>) -> ContainerRequest<I> {
+        let mut container_req = self.into();
+        container_req.hostname = Some(hostname.into());
         container_req
     }
 

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -140,6 +140,7 @@ where
         let mut config = ContainerCreateBody {
             image: Some(container_req.descriptor()),
             labels: Some(labels),
+            hostname: container_req.hostname().map(|h| h.to_string()),
             host_config: Some(HostConfig {
                 privileged: Some(container_req.privileged()),
                 extra_hosts: Some(extra_hosts),


### PR DESCRIPTION
The Docker container create command supports the --hostname parameter ([1]). This is also supported through the Bollard library as part of the the ContainerCreateBody struct ([2]). This commit adds the option to configure this parameter through the ImageExt trait.

This was previously proposed for an older version of testcontainers-rs ([3]), however it was rejected.

The usefulness of this feature is to allow programs inside the container to report back a hostname that makes sense in a test environment. For instance, ClickHouse has the hostName function ([4]) which will report this configured value. By default Docker assigns the Docker container ID, which in an integration testing context isn't that useful.

[1]: https://docs.docker.com/reference/cli/docker/container/create/
[2]: https://docs.rs/bollard/latest/bollard/secret/struct.ContainerCreateBody.html
[3]: https://github.com/testcontainers/testcontainers-rs/pull/539
[4]: https://clickhouse.com/docs/sql-reference/functions/other-functions#hostname