### PR TITLE
chore: bump testcontainers/sshd image from 1.3.0 to 1.4.0

### DIFF
--- a/testcontainers/src/core/containers/host.rs
+++ b/testcontainers/src/core/containers/host.rs
@@ -179,7 +179,7 @@ fn prepare_host_exposure<I: Image>(
         ssh_retry_delay: Duration::from_millis(100),
         ssh_max_retry_delay: Duration::from_millis(2000),
         ssh_image: "testcontainers/sshd",
-        ssh_tag: "1.3.0",
+        ssh_tag: "1.4.0",
     }))
 }
 


### PR DESCRIPTION
Bumps the `testcontainers/sshd` sidecar image tag from `1.3.0` to `1.4.0`.

Changes in 1.4.0:
- Base image updated to Alpine 3.23
- Added `AddressFamily any` sshd option (fixes IPv6-only and dual-stack host environments)

No SHA-pinned digest references were found in the codebase — only the `ssh_tag` field in `testcontainers/src/core/containers/host.rs` needed updating.

**Tests:** The `host_port_exposure` integration test suite (5 tests) was run locally with `cargo test --package testcontainers --features host-port-exposure --test host_port_exposure`:
- `fails_when_exposing_reserved_port` ✓
- `fails_when_alias_conflicts` ✓
- `exposes_single_host_port`, `exposes_multiple_host_ports`, `host_port_exposure_is_scoped_per_container` — failed due to sandbox DNS not resolving `localhost` (pre-existing environment limitation, not a regression from this change)