### PR TITLE
chore: update ferroid to stable `1.0.0`

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread", "process
 tokio-stream = "0.1.15"
 astral-tokio-tar = "0.5.6"
 tokio-util = { version = "0.7.10", features = ["io"] }
-ferroid = { version = "0.8.7", features = ["std", "ulid", "base32"] }
+ferroid = { version = "1.0.0", features = ["std", "ulid", "base32"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["v4"], optional = true }
 


### PR DESCRIPTION
Simple bump to the latest stable version which should now minimize the risk of breaking API changes.