### PR TITLE
chore: bump docker-compose-types from 0.22 to 0.23

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -21,7 +21,7 @@ bollard = { version = "0.20.0", features = ["buildkit_providerless", "time"] }
 http = "1.1"
 bytes = "1.6.0"
 conquer-once = { version = "0.4", optional = true }
-docker-compose-types = { version = "0.22", optional = true }
+docker-compose-types = { version = "0.23", optional = true }
 docker_credential = "1.3.1"
 either = "1.12.0"
 etcetera = "0.11.0"


### PR DESCRIPTION
## Summary

Bumps `docker-compose-types` from `0.22` to `0.23`.

## Motivation

`docker-compose-types 0.22.0` hardcodes its `serde_yaml` dependency to the exact version `=0.9.33`. This strict pin means any workspace that transitively depends on both `testcontainers` (with the `docker-compose` feature) and a crate requiring `serde_yaml >= 0.9.34` will fail to resolve dependencies entirely — Cargo cannot satisfy both constraints simultaneously.

`docker-compose-types 0.23.0` fixes this in two ways:
1. `serde_yaml` is now **optional**, gated behind the `yaml` feature (which remains on by default for backwards compatibility)
2. The version constraint is relaxed from `=0.9.33` to `^0.9.33`, allowing any compatible `0.9.x` release

The fix was made in [stephanbuys/docker-compose-types#64](https://github.com/stephanbuys/docker-compose-types/pull/64) and released as `0.23.0`.

Because `testcontainers` declares `docker-compose-types = "0.22"`, Cargo's semver resolution restricts it to `>=0.22.0, <0.23.0` and will never pick up the fixed `0.23.0` release without this bump. Updating `testcontainers` to `"0.23"` is therefore required to let downstream workspaces benefit from the fix.

## Test plan

- [ ] Existing CI passes