### PR TITLE
feat: add User-Agent header 'tc-rust/<version>' to Docker API requests

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -17,10 +17,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = { version = "0.1" }
-bollard = { version = "0.19.4", features = ["buildkit_providerless"] }
+bollard = { version = "0.20.0", features = ["buildkit_providerless", "time"] }
 http = "1.1"
-hyper = { version = "1.3", features = ["client", "http1"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
 docker-compose-types = { version = "0.22", optional = true }
@@ -67,13 +65,6 @@ reusable-containers = []
 device-requests = []
 host-port-exposure = ["dep:russh", "russh/ring"]
 docker-compose = ["dep:docker-compose-types", "dep:uuid"]
-
-[target.'cfg(unix)'.dependencies]
-hyperlocal = "0.9"
-
-[target.'cfg(windows)'.dependencies]
-hyper-named-pipe = "0.1"
-hex = "0.4"
 
 [dev-dependencies]
 anyhow = "1.0.86"

--- a/testcontainers/src/core/client.rs
+++ b/testcontainers/src/core/client.rs
@@ -7,8 +7,8 @@ use bollard::{
     errors::Error as BollardError,
     exec::{CreateExecOptions, StartExecOptions, StartExecResults},
     models::{
-        ContainerCreateBody, ContainerInspectResponse, ExecInspectResponse, Network,
-        NetworkCreateRequest,
+        ContainerCreateBody, ContainerInspectResponse, ExecInspectResponse, NetworkCreateRequest,
+        NetworkInspect,
     },
     query_parameters::{
         BuildImageOptionsBuilder, BuilderVersion, CreateContainerOptions,
@@ -369,7 +369,7 @@ impl Client {
     }
 
     /// Inspects a network
-    pub(crate) async fn inspect_network(&self, name: &str) -> Result<Network, ClientError> {
+    pub(crate) async fn inspect_network(&self, name: &str) -> Result<NetworkInspect, ClientError> {
         self.bollard
             .inspect_network(name, Some(InspectNetworkOptionsBuilder::new().build()))
             .await

--- a/testcontainers/src/core/client/bollard_client.rs
+++ b/testcontainers/src/core/client/bollard_client.rs
@@ -1,12 +1,7 @@
-use std::{pin::Pin, str::FromStr, sync::Arc, time::Duration};
+use std::{str::FromStr, time::Duration};
 
-use bollard::{errors::Error, BollardRequest, Docker, API_DEFAULT_VERSION};
-use futures::Future;
-#[cfg(windows)]
-use hex;
+use bollard::{Docker, API_DEFAULT_VERSION};
 use http::header::{HeaderValue, USER_AGENT};
-use hyper::Response;
-use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use url::Url;
 
 use crate::core::env;
@@ -14,172 +9,44 @@ use crate::core::env;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 const USER_AGENT_VALUE: &str = concat!("tc-rust/", env!("CARGO_PKG_VERSION"));
 
-type TransportFuture =
-    Pin<Box<dyn Future<Output = Result<Response<hyper::body::Incoming>, Error>> + Send>>;
-
-pub(super) fn init(config: &env::Config) -> Result<Docker, Error> {
+pub(super) fn init(config: &env::Config) -> Result<Docker, bollard::errors::Error> {
     let host = &config.docker_host();
     let host_url = Url::from_str(host)?;
 
-    match host_url.scheme() {
+    let docker = match host_url.scheme() {
         #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
-        "https" => connect_with_ssl(config),
+        "https" => connect_with_ssl(config)?,
         "http" | "tcp" => {
             #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
             if config.tls_verify() {
-                return connect_with_ssl(config);
+                return Ok(connect_with_ssl(config)?.with_request_modifier(add_user_agent));
             }
-            connect_with_http(host)
+            Docker::connect_with_http(host, DEFAULT_TIMEOUT.as_secs(), API_DEFAULT_VERSION)?
         }
         #[cfg(unix)]
-        "unix" => connect_with_unix(host),
+        "unix" => Docker::connect_with_unix(host, DEFAULT_TIMEOUT.as_secs(), API_DEFAULT_VERSION)?,
         #[cfg(windows)]
-        "npipe" => connect_with_named_pipe(host),
-        _ => Err(Error::UnsupportedURISchemeError {
-            uri: host.to_string(),
-        }),
-    }
-}
-
-fn connect_with_http(host: &str) -> Result<Docker, Error> {
-    let connector = hyper_util::client::legacy::connect::HttpConnector::new();
-    let client = Arc::new(
-        Client::builder(TokioExecutor::new())
-            .pool_max_idle_per_host(0)
-            .build(connector),
-    );
-
-    let transport = move |req: BollardRequest| -> TransportFuture {
-        let client = Arc::clone(&client);
-        Box::pin(async move {
-            let (mut parts, body) = req.into_parts();
-            parts
-                .headers
-                .insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
-            let req = hyper::Request::from_parts(parts, body);
-            client.request(req).await.map_err(Error::from)
-        })
+        "npipe" => {
+            Docker::connect_with_named_pipe(host, DEFAULT_TIMEOUT.as_secs(), API_DEFAULT_VERSION)?
+        }
+        _ => {
+            return Err(bollard::errors::Error::UnsupportedURISchemeError {
+                uri: host.to_string(),
+            })
+        }
     };
 
-    Docker::connect_with_custom_transport(
-        transport,
-        Some(host),
-        DEFAULT_TIMEOUT.as_secs(),
-        API_DEFAULT_VERSION,
-    )
+    Ok(docker.with_request_modifier(add_user_agent))
 }
 
-#[cfg(unix)]
-fn connect_with_unix(path: &str) -> Result<Docker, Error> {
-    let socket_path = path.strip_prefix("unix://").unwrap_or(path);
-
-    if !std::path::Path::new(socket_path).exists() {
-        return Err(Error::DockerResponseServerError {
-            status_code: 404,
-            message: format!("Unix socket not found: {socket_path}"),
-        });
-    }
-
-    let connector = hyperlocal::UnixConnector;
-    let client = Arc::new(
-        Client::builder(TokioExecutor::new())
-            .pool_max_idle_per_host(0)
-            .build(connector),
-    );
-
-    let socket_path_owned = socket_path.to_owned();
-    let transport = move |req: BollardRequest| -> TransportFuture {
-        let client = Arc::clone(&client);
-        let socket_path = socket_path_owned.clone();
-        Box::pin(async move {
-            let (mut parts, body) = req.into_parts();
-            parts
-                .headers
-                .insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
-
-            // Transform URI to hyperlocal format
-            // Bollard sends URIs like "http://localhost/v1.47/containers/json"
-            // We need to extract the path and convert to hyperlocal format
-            let request_path = parts
-                .uri
-                .path_and_query()
-                .map_or("/", |pq| pq.as_str())
-                .to_owned();
-
-            let hyperlocal_uri: hyper::Uri =
-                hyperlocal::Uri::new(&socket_path, &request_path).into();
-            parts.uri = hyperlocal_uri;
-
-            let req = hyper::Request::from_parts(parts, body);
-            client.request(req).await.map_err(Error::from)
-        })
-    };
-
-    // Use http://localhost so bollard creates valid HTTP URIs that we transform
-    Docker::connect_with_custom_transport(
-        transport,
-        Some("http://localhost"),
-        DEFAULT_TIMEOUT.as_secs(),
-        API_DEFAULT_VERSION,
-    )
-}
-
-#[cfg(windows)]
-fn connect_with_named_pipe(path: &str) -> Result<Docker, Error> {
-    let pipe_path = path.strip_prefix("npipe://").unwrap_or(path);
-
-    let connector = hyper_named_pipe::PipeConnector;
-    let client = Arc::new(
-        Client::builder(TokioExecutor::new())
-            .pool_max_idle_per_host(0)
-            .build(connector),
-    );
-
-    let pipe_path_owned = pipe_path.to_owned();
-    let transport = move |req: BollardRequest| -> TransportFuture {
-        let client = Arc::clone(&client);
-        let pipe_path = pipe_path_owned.clone();
-        Box::pin(async move {
-            let (mut parts, body) = req.into_parts();
-            parts
-                .headers
-                .insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
-
-            // Transform URI to named pipe format
-            // The pipe path needs to be hex-encoded for hyper-named-pipe
-            let request_path = parts
-                .uri
-                .path_and_query()
-                .map_or("/", |pq| pq.as_str())
-                .to_owned();
-
-            let hex_path = hex::encode(&pipe_path);
-            let pipe_uri: hyper::Uri = format!("net.pipe://localhost/{}{}", hex_path, request_path)
-                .parse()
-                .expect("valid URI");
-            parts.uri = pipe_uri;
-
-            let req = hyper::Request::from_parts(parts, body);
-            client.request(req).await.map_err(Error::from)
-        })
-    };
-
-    // Use http://localhost so bollard creates valid HTTP URIs that we transform
-    Docker::connect_with_custom_transport(
-        transport,
-        Some("http://localhost"),
-        DEFAULT_TIMEOUT.as_secs(),
-        API_DEFAULT_VERSION,
-    )
+fn add_user_agent(mut req: bollard::BollardRequest) -> bollard::BollardRequest {
+    req.headers_mut()
+        .insert(USER_AGENT, HeaderValue::from_static(USER_AGENT_VALUE));
+    req
 }
 
 #[cfg(any(feature = "ring", feature = "aws-lc-rs"))]
-fn connect_with_ssl(config: &env::Config) -> Result<Docker, Error> {
-    // For SSL, we fall back to bollard's built-in SSL support since it handles
-    // certificate loading and rustls configuration. The User-Agent header won't
-    // be added for SSL connections until bollard provides a simpler API.
-    // This is a known limitation tracked in:
-    // https://github.com/testcontainers/testcontainers-rs/issues/576
+fn connect_with_ssl(config: &env::Config) -> Result<Docker, bollard::errors::Error> {
     let cert_path = config.cert_path().expect("cert path not found");
 
     Docker::connect_with_ssl(

--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -266,7 +266,7 @@ where
                 .iter()
                 .copied()
                 .chain(mapped_ports)
-                .map(|p| (format!("{p}"), HashMap::new()))
+                .map(|p| format!("{p}"))
                 .collect();
 
             // exposed ports of the image + mapped ports


### PR DESCRIPTION
Closes #576 

Uses bollard's `connect_with_custom_transport` to inject the header for HTTP, Unix socket, and Windows named pipe transports.

Limitation: SSL/TLS connections don't include the header (would require reimplementing bollard's TLS transport).