### PR TITLE
chore(deps): use bollard 0.19.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/testcontainers/testcontainers-rs"
 rust-version = "1.88"
-
-[patch.crates-io]
-bollard = { git = "https://github.com/DDtKey/bollard.git", branch = "fix/providerless-session" }

--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = { version = "0.1" }
-bollard = { version = "0.19.3", features = ["buildkit_providerless"] }
+bollard = { version = "0.19.4", features = ["buildkit_providerless"] }
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
 docker-compose-types = { version = "0.22", optional = true }


### PR DESCRIPTION
Bollard [0.19.4](https://github.com/fussybeaver/bollard/releases/tag/v0.19.4) has been released, containing @DDtKey fix 

This PR removed the patch in the `Cargo.toml`. 