### PR TITLE
feat: add org.testcontainers=true label for ecosystem consistency

### DIFF
--- a/testcontainers/src/runners/async_runner.rs
+++ b/testcontainers/src/runners/async_runner.rs
@@ -97,6 +97,10 @@ where
                 .map(|(key, value)| (key.into(), value.into()))
                 .chain([
                     (
+                        "org.testcontainers".into(),
+                        "true".into(),
+                    ),
+                    (
                         "org.testcontainers.managed-by".into(),
                         "testcontainers".into(),
                     ),
@@ -522,7 +526,11 @@ mod tests {
         // `org.testcontainers.managed-by` key will be overwritten
         assert_ne!(&labels, &container_labels);
 
-        // If we add the expected `managed-by` value though, they should then match
+        // If we add the expected labels though, they should then match
+        labels.insert(
+            "org.testcontainers".to_string(),
+            "true".to_string(),
+        );
         labels.insert(
             "org.testcontainers.managed-by".to_string(),
             "testcontainers".to_string(),


### PR DESCRIPTION
Closes #926

## Summary

Adds the standard `org.testcontainers=true` label to all containers started by `testcontainers-rs`, aligning with the Java and Go implementations.

## Changes

- Add `org.testcontainers=true` label in the label chain in `AsyncRunner::start` (which is also used by `SyncRunner` via delegation)
- Update the existing label assertion test to expect the new label

## Context

Other Testcontainers implementations (Java, Go) already apply this label by default. Adding it to the Rust implementation enables consistent cross-language filtering of testcontainers-managed containers:

```sh
docker ps --filter "label=org.testcontainers=true"
```

This complements the existing `org.testcontainers.managed-by=testcontainers` label.

## Test plan

- [x] Updated existing `async_start_should_apply_expected_labels` test to include the new label in expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)