### PR TITLE
build: try to reconcile deps

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 async-trait = { version = "0.1" }
-bollard = { version = "0.19.4", features = ["buildkit_providerless"] }
+bollard = { version = "0.19.4" }
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
 docker-compose-types = { version = "0.22", optional = true }
@@ -28,7 +28,7 @@ futures = "0.3"
 itertools = "0.14"
 log = "0.4"
 memchr = "2.7.2"
-parse-display = "0.9.0"
+parse-display = "0.10.0"
 pin-project-lite = "0.2.14"
 russh = { version = "0.55.0", default-features = false, optional = true }
 reqwest = { version = "0.12.5", features = [


### PR DESCRIPTION
This refers to https://github.com/testcontainers/testcontainers-rs/issues/893#issuecomment-3694438610.

See why we need "buildkit_providerless".