### PR TITLE
fix: make port_bindings consistent with docker cli when publish_all_ports = true

### DIFF
--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -278,6 +278,7 @@ where
         } else if !is_container_networked {
             config.host_config = config.host_config.map(|mut host_config| {
                 host_config.publish_all_ports = Some(true);
+                host_config.port_bindings = Some(HashMap::new());
                 host_config
             });
         }


### PR DESCRIPTION
See #884 