### PR TITLE
chore(deps): update astral-tokio-tar version to 0.6.2

### DIFF
--- a/testcontainers/Cargo.toml
+++ b/testcontainers/Cargo.toml
@@ -45,7 +45,7 @@ signal-hook = { version = "0.4", optional = true }
 thiserror = "2.0.3"
 tokio = { version = "1", features = ["macros", "fs", "rt-multi-thread", "process"] }
 tokio-stream = "0.1.15"
-astral-tokio-tar = "0.6.1"
+astral-tokio-tar = "0.6.2"
 tokio-util = { version = "0.7.10", features = ["io"] }
 ferroid = { version = "2.0.0", features = ["std", "ulid", "base32"] }
 url = { version = "2", features = ["serde"] }


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2026-0145