### PR TITLE
fix: replace tokio-tar with astral-tokio-tar

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -44,7 +44,7 @@ signal-hook = { version = "0.3", optional = true }
 thiserror = "2.0.3"
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
-tokio-tar = "0.3.1"
+astral-tokio-tar = "0.5.6"
 tokio-util = { version = "0.7.10", features = ["io"] }
 ulid = { version = "1.1.3" }
 url = { version = "2", features = ["serde"] }


### PR DESCRIPTION
`tokio-tar` has been flagged as vulnerable and unmaintained according to CVE-2025-62518. Switch to [a maintained fork of this crate](https://github.com/astral-sh/tokio-tar).

Fixes #851