### PR TITLE
chore(deps): update astral-tokio-tar from 0.6.0 to 0.6.1

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -45,7 +45,7 @@ signal-hook = { version = "0.4", optional = true }
 thiserror = "2.0.3"
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread", "process"] }
 tokio-stream = "0.1.15"
-astral-tokio-tar = "0.6.0"
+astral-tokio-tar = "0.6.1"
 tokio-util = { version = "0.7.10", features = ["io"] }
 ferroid = { version = "2.0.0", features = ["std", "ulid", "base32"] }
 url = { version = "2", features = ["serde"] }


### PR DESCRIPTION
Addresses vulnerability:

```
error[vulnerability]: PAX Header Desynchronization in astral-tokio-tar
   ┌─ /src/myproject/Cargo.lock:12:1
   │
12 │ astral-tokio-tar 0.6.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
   │
   ├ ID: RUSTSEC-2026-0112
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0112
   ├ Versions of astral-tokio-tar prior to 0.6.1 contain a PAX header interpretation
     bug that allows manipulated entries to be made selectively visible or invisible
     during extraction with astral-tokio-tar versus other tar implementations.
     An attacker could use this differential to smuggle unexpected files onto a
     victim's filesystem.
   ├ Announcement: https://github.com/advisories/GHSA-fp55-jw48-c537
   ├ Solution: Upgrade to >=0.6.1 (try `cargo update -p astral-tokio-tar`)
   ├ astral-tokio-tar v0.6.0
     └── testcontainers v0.27.3