### PR TITLE
feat!: CopyDataSource from static sources

### DIFF
--- a/testcontainers/src/core/copy.rs
+++ b/testcontainers/src/core/copy.rs
@@ -252,6 +252,24 @@ impl From<Vec<u8>> for CopyDataSource {
     }
 }
 
+impl From<String> for CopyDataSource {
+    fn from(value: String) -> Self {
+        CopyDataSource::Data(Cow::Owned(value.into_bytes()))
+    }
+}
+
+impl From<&'static [u8]> for CopyDataSource {
+    fn from(value: &'static [u8]) -> Self {
+        CopyDataSource::Data(Cow::Borrowed(value))
+    }
+}
+
+impl From<&'static str> for CopyDataSource {
+    fn from(value: &'static str) -> Self {
+        CopyDataSource::Data(Cow::Borrowed(value.as_bytes()))
+    }
+}
+
 impl CopyDataSource {
     pub(crate) async fn append_tar(
         &self,

--- a/testcontainers/src/core/copy.rs
+++ b/testcontainers/src/core/copy.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
 use async_trait::async_trait;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -22,7 +25,7 @@ pub struct CopyTargetOptions {
 #[derive(Debug, Clone)]
 pub enum CopyDataSource {
     File(PathBuf),
-    Data(Vec<u8>),
+    Data(Cow<'static, [u8]>),
 }
 
 /// Errors that can occur while materializing data copied from a container.
@@ -242,9 +245,10 @@ impl From<PathBuf> for CopyDataSource {
         CopyDataSource::File(value)
     }
 }
+
 impl From<Vec<u8>> for CopyDataSource {
     fn from(value: Vec<u8>) -> Self {
-        CopyDataSource::Data(value)
+        CopyDataSource::Data(Cow::Owned(value))
     }
 }
 
@@ -324,7 +328,7 @@ async fn append_tar_file(
 
 async fn append_tar_bytes(
     ar: &mut tokio_tar::Builder<Vec<u8>>,
-    data: &Vec<u8>,
+    data: &[u8],
     target: &CopyTargetOptions,
 ) -> Result<(), CopyToContainerError> {
     let relative_target_path = make_path_relative(target.target());
@@ -334,7 +338,7 @@ async fn append_tar_bytes(
     header.set_mode(target.mode().unwrap_or(0o0644));
     header.set_cksum();
 
-    ar.append_data(&mut header, relative_target_path, data.as_slice())
+    ar.append_data(&mut header, relative_target_path, data)
         .await
         .map_err(CopyToContainerError::IoError)?;
 


### PR DESCRIPTION
This PR changes `CopyDataSource::Data` from containing a `Vec<u8>` to a `Cow<'static, [u8]>`, and then provides additional `From<{&'static u8,&'static str,String}>` implementation for it.

The motivation for this breaking change is admittedly mostly aesthetic.

```rust
fn new(config: impl Into<CopyDataSource>) -> SomeContainer;

const CONFIG: &str = r#"
  name = "foo"
  enabled = true
"#;

// Before:
let container = SomeContainer::new(CONFIG.as_bytes().to_vec());
// After:
let container = SomeContainer::new(CONFIG);
```

The first change will break compilation for projects that construct `CopyDataSource` directly with `CopyDataSource::Data(vec)`. Those using `impl Into<CopyDataSource>` are unaffected by this change. Hopefully, most users construct `CopyDataSource` with the latter alternative. `testcontainers-modules` does this exclusively.

Another alternative could be to extend the enum with a third variant:

```rust
pub enum CopyDataSource {
    File(PathBuf),
    Data(Vec<u8>),
    StaticData(&'static u8),
}
```

This is also a breaking change, but only for those performing pattern matching on `CopyDataSource`, to which I assume a lot fewer do. 

Completely understandable if this PR gets rejected given the questionable gains from such a breaking change ✌️